### PR TITLE
Introduce RequestStrategy pattern

### DIFF
--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -14,6 +14,20 @@
     the connection to be established  and 5 seconds for a
     server read timeout. Default is ``None`` (no timeout).
 
+.. |arg_request_strategy| replace:: A ``RequestStrategy`` to control how requests to
+    the Airtable API are made. You may pass either an instance or a subclass of 
+    ``RequestStrategy`` to be instantiated. Default is a ``SimpleRequestStrategy``, 
+    which just proxies request() method calls to its contained Session.
+
+.. |arg_session| replace:: A ``requests.Session`` instance to override what is
+    created by default. Useful if you want to provide additional behaviors or
+    headers.
+
+.. |arg_retrying| replace:: A ``tenacity.Retrying`` instance to control the
+    retry strategy for requests. See
+    https://tenacity.readthedocs.io/en/latest/api.html#tenacity.Retrying for
+    usage details.
+
 .. |kwarg_view| replace:: The name or ID of a view.
     If set, only the records in that view will be returned.
     The records will be sorted according to the order of the view.
@@ -64,3 +78,7 @@
     when using `string` as the `cell_format`. See
     https://support.airtable.com/hc/en-us/articles/216141558-Supported-timezones-for-SET-TIMEZONE
     for valid values.
+
+.. |kwargs_retrying| replace:: Keyword arguments for tenacity.Retrying(). See
+    https://tenacity.readthedocs.io/en/latest/api.html#tenacity.Retrying for
+    accepted keyword arguments and other documentation.

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -17,7 +17,7 @@ class Api(ApiAbstract):
         >>> api.all('base_id', 'table_name')
     """
 
-    def __init__(self, api_key: str, timeout=None):
+    def __init__(self, api_key: str, timeout=None, request_strategy=None):
         """
 
         Args:
@@ -25,9 +25,10 @@ class Api(ApiAbstract):
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|
+            request_strategy(``RequestStrategy``, optional): |arg_request_strategy|
 
         """
-        super().__init__(api_key, timeout=timeout)
+        super().__init__(api_key, timeout=timeout, request_strategy=request_strategy)
 
     def get_table(self, base_id: str, table_name: str) -> "Table":
         """

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -15,7 +15,7 @@ class Base(ApiAbstract):
 
     base_id: str
 
-    def __init__(self, api_key: str, base_id: str, timeout=None):
+    def __init__(self, api_key: str, base_id: str, timeout=None, request_strategy=None):
         """
         Args:
             api_key: |arg_api_key|
@@ -23,10 +23,11 @@ class Base(ApiAbstract):
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|
+            request_strategy(``RequestStrategy``, optional): |arg_request_strategy|
         """
 
         self.base_id = base_id
-        super().__init__(api_key, timeout=timeout)
+        super().__init__(api_key, timeout=timeout, request_strategy=request_strategy)
 
     def get_table(self, table_name: str) -> "Table":
         """

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -16,7 +16,15 @@ class Table(ApiAbstract):
     base_id: str
     table_name: str
 
-    def __init__(self, api_key: str, base_id: str, table_name: str, *, timeout=None):
+    def __init__(
+        self,
+        api_key: str,
+        base_id: str,
+        table_name: str,
+        *,
+        timeout=None,
+        request_strategy=None,
+    ):
         """
         Args:
             api_key: |arg_api_key|
@@ -25,10 +33,11 @@ class Table(ApiAbstract):
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|
+            request_strategy(``RequestStrategy``, optional): |arg_request_strategy|
         """
         self.base_id = base_id
         self.table_name = table_name
-        super().__init__(api_key, timeout=timeout)
+        super().__init__(api_key, timeout=timeout, request_strategy=request_strategy)
 
     @property
     def table_url(self):

--- a/pyairtable/request_strategies/__init__.py
+++ b/pyairtable/request_strategies/__init__.py
@@ -1,0 +1,12 @@
+from .abstract import RequestStrategy, Headers  # noqa
+from .simple import SimpleRequestStrategy
+from .retrying import RetryingRequestStrategy, RateLimitRetryingRequestStrategy
+
+
+__all__ = [
+    "RequestStrategy",
+    "Headers",
+    "SimpleRequestStrategy",
+    "RetryingRequestStrategy",
+    "RateLimitRetryingRequestStrategy",
+]

--- a/pyairtable/request_strategies/abstract.py
+++ b/pyairtable/request_strategies/abstract.py
@@ -1,0 +1,64 @@
+from abc import ABCMeta, abstractmethod
+from typing import Any, Dict, Iterable, Mapping, Optional, Text, Tuple, Type, Union
+
+from requests import Response
+from requests.exceptions import HTTPError
+
+Headers = Union[Mapping[str, Text], Iterable[Tuple[str, Text]]]
+
+
+def process_response(response: Response) -> Any:
+    """Process a Response to return the body or raise any errors with it."""
+    try:
+        response.raise_for_status()
+    except HTTPError as exc:
+        err_msg = str(exc)
+
+        # Attempt to get Error message from response, Issue #16
+        try:
+            error_dict = response.json()
+        except ValueError:
+            pass
+        else:
+            if "error" in error_dict:
+                err_msg += " [Error: {}]".format(error_dict["error"])
+        exc.args = (*exc.args, err_msg)
+        raise exc
+    else:
+        return response.json()
+
+
+class RequestStrategy(metaclass=ABCMeta):
+    """Abstract request strategy."""
+
+    session: Any
+
+    @abstractmethod
+    def request(
+        self,
+        method: str,
+        url: str,
+        params: Dict[str, Any],
+        json: Dict[str, Any],
+        timeout: Optional[Tuple[int, int]],
+        headers: Headers,
+    ) -> Any:
+        """Must provide a request method."""
+        ...
+
+    @classmethod
+    def initialize(
+        cls, request_strategy: Union[Type["RequestStrategy"], "RequestStrategy"]
+    ) -> "RequestStrategy":
+        """Init if a subclass, return if an instance, else raise."""
+        if isinstance(request_strategy, type) and issubclass(
+            request_strategy, RequestStrategy
+        ):
+            request_strategy = request_strategy()
+        elif not isinstance(request_strategy, RequestStrategy):
+            raise TypeError(
+                "Error! request_strategy must either be a subclass of "
+                "RequestStrategy or an instance of one! "
+                f"(got: `{request_strategy!r}`)"
+            )
+        return request_strategy

--- a/pyairtable/request_strategies/retrying.py
+++ b/pyairtable/request_strategies/retrying.py
@@ -1,0 +1,252 @@
+from typing import Any, Optional, overload
+from requests import Response, Session
+from .simple import SimpleRequestStrategy
+
+try:
+    from tenacity import Retrying
+except ImportError:
+    TENACITY_FOUND = False
+    Retrying = Any
+    retry_base = Any
+    wait_base = Any
+    retry_never = None
+    wait_none = None
+else:
+    TENACITY_FOUND = True
+    from tenacity.retry import retry_any, retry_base, retry_if_result, retry_never
+    from tenacity.wait import (
+        wait_combine,
+        wait_base,
+        wait_none,
+        wait_random_exponential,
+    )
+
+
+def assert_tenacity_installed():
+    """Raise if tenacity is not importable."""
+    if not TENACITY_FOUND:
+        raise ModuleNotFoundError(
+            """
+            Could not find the tenacity module! Please reinstall pyairtable
+            with the tenacity extra. You can do so with:
+                $ pip install pyairtable[tenacity]
+            """
+        )
+
+
+def is_rate_limited(response: Response):
+    """Return True if rate limited."""
+    return response.status_code == 429
+
+
+class RetryingRequestStrategy(SimpleRequestStrategy):
+    """
+    Wraps SimpleRequestStrategy to retry requests.
+
+    Accepts a tenacity.Retrying object to configure retry behavior.
+
+    Usage:
+        >>> request_strategy = RetryingRequestStrategy()
+        >>> api = Api('apikey', request_strategy=request_strategy)
+    or:
+        >>> retrying = Retrying(stop_after_attempt(3))
+        >>> request_strategy = RetryingRequestStrategy(retrying)
+        >>> api = Api('apikey', request_strategy=request_strategy)
+    or:
+        >>> request_strategy = RetryingRequestStrategy(
+                stop=stop_after_attempt(3)
+            )
+        >>> api = Api('apikey', request_strategy=request_strategy)
+    """
+
+    _retrying: Retrying
+
+    @overload
+    def __init__(self):
+        """Initialize with the defaults (retries on failure)."""
+        ...
+
+    @overload
+    def __init__(self, retrying_: Retrying, session: Optional[Session] = None):
+        """Initialize with a Retrying and optionally a Session."""
+        ...
+
+    @overload
+    def __init__(self, *, retrying_: Retrying, session: Optional[Session] = None):
+        """Initialize with Retrying and Session passed as keyword arguments."""
+        ...
+
+    @overload
+    def __init__(self, *, session: Optional[Session] = None, **kwargs: Any):
+        """Initialize with Session and other keyword arguments for Retrying."""
+        ...
+
+    @overload
+    def __init__(self, **kwargs: Any):
+        """Initialize with only keyword arguments for Retrying."""
+        ...
+
+    def __init__(
+        self,
+        retrying_: Optional[Retrying] = None,
+        session: Optional[Retrying] = None,
+        **kwargs: Any,
+    ):
+        """
+        If tenacity is installed, initialize a retrying strategy.
+
+        Arguments:
+            retrying(``Retrying``, optional): |arg_retrying|
+            session(``Session``, optional): |arg_session|
+
+        Keyword Arguments:
+            **kwargs(``dict``, optional): |kwargs_retrying|
+        """
+        assert_tenacity_installed()
+        super().__init__(session=session)
+
+        if retrying_ is None:
+            retrying_ = kwargs.pop("retrying", None)
+
+        if retrying_ is not None:
+            if not isinstance(retrying_, Retrying):
+                raise TypeError(
+                    f"Must provide a Retrying as a strategy! Got {retrying_!r}"
+                )
+            if kwargs:
+                raise ValueError(
+                    "Must provide either Retrying instance or Retrying "
+                    f"constructor keyword arguments! Got both {retrying_!r} "
+                    f"and {kwargs!r}!"
+                )
+            self.retrying = retrying_
+        elif not kwargs:
+            raise ValueError(
+                "Must provide either Retrying instance or Retrying constructor"
+                "keyword arguments! Got neither!"
+            )
+        self.retrying = self.__class__.make_retrying(**kwargs)
+
+    @property
+    def retrying(self) -> Retrying:
+        """Return the tenacity.Retrying object that wraps _request."""
+        return self._retrying
+
+    if TENACITY_FOUND:
+
+        @retrying.setter
+        def retrying(self, retrying: Retrying):
+            """Set the tenacity.Retrying and update the wrapped _request()."""
+            self._retrying = retrying
+            self._retrying_request = retrying.wraps(super()._request)
+
+        def _request(self, method: str, url: str, **kwargs: Any) -> Response:
+            """Make requests and retry based on the response code."""
+            if self._retrying_request is None:
+                return self._request(method, url, **kwargs)
+            return self._retrying_request(method, url, **kwargs)
+
+    @staticmethod
+    def make_retrying(*, retry: retry_base = None, wait: wait_base = None, **kwargs):
+        """
+        Create a retrying object.
+
+        Sugar to bypass the need to importing Retrying. Passes any keyword
+        arguments to the Retrying constructor.
+
+        Keyword Arguments:
+            **kwargs(``dict``, optional): |kwargs_retrying|
+        """
+        assert_tenacity_installed()
+        return Retrying(retry=retry, wait=wait, **kwargs)
+
+
+class RateLimitRetryingRequestStrategy(RetryingRequestStrategy):
+    """
+    Wraps SimpleRequestStrategy to retry requests based on response code.
+
+    Airtable responds with a 429 if a request fails due to exceeding rate
+    limits. We can implement the strategy used by the official airtable.js and
+    retry with exponential and jittered backoff. See
+    https://github.com/Airtable/airtable.js/blob/9d40666979af77de9546d43177cab086a03028bf/src/run_action.ts#L70-L75
+
+    The API requires a wait of 30s after the rate limits are exceeded.
+
+    Keyword arguments passed to the constructor are combined with those needed
+    to implement the rate-limit respective behavior.
+
+    Usage:
+        >>> request_strategy = RateLimiRetryingRequestStrategy()
+        >>> api = Api('apikey', request_strategy=request_strategy)
+    or:
+        >>> request_strategy = RateLimiRetryingRequestStrategy(
+                stop=stop_after_attempt(3)
+            )
+        >>> api = Api('apikey', request_strategy=request_strategy)
+    """
+
+    def __init__(self, session: Optional[Session] = None, **kwargs: Any):
+        """
+        If tenacity is installed, initialize a retrying strategy that mimics
+        the retrying behavior of the offial airtable.js library.
+
+        NB: Unlike RetryingRequestStrategy, this constructor does not accept a
+        Retrying instance as a parameter.
+
+        Arguments:
+            session(``Session``, optional): |arg_session|
+
+        Keyword Arguments:
+            **kwargs(``dict``, optional): |kwargs_retrying|
+        """
+        assert_tenacity_installed()
+        if any(
+            (
+                isinstance(session, Retrying),
+                kwargs.get("retrying_", None) is not None,
+                kwargs.get("retrying", None) is not None,
+            )
+        ):
+            raise ValueError(
+                "RateLimiRetryingRequestStrategy does not accept a Retrying "
+                "instance as an argument!"
+            )
+
+        super().__init__(session=session, **kwargs)
+
+    @staticmethod
+    def make_retrying(
+        *,
+        retry: retry_base = retry_never,
+        wait: wait_base = wait_none,
+        **kwargs,
+    ):
+        """
+        Create a retrying object with rate limiting behavior.
+
+        Sugar to bypass the need to importing Retrying. Passes any keyword
+        arguments to the Retrying constructor.
+
+        See:
+            https://tenacity.readthedocs.io/en/latest/api.html#tenacity.Retrying
+
+        Keyword Arguments:
+            retry(``tenacit.retry_base``, optional):
+                Additional retry conditions to be combined with the condition
+                of retrying on 429 response codes.
+            wait(``tenacit.wait_base``, optional):
+                Additional wait time that will be added to the wait time
+                imposed by the 5s exponential backoff as used by the
+                airtable.js library.
+            **kwargs(``dict``, optional): Keyword arguments for Retrying()
+
+        See:
+            https://tenacity.readthedocs.io/en/latest/api.html#tenacity.Retrying
+        """
+        assert_tenacity_installed()
+        backoff = wait_random_exponential(multiplier=5, max=600)
+        return super().make_retrying(
+            retry=retry_any(retry, retry_if_result(is_rate_limited)),
+            wait=wait_combine(wait, backoff),
+            **kwargs,
+        )

--- a/pyairtable/request_strategies/simple.py
+++ b/pyairtable/request_strategies/simple.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict, Optional, Tuple, Union
+from requests import Response, Session
+from .abstract import RequestStrategy, Headers, process_response
+
+
+class SimpleRequestStrategy(RequestStrategy):
+    """
+    Simple request strategy that manages timeouts & headers.
+
+    Usage:
+        >>> request_strategy = SimpleRequestStrategy()
+        >>> api = Api('apikey', request_strategy=request_strategy)
+    """
+
+    session: Session
+    _timeout: Optional[Union[float, Tuple[int, int]]]
+
+    def __init__(
+        self,
+        session: Optional[Session] = None,
+    ):
+        """
+        Initialize a simple strategy that just proxies requests to its Session.
+
+        Args:
+            session(``Session``, optional): |arg_session|
+        """
+        self.session = session if session is not None else Session()
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]],
+        json: Optional[Dict[str, Any]],
+        timeout: Optional[Tuple[int, int]],
+        headers: Headers,
+    ) -> Any:
+        """Make a request via the Session & process the response into json."""
+        response = self._request(
+            method,
+            url,
+            params=params,
+            json=json,
+            timeout=timeout,
+            headers=headers,
+        )
+        return process_response(response)
+
+    def _request(self, method: str, url: str, **kwargs: Any) -> Response:
+        """Make a request using the session."""
+        return self.session.request(method, url, **kwargs)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,4 @@ requests-mock==1.8.0
 mock==4.0.3
 codecov==2.1.11
 tox==3.24.1
+tenacity>=8.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,10 @@ packages = find:
 install_requires =
     requests >= 2
 
+[options.extras_require]
+tenacity =
+    tenacity >= 8.0.1
+
 [aliases]
 test=pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,10 @@ from mock import Mock
 from posixpath import join as urljoin
 from requests import HTTPError
 from urllib.parse import urlencode, quote
+from collections import OrderedDict
 
 from pyairtable.api import Api, Table, Base
-from collections import OrderedDict
+from pyairtable.request_strategies import SimpleRequestStrategy
 
 
 @pytest.fixture
@@ -121,3 +122,13 @@ def response():
     response.raise_for_status.side_effect = http_error
     response.url = "page%20url"
     return response
+
+
+@pytest.fixture()
+def request_strategy():
+    return SimpleRequestStrategy()
+
+
+@pytest.fixture()
+def invalid_request_strategy():
+    return object()

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -57,7 +57,7 @@ def test_api_key(table, mock_response_single):
 
 def test_update_api_key(table):
     table.api_key = "123"
-    assert "123" in table.session.headers["Authorization"]
+    assert "123" in table.auth_headers["Authorization"]
 
 
 def test_get_base(table):

--- a/tests/test_request_errors.py
+++ b/tests/test_request_errors.py
@@ -1,24 +1,25 @@
 import pytest
 from requests import HTTPError
 from mock import Mock
+from pyairtable.request_strategies.abstract import process_response
 
 
-def test_error_mesg_in_json(table, response):
+def test_error_mesg_in_json(response):
     response.status_code = 400
     response.json = Mock(return_value={"error": "here's what went wrong"})
     with pytest.raises(HTTPError):
-        table._process_response(response)
+        process_response(response)
 
 
-def test_error_without_mesg_in_json(table, response):
+def test_error_without_mesg_in_json(response):
     response.status_code = 404
     response.json = Mock(return_value={})
     with pytest.raises(HTTPError):
-        table._process_response(response)
+        process_response(response)
 
 
-def test_non_422_error_with_json_decode_error(table, response):
+def test_non_422_error_with_json_decode_error(response):
     response.status_code = 400
     response.json.side_effect = ValueError
     with pytest.raises(HTTPError):
-        table._process_response(response)
+        process_response(response)

--- a/tests/test_request_strategies.py
+++ b/tests/test_request_strategies.py
@@ -1,0 +1,115 @@
+import pytest
+from pyairtable.api import Api, Table, Base
+from pyairtable.request_strategies import RequestStrategy, SimpleRequestStrategy
+
+
+def test_request_strategy_initialize(request_strategy, invalid_request_strategy):
+    # When passed a valid class should instantiate it
+    _request_strategy = RequestStrategy.initialize(SimpleRequestStrategy)
+    assert isinstance(_request_strategy, SimpleRequestStrategy)
+    # When passed a valid instance should return it
+    _request_strategy_2 = RequestStrategy.initialize(request_strategy)
+    assert isinstance(_request_strategy_2, SimpleRequestStrategy)
+    assert _request_strategy_2 is request_strategy
+    # When passed anything else, it should error
+    with pytest.raises(TypeError):
+        RequestStrategy.initialize(invalid_request_strategy)  # type: ignore
+
+
+def test_api_has_default_request_strategy(api):
+    assert hasattr(api, "request_strategy")
+    assert isinstance(api.request_strategy, SimpleRequestStrategy)
+
+
+def test_base_has_default_request_strategy(base):
+    assert hasattr(base, "request_strategy")
+    assert isinstance(base.request_strategy, SimpleRequestStrategy)
+
+
+def test_table_has_default_request_strategy(table):
+    assert hasattr(table, "request_strategy")
+    assert isinstance(table.request_strategy, SimpleRequestStrategy)
+
+
+def test_api_accepts_request_strategy_class(constants):
+    api = Api(constants["API_KEY"], request_strategy=SimpleRequestStrategy)
+    assert hasattr(api, "request_strategy")
+    assert isinstance(api.request_strategy, SimpleRequestStrategy)
+    assert not isinstance(api.request_strategy, type)
+
+
+def test_base_accepts_request_strategy_class(constants):
+    base = Base(
+        constants["API_KEY"],
+        constants["BASE_ID"],
+        request_strategy=SimpleRequestStrategy,
+    )
+    assert hasattr(base, "request_strategy")
+    assert isinstance(base.request_strategy, SimpleRequestStrategy)
+    assert not isinstance(base.request_strategy, type)
+
+
+def test_table_accepts_request_strategy_class(constants):
+    table = Table(
+        constants["API_KEY"],
+        constants["BASE_ID"],
+        constants["TABLE_NAME"],
+        request_strategy=SimpleRequestStrategy,
+    )
+    assert hasattr(table, "request_strategy")
+    assert isinstance(table.request_strategy, SimpleRequestStrategy)
+    assert not isinstance(table.request_strategy, type)
+
+
+def test_api_accepts_request_strategy_instance(constants, request_strategy):
+    api = Api(constants["API_KEY"], request_strategy=request_strategy)
+    assert hasattr(api, "request_strategy")
+    assert isinstance(api.request_strategy, SimpleRequestStrategy)
+    assert api.request_strategy is request_strategy
+
+
+def test_base_accepts_request_strategy_instance(constants, request_strategy):
+    base = Base(
+        constants["API_KEY"],
+        constants["BASE_ID"],
+        request_strategy=request_strategy,
+    )
+    assert hasattr(base, "request_strategy")
+    assert isinstance(base.request_strategy, SimpleRequestStrategy)
+    assert base.request_strategy is request_strategy
+
+
+def test_table_accepts_request_strategy_instance(constants, request_strategy):
+    table = Table(
+        constants["API_KEY"],
+        constants["BASE_ID"],
+        constants["TABLE_NAME"],
+        request_strategy=request_strategy,
+    )
+    assert hasattr(table, "request_strategy")
+    assert isinstance(table.request_strategy, SimpleRequestStrategy)
+    assert table.request_strategy is request_strategy
+
+
+def test_api_rejects_invalid_request_strategy(constants, invalid_request_strategy):
+    with pytest.raises(TypeError):
+        Api(constants["API_KEY"], request_strategy=invalid_request_strategy)
+
+
+def test_base_rejects_invalid_request_strategy(constants, invalid_request_strategy):
+    with pytest.raises(TypeError):
+        Base(
+            constants["API_KEY"],
+            constants["BASE_ID"],
+            request_strategy=invalid_request_strategy,
+        )
+
+
+def test_table_rejects_invalid_request_strategy(constants, invalid_request_strategy):
+    with pytest.raises(TypeError):
+        Table(
+            constants["API_KEY"],
+            constants["BASE_ID"],
+            constants["TABLE_NAME"],
+            request_strategy=invalid_request_strategy,
+        )


### PR DESCRIPTION
[Implements #142]

This PR introduces a new pattern for consumers to inject alternate request
functionality into pyAirtable's ApiAbstract base class. A RequestStrategy should
accept the request parameters pyAirtable uses, make the HTTP request to the
Airtable API and then process the response and return the contained records in
the format that pyAirtable expects.

Three implementations are included, SimpleRequestStrategy,
RetryingRequestStrategy, and RateLimitRetryingRequestStrategy:

SimpleRequestStrategy encapsulates the use of a `requests.Session` to make the
requests, and expects the caller to provide any needed parameters like timeout
or headers. This behavior should be a 1:1 replacement of the old behavior.
SimpleRequestStrategy accepts an optional pre-configured Session if the caller
needs to do more specific set-up, e.g. of headers, etc.

RetryingRequestStrategy relies on `tenacity.Retrying`, from tenacity, a
well-established, widely trusted, and batteries-included function-retry library.
The caller must provide a configured Retrying object to control the retry
behavior on the requests.

RateLimitRetryingRequestStrategy subclasses RetryingRequestStrategy and provides
a Retrying object that reimplements the built-in retry behavior of the official
Airtable JS library, airtable.js. Requests to Airtable that hit the rate limit
of 5 request/second, are rejected with a 429 status code, as are all subsequent
requests for 30 seconds. airtable.js accommodates this with a jittered
exponential backoff starting at 30s when it receives a 429, and that behavior is
implemented here.

---

## To Do

- [x] Add tests
- [x] Better type checking on request() to assert expected return shapes