### PR TITLE
Rate limit retry

### DIFF
--- a/airtable/__init__.py
+++ b/airtable/__init__.py
@@ -1,1 +1,1 @@
-from .airtable import Airtable  # noqa
+from .airtable import Airtable, RateLimitRetry  # noqa

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,10 +8,16 @@ Overview
 
 _______________________________________________
 
-Class API
+Airtable
 *********
 
 .. autoclass:: airtable.Airtable
+    :members:
+
+RateLimitRetry
+**************
+
+.. autoclass:: airtable.RateLimitRetry
     :members:
 
 _______________________________________________

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest import mock
+
+from airtable import RateLimitRetry
+from requests.exceptions import HTTPError
+
+
+@pytest.fixture
+def rate_error():
+    exc = HTTPError()
+    exc.response = mock.MagicMock()
+    exc.response.status_code = 429
+    return exc
+
+
+@mock.patch("airtable.airtable.Airtable._request")
+@mock.patch("airtable.airtable.time.sleep")
+def test_retry(m_sleep, m_request, table, rate_error):
+    # Raise Rate Error when airtable._request is called
+    m_request.side_effect = rate_error
+
+    with RateLimitRetry(table, wait_seconds=31):
+        table.insert({})
+
+    assert m_request.call_count == 3
+    assert m_sleep.call_count == 3
+    m_sleep.assert_called_with(31)
+
+
+@mock.patch("airtable.airtable.Airtable._request")
+@mock.patch("airtable.airtable.time.sleep")
+def test_without_retry(m_sleep, m_request, table, rate_error):
+    m_request.side_effect = rate_error
+    table.insert({})
+
+    assert m_request.call_count == 1
+    assert not m_sleep.called


### PR DESCRIPTION
Testing out an idea for using a Context Manager to retry requests when hit rate limit error.
I think [we are not supposed](https://stackoverflow.com/a/16919782/4411196) [to do this](https://mail.python.org/pipermail/python-ideas/2013-May/020633.html)🙊 

Looking for feedback and ideas to improve this! 

```python
>>> airtable = Airtable(...)
>>> for record in records:
...     with RateLimitRetry(airtable):
...         airtable.insert(record)
```

Options:
```python
>>> airtable = Airtable(...)
>>> for record in records:
...     with RateLimitRetry(airtable, retry_count=5, wait_seconds=60):
...         # will retry 5 times, 60sec between each
...         airtable.insert(record)
```

