### PR TITLE
Fix metadata api

### DIFF
--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -38,7 +38,10 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         self._api_key = value
 
     def _update_api_key(self, api_key: str) -> None:
-        self.session.headers.update({"Authorization": "Bearer {}".format(api_key)})
+        if api_key in api_key:
+            self.session.headers.update({"Authorization": "Bearer {}".format(api_key.api_key)})
+        else:
+            self.session.headers.update({"Authorization": "Bearer {}".format(api_key)})
 
     @lru_cache()
     def get_table_url(self, base_id: str, table_name: str):

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -38,10 +38,10 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         self._api_key = value
 
     def _update_api_key(self, api_key: str) -> None:
-        if api_key in api_key:
-            self.session.headers.update({"Authorization": "Bearer {}".format(api_key.api_key)})
-        else:
+        if type(api_key) == str:
             self.session.headers.update({"Authorization": "Bearer {}".format(api_key)})
+        else:
+            self.session.headers.update({"Authorization": "Bearer {}".format(api_key.api_key)})
 
     @lru_cache()
     def get_table_url(self, base_id: str, table_name: str):


### PR DESCRIPTION
So, I would definitely not suggest that you accept this PR. But I'm not totally sure the fix.

Basically what I'm seeing is that sometimes the api_key variable is a string that is the actual api_key, and sometimes the value is the actual pyairtable.Api class. Feels like something fishy is happening with these @property or setter annotations.

Sorry, it's not a solid fix, but it might help get closer.