### PR TITLE
[RFC] Add Retrying Session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ coverage.xml
 .coverage
 test.py
 pip-wheel-metadata
+.python-version
+.idea*

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,7 +3,7 @@
 Airtable Api
 ============
 
-Overview                                                                                                                                                                                                                                                                                                  
+Overview
 ********
 
 This client offers three classes you can use to access the Airtable Api:
@@ -232,7 +232,6 @@ Api
 .. autoclass:: pyairtable.api.Api
   :members:
 
-
 Base
 -----
 
@@ -247,6 +246,49 @@ Table
     :members:
 
 
+Retrying
+********
+
+.. versionadded:: 1.3.0
+
+You may provide an instance of ``urllib3.util.Retry`` to configure
+retrying behaviour.
+
+The library also provides :func:`~pyairtable.api.retrying.retry_strategy` to quickly generate a
+``Retry`` instance with reasonable defaults that you can use as-is or with tweaks.
+
+.. note:: for backwards-compatibility, the default behavior is no retry (`retry_strategy=None`).
+  This may change in future releases.
+
+Default Retry Strategy
+
+.. code-block:: python
+
+  from pyairtable import Api, retry_strategy
+  api = Api('apikey', retry_strategy=retry_strategy())
+
+
+Adjusted Default Strategy
+
+.. code-block:: python
+
+  from pyairtable import Api, retry_strategy
+  api = Api('apikey', retry_strategy=retry_strategy(total=3))
+
+Custom Retry
+
+.. code-block:: python
+
+  from pyairtable import Api, retry_strategy
+  from urllib3.util import Retry
+
+  myRetry = Retry(**kwargs)
+  api = Api('apikey', retry_strategy=myRetry)
+
+
+.. autofunction:: pyairtable.api.retrying.retry_strategy
+
+
 
 Parameters
 **********
@@ -257,7 +299,7 @@ Most options in the Airtable Api (eg. ``sort``, ``fields``, etc)
 have a corresponding ``kwargs`` that can be used with fetching methods like :meth:`~pyairtable.api.Table.iterate`.
 
 
-.. list-table:: Title
+.. list-table::
    :widths: 25 25 50
    :header-rows: 1
 
@@ -292,6 +334,7 @@ have a corresponding ``kwargs`` that can be used with fetching methods like :met
      - ``timeZone``
      - |kwarg_time_zone|
    * - ``return_fields_by_field_id``
+        .. versionadded:: 1.3.0
      - ``returnFieldsByFieldId``
      - |kwarg_return_fields_by_field_id|
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,10 +61,10 @@ autoapi_dirs = [os.path.join(root_dir, "pyairtable")]
 napoleon_google_docstring = True
 napoleon_include_init_with_doc = True
 napoleon_attr_annotations = True
-# napoleon_preprocess_types = False # True to convert the type definitions in the docstrings as references. Defaults to False.
+# napoleon_preprocess_types = True  # True to convert the type definitions in the docstrings as references. Defaults to False.
 # napoleon_type_aliases = None
 # napoleon_attr_annotations = True
-
+# napoleon_use_param = True
 
 __version__ = version.split("-", 0)
 __release__ = version

--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -14,6 +14,11 @@
     the connection to be established  and 5 seconds for a
     server read timeout. Default is ``None`` (no timeout).
 
+.. |arg_retry_strategy| replace:: An instance of ``urllib3.util.Retry``.
+    :func:`pyairtable.retrying.retry_strategy` returns one with reasonable
+    defaults, but you may provide your own custom instance of ``Retry``.
+    Default is ``None`` (no retry).
+
 .. |kwarg_view| replace:: The name or ID of a view.
     If set, only the records in that view will be returned.
     The records will be sorted according to the order of the view.
@@ -50,7 +55,7 @@
     automatic data conversion from string values. Default is False.
 
 .. |kwarg_cell_format| replace:: The cell format to request from the Airtable
-    API. Supported options are `json` (the default) and `string`. 
+    API. Supported options are `json` (the default) and `string`.
     `json` will return cells as a JSON object. `string` will return
     the cell as a string. `user_locale` and `time_zone` must be set when using
     `string`.

--- a/pyairtable/__init__.py
+++ b/pyairtable/__init__.py
@@ -1,3 +1,4 @@
 __version__ = "1.2.0"
 
 from .api import Api, Base, Table  # noqa
+from .api.retrying import retry_strategy  # noqa

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -1,12 +1,12 @@
 import abc
-from functools import lru_cache
 import posixpath
-from typing import List, Optional, Tuple
+import requests
 import time
+from functools import lru_cache
+from typing import List, Optional, Tuple
 from urllib.parse import quote
 
-import requests
-
+from pyairtable.utils import AutoRetrySession
 from .params import to_params_dict
 
 
@@ -17,7 +17,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     API_URL = posixpath.join(API_BASE_URL, VERSION)
     MAX_RECORDS_PER_REQUEST = 10
 
-    session: requests.Session
+    session: AutoRetrySession
     tiemout: Optional[Tuple[int, int]]
 
     def __init__(self, api_key: str, timeout=None):
@@ -64,7 +64,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     def _chunk(self, iterable, chunk_size):
         """Break iterable into chunks"""
         for i in range(0, len(iterable), chunk_size):
-            yield iterable[i : i + chunk_size]
+            yield iterable[i: i + chunk_size]
 
     def _build_batch_record_objects(self, records):
         return [{"fields": record} for record in records]

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,5 +1,7 @@
-from typing import List
-from .abstract import ApiAbstract
+from typing import List, Optional
+from .abstract import ApiAbstract, TimeoutTuple
+
+from .. import compat
 
 
 class Api(ApiAbstract):
@@ -17,17 +19,24 @@ class Api(ApiAbstract):
         >>> api.all('base_id', 'table_name')
     """
 
-    def __init__(self, api_key: str, timeout=None):
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        timeout: Optional[TimeoutTuple] = None,
+        retry_strategy: Optional["compat.Retry"] = None,
+    ):
         """
 
         Args:
             api_key: |arg_api_key|
 
         Keyword Args:
-            timeout(``Tuple``): |arg_timeout|
+            timeout (``Tuple``): |arg_timeout|
+            retry_strategy (``Retry``): |arg_retry_strategy|
 
         """
-        super().__init__(api_key, timeout=timeout)
+        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy)
 
     def get_table(self, base_id: str, table_name: str) -> "Table":
         """

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -1,6 +1,7 @@
-from typing import List
+from typing import List, Optional
 
-from .abstract import ApiAbstract
+from .abstract import ApiAbstract, TimeoutTuple
+from .. import compat
 
 
 class Base(ApiAbstract):
@@ -15,18 +16,26 @@ class Base(ApiAbstract):
 
     base_id: str
 
-    def __init__(self, api_key: str, base_id: str, timeout=None):
+    def __init__(
+        self,
+        api_key: str,
+        base_id: str,
+        *,
+        timeout: Optional[TimeoutTuple] = None,
+        retry_strategy: Optional["compat.Retry"] = None,
+    ):
         """
         Args:
             api_key: |arg_api_key|
             base_id: |arg_base_id|
 
         Keyword Args:
-            timeout(``Tuple``): |arg_timeout|
+            timeout (``Tuple``): |arg_timeout|
+            retry_strategy (``Retry``): |arg_retry_strategy|
         """
 
         self.base_id = base_id
-        super().__init__(api_key, timeout=timeout)
+        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy)
 
     def get_table(self, table_name: str) -> "Table":
         """

--- a/pyairtable/api/retrying.py
+++ b/pyairtable/api/retrying.py
@@ -1,0 +1,54 @@
+from requests import Session
+from requests.adapters import HTTPAdapter
+
+from .. import compat
+
+
+DEFAULT_RETRIABLE_STATUS_CODES = (429, 500, 502, 503, 504)
+DEFAULT_BACKOFF_FACTOR = 0.3
+DEFAULT_MAX_RETRIES = 5
+
+
+def retry_strategy(
+    *,
+    status_forcelist=DEFAULT_RETRIABLE_STATUS_CODES,
+    backoff_factor=DEFAULT_BACKOFF_FACTOR,
+    total=DEFAULT_MAX_RETRIES,
+    **kwargs,
+) -> "compat.Retry":
+    """
+    Creates a ``Retry`` instance with optional default values.
+    See `urllib3 Retry docs <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html>`_
+    for more details.
+
+    Keyword Args:
+        status_forcelist (``Tuple[int]``): list status code which should be retried.
+        backoff_factor (``float``): backoff factor.
+        total (``int``): max. number of retries. Note ``0`` means no retries,
+            while``1`` will exececute a total of two requests (1 + 1 retry).
+        **kwargs: All parameters supported by ``urllib3.util.Retry`` can be used.
+    """
+
+    try:
+        from urllib3.util import Retry
+    except ImportError:
+        raise ImportError(
+            "urllib3.util.Retry not found. Install newer urllib3 to use `Retry`."
+        )
+
+    return Retry(
+        total=total,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        **kwargs,
+    )
+
+
+class _RetryingSession(Session):
+    def __init__(self, retry_strategy: "compat.Retry"):
+        super().__init__()
+
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+
+        self.mount("https://", adapter)
+        self.mount("http://", adapter)

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -1,5 +1,7 @@
-from typing import List
-from .abstract import ApiAbstract
+from typing import List, Optional
+
+from .abstract import ApiAbstract, TimeoutTuple
+from .. import compat
 
 
 class Table(ApiAbstract):
@@ -16,7 +18,15 @@ class Table(ApiAbstract):
     base_id: str
     table_name: str
 
-    def __init__(self, api_key: str, base_id: str, table_name: str, *, timeout=None):
+    def __init__(
+        self,
+        api_key: str,
+        base_id: str,
+        table_name: str,
+        *,
+        timeout: Optional[TimeoutTuple] = None,
+        retry_strategy: Optional["compat.Retry"] = None,
+    ):
         """
         Args:
             api_key: |arg_api_key|
@@ -24,11 +34,12 @@ class Table(ApiAbstract):
             table_name: |arg_table_name|
 
         Keyword Args:
-            timeout(``Tuple``): |arg_timeout|
+            timeout (``Tuple``): |arg_timeout|
+            retry_strategy (``Retry``): |arg_retry_strategy|
         """
         self.base_id = base_id
         self.table_name = table_name
-        super().__init__(api_key, timeout=timeout)
+        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy)
 
     @property
     def table_url(self):

--- a/pyairtable/compat.py
+++ b/pyairtable/compat.py
@@ -1,0 +1,9 @@
+import sys
+import os
+from typing import TYPE_CHECKING
+
+
+IS_SPHINX = os.path.basename(os.path.dirname(sys.argv[0])) == "sphinx"
+
+if TYPE_CHECKING or IS_SPHINX:
+    from urllib3.util import Retry  # noqa

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -1,5 +1,10 @@
 from datetime import datetime, date
+from requests import Session
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from typing import Union
+
+from pyairtable import __version__ as pyairtable_version
 
 
 def datetime_to_iso_str(value: datetime) -> str:
@@ -78,3 +83,42 @@ def attachment(url: str, filename="") -> dict:
 
     """
     return {"url": url} if not filename else {"url": url, "filename": filename}
+
+
+class AutoRetrySession(Session):
+    """ This Session object will retry requests that return temporary errors. """
+
+    DEFAULT_RETRY_CODES = (429, 500, 502, 503, 504)
+    DEFAULT_RETRY_METHODS = ("HEAD", "GET", "POST", "PUT", "PATCH", "OPTIONS", "DELETE")
+    DEFAULT_BACKOFF_FACTOR = 0.3
+    DEFAULT_MAX_RETRIES = 5
+    DEFAULT_POOL_CONNECTIONS = 30
+    DEFAULT_MAX_POOL_SIZE = 30
+
+    # TODO: add ENV variables for controlling retry behaviour
+
+    def __init__(self, status_force: tuple = DEFAULT_RETRY_CODES, method_whitelist: tuple = DEFAULT_RETRY_METHODS,
+                 max_retries: int = DEFAULT_MAX_RETRIES, backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+                 pool_connections: int = DEFAULT_POOL_CONNECTIONS, pool_maxsize: int = DEFAULT_MAX_POOL_SIZE):
+        super().__init__()
+
+        # Indicate our preference for JSON
+        self.headers.update({"Accept": "application/json",
+                             'User-Agent': f'pyairtable client {pyairtable_version}'})
+
+        retry_strategy = Retry(
+            total=max_retries,
+            backoff_factor=backoff_factor,
+            status_forcelist=list(status_force),
+            method_whitelist=list(method_whitelist),
+            raise_on_status=False,  # type: ignore
+        )
+
+        adapter = HTTPAdapter(
+            pool_connections=pool_connections,
+            pool_maxsize=pool_maxsize,
+            max_retries=retry_strategy
+        )
+
+        super(AutoRetrySession, self).mount('https://', adapter)
+        super(AutoRetrySession, self).mount('http://', adapter)

--- a/tests/test_api_retrying.py
+++ b/tests/test_api_retrying.py
@@ -1,0 +1,116 @@
+"""
+For these tests Mocker cannot be used because Retry is operating on a lower level
+"""
+import pytest
+from unittest import mock
+
+import io
+import json
+from http.client import HTTPMessage, HTTPResponse
+import requests
+
+from pyairtable.api.retrying import retry_strategy
+from pyairtable.api.table import Table
+
+
+@pytest.fixture
+def table_with_retry_strategy(constants):
+    def _table_with_retry(retry_strategy):
+        return Table(
+            constants["API_KEY"],
+            constants["BASE_ID"],
+            constants["TABLE_NAME"],
+            timeout=(0.1, 0.1),
+            retry_strategy=retry_strategy,
+        )
+
+    return _table_with_retry
+
+
+@mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
+def test_retry_exceed(m, table_with_retry_strategy):
+
+    strategy = retry_strategy(total=2, status_forcelist=[429])
+    table = table_with_retry_strategy(strategy)
+
+    m.return_value.getresponse.side_effect = [
+        make_http_response_error(429),
+        make_http_response_error(429),
+        make_http_response_error(429),
+    ]
+
+    with pytest.raises(requests.exceptions.RetryError):
+        table.get("record")
+
+    assert len(m.return_value.request.mock_calls) == 3
+
+
+@mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
+def test_retry_status_not_allowed(m, table_with_retry_strategy, mock_response_single):
+
+    strategy = retry_strategy(total=2, status_forcelist=[429, 500])
+    table = table_with_retry_strategy(strategy)
+
+    response = make_response(mock_response_single, 200)
+
+    m.return_value.getresponse.side_effect = [
+        make_http_response_error(401),
+        response,
+    ]
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        response = table.get("record")
+
+    assert len(m.return_value.request.mock_calls) == 1
+
+
+@mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
+def test_retry_eventual_success(m, table_with_retry_strategy, mock_response_single):
+
+    strategy = retry_strategy(total=2, status_forcelist=[429, 500])
+    table = table_with_retry_strategy(strategy)
+
+    response = make_response(mock_response_single, 200)
+
+    m.return_value.getresponse.side_effect = [
+        make_http_response_error(429),
+        make_http_response_error(500),
+        response,
+    ]
+
+    response = table.get("record")
+    assert response == mock_response_single
+    assert len(m.return_value.request.mock_calls) == 3
+
+
+# Test Helpers
+
+
+def make_response(body: dict, status=200) -> HTTPResponse:
+    headers = HTTPMessage()
+    body_bytes = json.dumps(body).encode()
+
+    sock = FakeSocketHelper(body_bytes)
+    response = HTTPResponse(sock)  # type: ignore
+    response.chunked = False  # type: ignore
+    response.length = len(body_bytes)  # type: ignore
+    response.status = status
+    response.msg = headers
+    return response
+
+
+def make_http_response_error(status: int):
+    return mock.Mock(status=status, msg=HTTPMessage())
+
+
+class FakeSocketHelper:
+    def __init__(self, text):
+        if isinstance(text, str):
+            text = text.encode("ascii")
+        self.text = text
+        self.data = b""
+        self.file_closed = False
+
+    def makefile(self, mode, bufsize=None):
+        self.file = io.BytesIO(self.text)
+        return self.file


### PR DESCRIPTION
Based on #165 and #143 

Here is the proposed api:

```python
from pyairtable import Api,retry_strategy

# current
api = Api("key", "base", "table")

# w/ default retry
api = Api("key", "base", "table", retry_strategy=retry_strategy())

# w/ customized retry
api = Api("key", "base", "table", retry_strategy=retry_strategy(total=5)
api = Api("key", "base", "table", retry_strategy=retry_strategy(status_forcelist=[429])
```

* left `retry_strategy` args as is to avoid duplicating their docs and mapping args names. Docs just references `Retry` lib docs.
* `retry_strategy` simply generates a default retry strategy but allows easy modification

PR Includes tests + docs
Opening up for feedback!
@@borland667