### PR TITLE
New LOWER function added to formulas plus updated test

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -348,5 +348,5 @@ can use if you want to compose formulas:
 .. autofunction:: pyairtable.formulas.FIND
 .. autofunction:: pyairtable.formulas.IF
 .. autofunction:: pyairtable.formulas.STR_VALUE
-
+.. autofunction:: pyairtable.formulas.LOWER
 

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -184,3 +184,10 @@ def OR(*args) -> str:
     'OR(1, 2, 3)'
     """
     return "OR({})".format(",".join(args))
+
+def LOWER(value) -> str:
+    """
+    Creates the LOWER function, making a string lowercase.
+    Can you be used on a string or a full airtable column and will lower all the strings in that column.
+    """
+    return "LOWER({})".format(value)

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -189,5 +189,8 @@ def LOWER(value) -> str:
     """
     Creates the LOWER function, making a string lowercase.
     Can you be used on a string or a full airtable column and will lower all the strings in that column.
+    
+    >>> LOWER("TestValue")
+    "LOWER(TestValue)"
     """
     return "LOWER({})".format(value)

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -188,7 +188,7 @@ def OR(*args) -> str:
 def LOWER(value) -> str:
     """
     Creates the LOWER function, making a string lowercase.
-    Can you be used on a string or a full airtable column and will lower all the strings in that column.
+    Can be used on a string or a field name and will lower all the strings in the field.
     
     >>> LOWER("TestValue")
     "LOWER(TestValue)"

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -9,6 +9,7 @@ from pyairtable.formulas import (
     match,
     escape_quotes,
     FIND,
+    LOWER
 )
 
 
@@ -77,3 +78,6 @@ def test_match(dict, exprected_formula):
 def test_escape_quotes(text, escaped):
     rv = escape_quotes(text)
     assert rv == escaped
+
+def test_lower():
+    assert LOWER('TestValue') == "LOWER(TestValue)"

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -80,4 +80,4 @@ def test_escape_quotes(text, escaped):
     assert rv == escaped
 
 def test_lower():
-    assert LOWER('TestValue') == "LOWER(TestValue)"
+    assert LOWER("TestValue") == "LOWER(TestValue)"


### PR DESCRIPTION
As mentioned in my original issue here: https://github.com/gtalarico/pyairtable/issues/154 I wanted to add support for Airtable's LOWER function for use with formulas. I needed this in my own Flask application to enable case insensitive search of Airtable fields.

I have also tested this change in my Flask application with this minimal proof of concept code and all is working as expected:

```
...
query = request.args.get('search')
formula = FIND(LOWER(STR_VALUE(query)), LOWER(FIELD('Title')))
search_records = TABLE.all(formula=formula)
...
```

Let me know if you need any further information about this PR and I will get back to you as soon as I can. Thanks!