### PR TITLE
Parameterize max records per request

### DIFF
--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -14,6 +14,8 @@
     the connection to be established  and 5 seconds for a
     server read timeout. Default is ``None`` (no timeout).
 
+.. |arg_max_records_per_request| replace:: Maximum records per request, to be used when doing batch creations/updates
+
 .. |kwarg_view| replace:: The name or ID of a view.
     If set, only the records in that view will be returned.
     The records will be sorted according to the order of the view.

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -19,7 +19,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     API_URL = posixpath.join(API_BASE_URL, VERSION)
 
     session: requests.Session
-    tiemout: Optional[Tuple[int, int]]
+    timeout: Optional[Tuple[int, int]]
 
     def __init__(self, api_key: str, max_records_per_request: int, timeout=None):
         session = requests.Session()

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -66,7 +66,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     def _chunk(self, iterable, chunk_size):
         """Break iterable into chunks"""
         for i in range(0, len(iterable), chunk_size):
-            yield iterable[i: i + chunk_size]
+            yield iterable[i : i + chunk_size]
 
     def _build_batch_record_objects(self, records):
         return [{"fields": record} for record in records]

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -9,7 +9,7 @@ import requests
 
 from .params import to_params_dict
 
-MAX_RECORDS_PER_REQUEST = 10
+DEFAULT_MAX_RECORDS_PER_REQUEST = 10
 
 
 class ApiAbstract(metaclass=abc.ABCMeta):
@@ -21,7 +21,8 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     session: requests.Session
     timeout: Optional[Tuple[int, int]]
 
-    def __init__(self, api_key: str, max_records_per_request: int, timeout=None):
+    def __init__(self, api_key: str, timeout: Optional[int]=None,
+                 max_records_per_request: Optional[int]=DEFAULT_MAX_RECORDS_PER_REQUEST):
         session = requests.Session()
         self.session = session
         self.timeout = timeout

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -21,7 +21,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     session: requests.Session
     tiemout: Optional[Tuple[int, int]]
 
-    def __init__(self, api_key: str, max_records_per_request, timeout=None):
+    def __init__(self, api_key: str, max_records_per_request: int, timeout=None):
         session = requests.Session()
         self.session = session
         self.timeout = timeout

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -18,7 +18,12 @@ class Api(ApiAbstract):
         >>> api.all('base_id', 'table_name')
     """
 
-    def __init__(self, api_key: str, timeout=None, max_records_per_request=MAX_RECORDS_PER_REQUEST):
+    def __init__(
+        self,
+        api_key: str,
+        timeout=None,
+        max_records_per_request=MAX_RECORDS_PER_REQUEST,
+    ):
         """
 
         Args:
@@ -28,7 +33,9 @@ class Api(ApiAbstract):
             timeout(``Tuple``): |arg_timeout|
             max_records_per_request: |arg_max_records_per_request|
         """
-        super().__init__(api_key, max_records_per_request=max_records_per_request, timeout=timeout)
+        super().__init__(
+            api_key, max_records_per_request=max_records_per_request, timeout=timeout
+        )
 
     def get_table(self, base_id: str, table_name: str) -> "Table":
         """

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from .abstract import ApiAbstract, MAX_RECORDS_PER_REQUEST
+from .abstract import ApiAbstract, DEFAULT_MAX_RECORDS_PER_REQUEST
 
 
 class Api(ApiAbstract):
@@ -22,7 +22,7 @@ class Api(ApiAbstract):
         self,
         api_key: str,
         timeout=None,
-        max_records_per_request=MAX_RECORDS_PER_REQUEST,
+        max_records_per_request=DEFAULT_MAX_RECORDS_PER_REQUEST,
     ):
         """
 

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -23,10 +23,10 @@ class Api(ApiAbstract):
 
         Args:
             api_key: |arg_api_key|
+            max_records_per_request: |arg_max_records_per_request|
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|
-            max_records_per_request: |arg_max_records_per_request|
         """
         super().__init__(api_key, max_records_per_request=max_records_per_request, timeout=timeout)
 

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,5 +1,6 @@
 from typing import List
-from .abstract import ApiAbstract
+
+from .abstract import ApiAbstract, MAX_RECORDS_PER_REQUEST
 
 
 class Api(ApiAbstract):
@@ -17,7 +18,7 @@ class Api(ApiAbstract):
         >>> api.all('base_id', 'table_name')
     """
 
-    def __init__(self, api_key: str, timeout=None):
+    def __init__(self, api_key: str, max_records_per_request=MAX_RECORDS_PER_REQUEST, timeout=None):
         """
 
         Args:
@@ -25,9 +26,9 @@ class Api(ApiAbstract):
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|
-
+            max_records_per_request: |arg_max_records_per_request|
         """
-        super().__init__(api_key, timeout=timeout)
+        super().__init__(api_key, max_records_per_request=max_records_per_request, timeout=timeout)
 
     def get_table(self, base_id: str, table_name: str) -> "Table":
         """

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -18,15 +18,15 @@ class Api(ApiAbstract):
         >>> api.all('base_id', 'table_name')
     """
 
-    def __init__(self, api_key: str, max_records_per_request=MAX_RECORDS_PER_REQUEST, timeout=None):
+    def __init__(self, api_key: str, timeout=None, max_records_per_request=MAX_RECORDS_PER_REQUEST):
         """
 
         Args:
             api_key: |arg_api_key|
-            max_records_per_request: |arg_max_records_per_request|
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|
+            max_records_per_request: |arg_max_records_per_request|
         """
         super().__init__(api_key, max_records_per_request=max_records_per_request, timeout=timeout)
 

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from .abstract import ApiAbstract, MAX_RECORDS_PER_REQUEST
+from .abstract import ApiAbstract, DEFAULT_MAX_RECORDS_PER_REQUEST
 
 
 class Base(ApiAbstract):
@@ -20,7 +20,7 @@ class Base(ApiAbstract):
         api_key: str,
         base_id: str,
         timeout=None,
-        max_records_per_request=MAX_RECORDS_PER_REQUEST,
+        max_records_per_request=DEFAULT_MAX_RECORDS_PER_REQUEST,
     ):
         """
         Args:

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -15,7 +15,13 @@ class Base(ApiAbstract):
 
     base_id: str
 
-    def __init__(self, api_key: str, base_id: str, timeout=None, max_records_per_request=MAX_RECORDS_PER_REQUEST):
+    def __init__(
+        self,
+        api_key: str,
+        base_id: str,
+        timeout=None,
+        max_records_per_request=MAX_RECORDS_PER_REQUEST,
+    ):
         """
         Args:
             api_key: |arg_api_key|
@@ -27,7 +33,9 @@ class Base(ApiAbstract):
         """
 
         self.base_id = base_id
-        super().__init__(api_key,  max_records_per_request=max_records_per_request, timeout=timeout)
+        super().__init__(
+            api_key, max_records_per_request=max_records_per_request, timeout=timeout
+        )
 
     def get_table(self, table_name: str) -> "Table":
         """

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -15,15 +15,15 @@ class Base(ApiAbstract):
 
     base_id: str
 
-    def __init__(self, api_key: str, base_id: str, max_records_per_request=MAX_RECORDS_PER_REQUEST, timeout=None):
+    def __init__(self, api_key: str, base_id: str, timeout=None, max_records_per_request=MAX_RECORDS_PER_REQUEST):
         """
         Args:
             api_key: |arg_api_key|
             base_id: |arg_base_id|
-            max_records_per_request: |arg_max_records_per_request|
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|
+            max_records_per_request: |arg_max_records_per_request|
         """
 
         self.base_id = base_id

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from .abstract import ApiAbstract
+from .abstract import ApiAbstract, MAX_RECORDS_PER_REQUEST
 
 
 class Base(ApiAbstract):
@@ -15,7 +15,7 @@ class Base(ApiAbstract):
 
     base_id: str
 
-    def __init__(self, api_key: str, base_id: str, timeout=None):
+    def __init__(self, api_key: str, base_id: str, max_records_per_request=MAX_RECORDS_PER_REQUEST, timeout=None):
         """
         Args:
             api_key: |arg_api_key|
@@ -23,10 +23,11 @@ class Base(ApiAbstract):
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|
+            max_records_per_request: |arg_max_records_per_request|
         """
 
         self.base_id = base_id
-        super().__init__(api_key, timeout=timeout)
+        super().__init__(api_key,  max_records_per_request=max_records_per_request, timeout=timeout)
 
     def get_table(self, table_name: str) -> "Table":
         """

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -20,10 +20,10 @@ class Base(ApiAbstract):
         Args:
             api_key: |arg_api_key|
             base_id: |arg_base_id|
+            max_records_per_request: |arg_max_records_per_request|
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|
-            max_records_per_request: |arg_max_records_per_request|
         """
 
         self.base_id = base_id

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -1,5 +1,5 @@
 from typing import List
-from .abstract import ApiAbstract
+from .abstract import ApiAbstract, MAX_RECORDS_PER_REQUEST
 
 
 class Table(ApiAbstract):
@@ -16,7 +16,8 @@ class Table(ApiAbstract):
     base_id: str
     table_name: str
 
-    def __init__(self, api_key: str, base_id: str, table_name: str, *, timeout=None):
+    def __init__(self, api_key: str, base_id: str, table_name: str, *, max_records_per_request=MAX_RECORDS_PER_REQUEST,
+                 timeout=None):
         """
         Args:
             api_key: |arg_api_key|
@@ -28,7 +29,7 @@ class Table(ApiAbstract):
         """
         self.base_id = base_id
         self.table_name = table_name
-        super().__init__(api_key, timeout=timeout)
+        super().__init__(api_key,  max_records_per_request=max_records_per_request, timeout=timeout)
 
     @property
     def table_url(self):

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -16,8 +16,15 @@ class Table(ApiAbstract):
     base_id: str
     table_name: str
 
-    def __init__(self, api_key: str, base_id: str, table_name: str, *,timeout=None,
-                 max_records_per_request=MAX_RECORDS_PER_REQUEST):
+    def __init__(
+        self,
+        api_key: str,
+        base_id: str,
+        table_name: str,
+        *,
+        timeout=None,
+        max_records_per_request=MAX_RECORDS_PER_REQUEST,
+    ):
         """
         Args:
             api_key: |arg_api_key|
@@ -30,7 +37,9 @@ class Table(ApiAbstract):
         """
         self.base_id = base_id
         self.table_name = table_name
-        super().__init__(api_key,  max_records_per_request=max_records_per_request, timeout=timeout)
+        super().__init__(
+            api_key, max_records_per_request=max_records_per_request, timeout=timeout
+        )
 
     @property
     def table_url(self):

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -16,13 +16,14 @@ class Table(ApiAbstract):
     base_id: str
     table_name: str
 
-    def __init__(self, api_key: str, base_id: str, table_name: str, *, max_records_per_request=MAX_RECORDS_PER_REQUEST,
+    def __init__(self, api_key: str, base_id: str, table_name: str, max_records_per_request=MAX_RECORDS_PER_REQUEST, *,
                  timeout=None):
         """
         Args:
             api_key: |arg_api_key|
             base_id: |arg_base_id|
             table_name: |arg_table_name|
+            max_records_per_request: |arg_max_records_per_request|
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -16,17 +16,17 @@ class Table(ApiAbstract):
     base_id: str
     table_name: str
 
-    def __init__(self, api_key: str, base_id: str, table_name: str, max_records_per_request=MAX_RECORDS_PER_REQUEST, *,
-                 timeout=None):
+    def __init__(self, api_key: str, base_id: str, table_name: str, *,timeout=None,
+                 max_records_per_request=MAX_RECORDS_PER_REQUEST):
         """
         Args:
             api_key: |arg_api_key|
             base_id: |arg_base_id|
             table_name: |arg_table_name|
-            max_records_per_request: |arg_max_records_per_request|
 
         Keyword Args:
             timeout(``Tuple``): |arg_timeout|
+            max_records_per_request: |arg_max_records_per_request|
         """
         self.base_id = base_id
         self.table_name = table_name

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -1,5 +1,5 @@
 from typing import List
-from .abstract import ApiAbstract, MAX_RECORDS_PER_REQUEST
+from .abstract import ApiAbstract, DEFAULT_MAX_RECORDS_PER_REQUEST
 
 
 class Table(ApiAbstract):
@@ -23,7 +23,7 @@ class Table(ApiAbstract):
         table_name: str,
         *,
         timeout=None,
-        max_records_per_request=MAX_RECORDS_PER_REQUEST,
+        max_records_per_request=DEFAULT_MAX_RECORDS_PER_REQUEST,
     ):
         """
         Args:


### PR DESCRIPTION
I'm pushing a lot of records to a table (~10k), so I'd rather try more than 10 per request in the batch creation/updates. This PR parameterized the MAX_RECORD_PER_REQUEST arg, defaulting to 10