### PR TITLE
🚧 Add upsert functionality to batch_update

### DIFF
--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from .abstract import ApiAbstract, TimeoutTuple
+from .abstract import ApiAbstract, TimeoutTuple, UpsertOptions
 
 from .. import compat
 
@@ -269,6 +269,7 @@ class Api(ApiAbstract):
         records: List[dict],
         replace=False,
         typecast=False,
+        perform_upsert: Optional[UpsertOptions] = None,
     ):
         """
         Updates a records by their record id's in batch.
@@ -284,12 +285,21 @@ class Api(ApiAbstract):
                 bet set to null. If False, only provided fields are updated.
                 Default is ``False``.
             typecast: |kwarg_typecast|
+            perform_upsert: (``dict``, optional): Dictionary with key ``performUpsertOn`` with value
+                equal to a list of field IDs or names
 
         Returns:
             records(``list``): list of updated records
+
+        # TODO document different return type when perform_upsert is at play
         """
         return super()._batch_update(
-            base_id, table_name, records, replace=replace, typecast=typecast
+            base_id,
+            table_name,
+            records,
+            replace=replace,
+            typecast=typecast,
+            perform_upsert=perform_upsert,
         )
 
     def delete(self, base_id: str, table_name: str, record_id: str):

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from .abstract import ApiAbstract, TimeoutTuple
+from .abstract import ApiAbstract, TimeoutTuple, UpsertOptions
 from .. import compat
 
 
@@ -119,14 +119,24 @@ class Base(ApiAbstract):
         )
 
     def batch_update(
-        self, table_name: str, records: List[dict], replace=False, typecast=False
+        self,
+        table_name: str,
+        records: List[dict],
+        replace=False,
+        typecast=False,
+        perform_upsert: Optional[UpsertOptions] = None,
     ):
         """
         Same as :meth:`Api.batch_update <pyairtable.api.Api.batch_update>`
         but without ``base_id`` arg.
         """
         return super()._batch_update(
-            self.base_id, table_name, records, replace=replace, typecast=typecast
+            self.base_id,
+            table_name,
+            records,
+            replace=replace,
+            typecast=typecast,
+            perform_upsert=perform_upsert,
         )
 
     def delete(self, table_name: str, record_id: str):

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from .abstract import ApiAbstract, TimeoutTuple
+from .abstract import ApiAbstract, TimeoutTuple, UpsertOptions
 from .. import compat
 
 
@@ -95,7 +95,9 @@ class Table(ApiAbstract):
         Same as :meth:`Api.create <pyairtable.api.Api.create>`
         but without ``base_id`` and ``table_name`` arg.
         """
-        return super()._create(self.base_id, self.table_name, fields, typecast=typecast, **options)
+        return super()._create(
+            self.base_id, self.table_name, fields, typecast=typecast, **options
+        )
 
     def batch_create(self, records, typecast=False, **options):
         """
@@ -107,12 +109,7 @@ class Table(ApiAbstract):
         )
 
     def update(
-        self,
-        record_id: str,
-        fields: dict,
-        replace=False,
-        typecast=False,
-        **options
+        self, record_id: str, fields: dict, replace=False, typecast=False, **options
     ):
         """
         Same as :meth:`Api.update <pyairtable.api.Api.update>`
@@ -125,16 +122,29 @@ class Table(ApiAbstract):
             fields,
             replace=replace,
             typecast=typecast,
-            **options
+            **options,
         )
 
-    def batch_update(self, records: List[dict], replace=False, typecast=False, **options):
+    def batch_update(
+        self,
+        records: List[dict],
+        replace=False,
+        typecast=False,
+        perform_upsert: Optional[UpsertOptions] = None,
+        **options,
+    ):
         """
         Same as :meth:`Api.batch_update <pyairtable.api.Api.batch_update>`
         but without ``base_id`` and ``table_name`` arg.
         """
         return super()._batch_update(
-            self.base_id, self.table_name, records, replace=replace, typecast=typecast, **options
+            self.base_id,
+            self.table_name,
+            records,
+            replace=replace,
+            typecast=typecast,
+            perform_upsert=perform_upsert,
+            **options,
         )
 
     def delete(self, record_id: str):


### PR DESCRIPTION
## Summary
Addresses 
> 'Upsert' option in the batch_update method

from  #208. Relevant Airtable API docs live at https://airtable.com/developers/web/api/update-multiple-records

## Example usage
Assumes a record already exists with `Unique ID` `aaa`
```python
inputRecords = [
    {'fields': {'Unique ID': 'aaa', 'First Name': 'A'}},
    {'fields': {'Unique ID': 'bbb', 'First Name': 'B'}}
]

upsert_result = table.batch_update(inputRecords, perform_upsert=dict(fieldsToMergeOn=['Unique ID']))
pprint(dict(upsert_result=upsert_result))
```
returns
```
{'upsert_result': {'created_record_ids': ['recIln1E0eUxq0S0i'],
                   'records': [{'createdTime': '2022-10-24T19:49:10.000Z',
                                'fields': {'First Name': 'aaa',
                                           'Name': 'aaa  (ID:aaa)',
                                           'Unique ID': 'aaa'},
                                'id': 'reckUKamPArJEfbwe'},
                               {'createdTime': '2022-12-04T22:12:25.000Z',
                                'fields': {'First Name': 'bbb',
                                           'Name': 'bbb  (ID:bbb)',
                                           'Unique ID': 'bbb'},
                                'id': 'recIln1E0eUxq0S0i'}],
                   'updated_record_ids': ['reckUKamPArJEfbwe']}}
```