### PR TITLE
fix: key error in doc

### DIFF
--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -131,7 +131,7 @@ class Api(ApiAbstract):
 
         >>> api.all('base_id', 'table_name', view='MyView', fields=['ColA', '-ColB'])
         [{'fields': ... }, ...]
-        >>> api.all('base_id', 'table_name', maxRecords=50)
+        >>> api.all('base_id', 'table_name', max_records=50)
         [{'fields': ... }, ...]
 
         Args:
@@ -152,7 +152,7 @@ class Api(ApiAbstract):
         Returns:
             records (``list``): List of Records
 
-        >>> records = all(maxRecords=3, view='All')
+        >>> records = all(max_records=3, view='All')
 
         """
         return super()._all(base_id, table_name, **options)


### PR DESCRIPTION
I was going through the docs and can across this error copy pasting from it
![image](https://user-images.githubusercontent.com/57913645/164026008-89a603ca-849e-490b-b55d-287b2a8c962e.png)

The parameter in the doc is `maxRecords`(which is actually the airtable api parameter). What worked for me instead is `max_records`. 

I've made this small PR in order to fix the doc..... And thanks a lot for this awesome package.... It helped me a lot in my recent project....
