### PR TITLE
Add returnFieldsByFieldId parameter

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -291,6 +291,9 @@ have a corresponding ``kwargs`` that can be used with fetching methods like :met
    * - ``time_zone``
      - ``timeZone``
      - |kwarg_time_zone|
+   * - ``return_fields_by_field_id``
+     - ``returnFieldsByFieldId``
+     - |kwarg_return_fields_by_field_id|
 
 
 Formulas

--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -64,3 +64,6 @@
     when using `string` as the `cell_format`. See
     https://support.airtable.com/hc/en-us/articles/216141558-Supported-timezones-for-SET-TIMEZONE
     for valid values.
+
+.. |kwarg_return_fields_by_field_id| replace:: An optional boolean value that lets you return field objects where the
+    key is the field id. This defaults to `false`, which returns field objects where the key is the field name.

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -97,6 +97,7 @@ class Api(ApiAbstract):
             cell_format: |kwarg_cell_format|
             user_locale: |kwarg_user_locale|
             time_zone: |kwarg_time_zone|
+            return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
             iterator: Record Iterator, grouped by page size
@@ -148,6 +149,7 @@ class Api(ApiAbstract):
             cell_format: |kwarg_cell_format|
             user_locale: |kwarg_user_locale|
             time_zone: |kwarg_time_zone|
+            return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
             records (``list``): List of Records

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -85,6 +85,8 @@ def to_params_dict(param_name: str, value: Any):
         return {"timeZone": value}
     elif param_name == "user_locale":
         return {"userLocale": value}
+    elif param_name == "returnFieldsByFieldId":
+        return {"returnFieldsByFieldId": value}
     elif param_name == "sort":
         sorting_dict_list = field_names_to_sorting_dict(value)
         return dict_list_to_request_params("sort", sorting_dict_list)

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -85,8 +85,8 @@ def to_params_dict(param_name: str, value: Any):
         return {"timeZone": value}
     elif param_name == "user_locale":
         return {"userLocale": value}
-    elif param_name == "returnFieldsByFieldId":
-        return {"returnFieldsByFieldId": value}
+    elif param_name == "return_fields_by_field_id":
+        return {"returnFieldsByFieldId": int(value)}
     elif param_name == "sort":
         sorting_dict_list = field_names_to_sorting_dict(value)
         return dict_list_to_request_params("sort", sorting_dict_list)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -16,6 +16,7 @@ def test_params_integration(table, mock_records, mock_response_iterator):
         "view": "View",
         "sort": ["Name"],
         "fields": ["Name", "Age"],
+        "return_fields_by_field_id": 1,
     }
     with Mocker() as m:
         url_params = (
@@ -25,6 +26,7 @@ def test_params_integration(table, mock_records, mock_response_iterator):
             "&view=View"
             "&fields%5B%5D=Name"
             "&fields%5B%5D=Age"
+            "&returnFieldsByFieldId=1"
             ""
         )
         mock_url = "{0}?{1}".format(table.table_url, url_params)
@@ -97,6 +99,9 @@ def test_params_integration(table, mock_records, mock_response_iterator):
             "?timeZone=America%2FChicago"
             # '?timeZone=America/Chicago'
         ],
+        ["return_fields_by_field_id", True, "?returnFieldsByFieldId=1"],
+        ["return_fields_by_field_id", 1, "?returnFieldsByFieldId=1"],
+        ["return_fields_by_field_id", False, "?returnFieldsByFieldId=0"],
         # TODO
         # [
         #     {"sort": [("Name", "desc"), ("Phone", "asc")]},


### PR DESCRIPTION
Replaces https://github.com/gtalarico/pyairtable/pull/157, including some docs and tests.

Adds support for `returnFieldsByFieldId` Airtable parameter, which instructs the Airtable API to return field IDs rather than names. It is recommended to use this option when possible:

> Field names and field ids can be used interchangeably. Using field ids means field name changes do not require modifications to your API request. We recommend using field ids over field names where possible, to reduce modifications to your API request if the user changes the field name later.