### PR TITLE
Reduce unnecessary sleep after API calls

### DIFF
--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -107,11 +107,11 @@ class ApiAbstract(metaclass=abc.ABCMeta):
                 params.update({"offset": offset})
             data = self._request("get", table_url, params=params)
             records = data.get("records", [])
-            time.sleep(self.API_LIMIT)
             yield records
             offset = data.get("offset")
             if not offset:
                 break
+            time.sleep(self.API_LIMIT)
 
     def _first(self, base_id: str, table_name: str, **options) -> Optional[dict]:
         for records in self._iterate(


### PR DESCRIPTION
Right now `ApiAbstract._iterate` calls `time.sleep` before yielding the results of its first API call. This slows down operations that only retrieve a single record (or a single page of results) and it seems unnecessary unless we're about to request a second page of results.

This moves the `time.sleep` call to the end of the loop, so it only happens if we need to fetch a second page.
