### PR TITLE
Add support for retry with exponential backoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ coverage.xml
 .coverage
 test.py
 pip-wheel-metadata
+.python-version
+.idea*

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -1,12 +1,12 @@
 import abc
-from functools import lru_cache
 import posixpath
-from typing import List, Optional, Tuple
+import requests
 import time
+from functools import lru_cache
+from typing import List, Optional, Tuple
 from urllib.parse import quote
 
-import requests
-
+from pyairtable.utils import AutoRetrySession
 from .params import to_params_dict
 
 
@@ -17,7 +17,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     API_URL = posixpath.join(API_BASE_URL, VERSION)
     MAX_RECORDS_PER_REQUEST = 10
 
-    session: requests.Session
+    session: AutoRetrySession
     tiemout: Optional[Tuple[int, int]]
 
     def __init__(self, api_key: str, timeout=None):
@@ -64,7 +64,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     def _chunk(self, iterable, chunk_size):
         """Break iterable into chunks"""
         for i in range(0, len(iterable), chunk_size):
-            yield iterable[i : i + chunk_size]
+            yield iterable[i: i + chunk_size]
 
     def _build_batch_record_objects(self, records):
         return [{"fields": record} for record in records]

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -1,12 +1,13 @@
 import abc
 import posixpath
-import requests
 import time
 from functools import lru_cache
 from typing import List, Optional, Tuple
 from urllib.parse import quote
 
-from pyairtable.utils import AutoRetrySession
+import requests
+
+from pyairtable.utils import AutoRetrySession, API_CLIENT_ENABLE_RETRIES, API_CLIENT_MAX_RETRIES
 from .params import to_params_dict
 
 
@@ -16,13 +17,14 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     API_LIMIT = 1.0 / 5  # 5 per second
     API_URL = posixpath.join(API_BASE_URL, VERSION)
     MAX_RECORDS_PER_REQUEST = 10
-
-    session: AutoRetrySession
-    tiemout: Optional[Tuple[int, int]]
+    session = requests.Session
+    timeout: Optional[Tuple[int, int]]
 
     def __init__(self, api_key: str, timeout=None):
-        session = requests.Session()
-        self.session = session
+        if API_CLIENT_ENABLE_RETRIES and API_CLIENT_MAX_RETRIES > 0:
+            self.session = AutoRetrySession()
+        else:
+            self.session = requests.Session()
         self.timeout = timeout
         self.api_key = api_key
 

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -1,8 +1,10 @@
+import os
 from datetime import datetime, date
+from typing import Union
+
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-from typing import Union
 
 from pyairtable import __version__ as pyairtable_version
 
@@ -85,21 +87,24 @@ def attachment(url: str, filename="") -> dict:
     return {"url": url} if not filename else {"url": url, "filename": filename}
 
 
+API_CLIENT_MAX_RETRIES = os.getenv('API_CLIENT_MAX_RETRIES', 3)
+API_CLIENT_POOL_CONNECTIONS = os.getenv('API_CLIENT_POOL_CONNECTIONS', 30)
+API_CLIENT_MAX_POOL_SIZE = os.getenv('API_CLIENT_MAX_POOL_SIZE', 30)
+API_CLIENT_ENABLE_RETRIES = str(os.getenv('API_CLIENT_ENABLE_RETRIES', False)).lower() in ['1', 'yes', 'true', 'on']
+
+
 class AutoRetrySession(Session):
     """ This Session object will retry requests that return temporary errors. """
 
     DEFAULT_RETRY_CODES = (429, 500, 502, 503, 504)
     DEFAULT_RETRY_METHODS = ("HEAD", "GET", "POST", "PUT", "PATCH", "OPTIONS", "DELETE")
     DEFAULT_BACKOFF_FACTOR = 0.3
-    DEFAULT_MAX_RETRIES = 5
-    DEFAULT_POOL_CONNECTIONS = 30
-    DEFAULT_MAX_POOL_SIZE = 30
 
     # TODO: add ENV variables for controlling retry behaviour
 
     def __init__(self, status_force: tuple = DEFAULT_RETRY_CODES, method_whitelist: tuple = DEFAULT_RETRY_METHODS,
-                 max_retries: int = DEFAULT_MAX_RETRIES, backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
-                 pool_connections: int = DEFAULT_POOL_CONNECTIONS, pool_maxsize: int = DEFAULT_MAX_POOL_SIZE):
+                 max_retries: int = API_CLIENT_MAX_RETRIES, backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+                 pool_connections: int = API_CLIENT_POOL_CONNECTIONS, pool_maxsize: int = API_CLIENT_MAX_POOL_SIZE):
         super().__init__()
 
         # Indicate our preference for JSON

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -1,5 +1,10 @@
 from datetime import datetime, date
+from requests import Session
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from typing import Union
+
+from pyairtable import __version__ as pyairtable_version
 
 
 def datetime_to_iso_str(value: datetime) -> str:
@@ -78,3 +83,42 @@ def attachment(url: str, filename="") -> dict:
 
     """
     return {"url": url} if not filename else {"url": url, "filename": filename}
+
+
+class AutoRetrySession(Session):
+    """ This Session object will retry requests that return temporary errors. """
+
+    DEFAULT_RETRY_CODES = (429, 500, 502, 503, 504)
+    DEFAULT_RETRY_METHODS = ("HEAD", "GET", "POST", "PUT", "PATCH", "OPTIONS", "DELETE")
+    DEFAULT_BACKOFF_FACTOR = 0.3
+    DEFAULT_MAX_RETRIES = 5
+    DEFAULT_POOL_CONNECTIONS = 30
+    DEFAULT_MAX_POOL_SIZE = 30
+
+    # TODO: add ENV variables for controlling retry behaviour
+
+    def __init__(self, status_force: tuple = DEFAULT_RETRY_CODES, method_whitelist: tuple = DEFAULT_RETRY_METHODS,
+                 max_retries: int = DEFAULT_MAX_RETRIES, backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+                 pool_connections: int = DEFAULT_POOL_CONNECTIONS, pool_maxsize: int = DEFAULT_MAX_POOL_SIZE):
+        super().__init__()
+
+        # Indicate our preference for JSON
+        self.headers.update({"Accept": "application/json",
+                             'User-Agent': f'pyairtable client {pyairtable_version}'})
+
+        retry_strategy = Retry(
+            total=max_retries,
+            backoff_factor=backoff_factor,
+            status_forcelist=list(status_force),
+            method_whitelist=list(method_whitelist),
+            raise_on_status=False,  # type: ignore
+        )
+
+        adapter = HTTPAdapter(
+            pool_connections=pool_connections,
+            pool_maxsize=pool_maxsize,
+            max_retries=retry_strategy
+        )
+
+        super(AutoRetrySession, self).mount('https://', adapter)
+        super(AutoRetrySession, self).mount('http://', adapter)


### PR DESCRIPTION
Add retry with exponential backoff mechanism when the airtable API returns 429, 500, 502, 503, 504 http code responses

Added 4 new environment variables to enable retries, max retry count and connection pool sizes.

* API_CLIENT_ENABLE_RETRIES
* API_CLIENT_MAX_RETRIES
* API_CLIENT_POOL_CONNECTIONS
* API_CLIENT_MAX_POOL_SIZE

Feel free to suggest better names :)