### PR TITLE
Changes "API Key" to "API Key or Access Token"

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -21,13 +21,13 @@ For example, the three ``all()`` calls below would return the same result:
 
   from pyairtable import Api, Base, Table
 
-  api = Api('apikey/accesstoken')
+  api = Api('auth_token')
   api.all('base_id', 'table_name')
 
-  base = Base('apikey/accesstoken', 'base_id')
+  base = Base('auth_token', 'base_id')
   base.all('table_name')
 
-  table = Table('apikey/accesstoken', 'base_id', 'table_name')
+  table = Table('auth_token', 'base_id', 'table_name')
   table.all()
 
 Interface
@@ -215,7 +215,7 @@ specified on each request.
 
 .. code-block:: python
 
-  >>> base = Base('apikey/accesstoken', 'base_id')
+  >>> base = Base('auth_token', 'base_id')
   >>> base.all('Contacts)
   [{id:'rec123asa23', fields': {'Last Name': 'Alfred', "Age": 84}, ... ]
 
@@ -265,7 +265,7 @@ Default Retry Strategy
 .. code-block:: python
 
   from pyairtable import Api, retry_strategy
-  api = Api('apikey/accesstoken', retry_strategy=retry_strategy())
+  api = Api('auth_token', retry_strategy=retry_strategy())
 
 
 Adjusted Default Strategy
@@ -273,7 +273,7 @@ Adjusted Default Strategy
 .. code-block:: python
 
   from pyairtable import Api, retry_strategy
-  api = Api('apikey/accesstoken', retry_strategy=retry_strategy(total=3))
+  api = Api('auth_token', retry_strategy=retry_strategy(total=3))
 
 Custom Retry
 
@@ -283,7 +283,7 @@ Custom Retry
   from urllib3.util import Retry
 
   myRetry = Retry(**kwargs)
-  api = Api('apikey/accesstoken', retry_strategy=myRetry)
+  api = Api('auth_token', retry_strategy=myRetry)
 
 
 .. autofunction:: pyairtable.api.retrying.retry_strategy
@@ -358,7 +358,7 @@ against a python dictionary:
   >>> from pyairtable import Table
   >>> from pyairtable.formulas import match
   >>>
-  >>> table = Table("apikey/accesstoken", "base_id", "Contact")
+  >>> table = Table("auth_token", "base_id", "Contact")
   >>> formula = match({"First Name": "John", "Age": 21})
   >>> table.first(formula=formula)
   {"id": "recUwKa6lbNSMsetH", "fields": {"First Name": "John", "Age": 21}}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -21,13 +21,13 @@ For example, the three ``all()`` calls below would return the same result:
 
   from pyairtable import Api, Base, Table
 
-  api = Api('apikey')
+  api = Api('apikey/accesstoken')
   api.all('base_id', 'table_name')
 
-  base = Base('apikey', 'base_id')
+  base = Base('apikey/accesstoken', 'base_id')
   base.all('table_name')
 
-  table = Table('apikey', 'base_id', 'table_name')
+  table = Table('apikey/accesstoken', 'base_id', 'table_name')
   table.all()
 
 Interface
@@ -215,7 +215,7 @@ specified on each request.
 
 .. code-block:: python
 
-  >>> base = Base('apikey', 'base_id')
+  >>> base = Base('apikey/accesstoken', 'base_id')
   >>> base.all('Contacts)
   [{id:'rec123asa23', fields': {'Last Name': 'Alfred', "Age": 84}, ... ]
 
@@ -265,7 +265,7 @@ Default Retry Strategy
 .. code-block:: python
 
   from pyairtable import Api, retry_strategy
-  api = Api('apikey', retry_strategy=retry_strategy())
+  api = Api('apikey/accesstoken', retry_strategy=retry_strategy())
 
 
 Adjusted Default Strategy
@@ -273,7 +273,7 @@ Adjusted Default Strategy
 .. code-block:: python
 
   from pyairtable import Api, retry_strategy
-  api = Api('apikey', retry_strategy=retry_strategy(total=3))
+  api = Api('apikey/accesstoken', retry_strategy=retry_strategy(total=3))
 
 Custom Retry
 
@@ -283,7 +283,7 @@ Custom Retry
   from urllib3.util import Retry
 
   myRetry = Retry(**kwargs)
-  api = Api('apikey', retry_strategy=myRetry)
+  api = Api('apikey/accesstoken', retry_strategy=myRetry)
 
 
 .. autofunction:: pyairtable.api.retrying.retry_strategy
@@ -358,7 +358,7 @@ against a python dictionary:
   >>> from pyairtable import Table
   >>> from pyairtable.formulas import match
   >>>
-  >>> table = Table("apikey", "base_id", "Contact")
+  >>> table = Table("apikey/accesstoken", "base_id", "Contact")
   >>> formula = match({"First Name": "John", "Age": 21})
   >>> table.first(formula=formula)
   {"id": "recUwKa6lbNSMsetH", "fields": {"First Name": "John", "Age": 21}}

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -19,10 +19,10 @@ Installation
 _______________________________________________
 
 
-Api Key
+Api Key / Access Token
 *******
 
-Your Airtable API key should be securely stored. 
+Your Airtable API key or access token should be securely stored. 
 A common way to do this, is to `store it as an environment variable <https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html>`_, 
 and load it using ``os.environ``:
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -19,10 +19,11 @@ Installation
 _______________________________________________
 
 
-Api Key / Access Token
+Authorization Token
 *******
 
-Your Airtable API key or access token should be securely stored. 
+Airtable accepts two types of authentication tokens: Api Keys, and Personal Access tokens.
+Your auth token should be securely stored.
 A common way to do this, is to `store it as an environment variable <https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html>`_, 
 and load it using ``os.environ``:
 
@@ -31,7 +32,11 @@ and load it using ``os.environ``:
     import os
     api_key = os.environ["AIRTABLE_API_KEY"]
 
-
+.. Note: 
+     Personal access tokens are a new, more secure way to grant API access to your Airtable data.
+     They can create multiple tokens, grant them access to specific bases, and manage them individually.
+ 
+     Api keys are scheduled to be deprecated in upcoming versions.
 
 Quickstart
 **********

--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -1,6 +1,6 @@
 
 
-.. |arg_api_key| replace:: An Airtable API Key.
+.. |arg_api_key| replace:: An Airtable API Key or Access Token.
 
 .. |arg_base_id| replace:: An Airtable base id.
 

--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -1,6 +1,6 @@
 
 
-.. |arg_api_key| replace:: An Airtable API Key or Access Token.
+.. |arg_api_key| replace:: An Airtable API Key or An Airtable Authorization Token.
 
 .. |arg_base_id| replace:: An Airtable base id.
 

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -8,14 +8,14 @@ class Api(ApiAbstract):
     """
     Represents an Airtable Api.
 
-    The Api Key or Access Token is provided on init and ``base_id`` and ``table_id``
+    The Api Key or Authorization Token is provided on init and ``base_id`` and ``table_id``
     can be provided on each method call.
 
     If you are only operating on one Table, or one Base, consider using
     :class:`Base` or :class:`Table`.
 
     Usage:
-        >>> api = Api('apikey/accesstoken')
+        >>> api = Api('auth_token')
         >>> api.all('base_id', 'table_name')
     """
 

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -8,14 +8,14 @@ class Api(ApiAbstract):
     """
     Represents an Airtable Api.
 
-    The Api Key is provided on init and ``base_id`` and ``table_id``
+    The Api Key or Access Token is provided on init and ``base_id`` and ``table_id``
     can be provided on each method call.
 
     If you are only operating on one Table, or one Base, consider using
     :class:`Base` or :class:`Table`.
 
     Usage:
-        >>> api = Api('apikey')
+        >>> api = Api('apikey/accesstoken')
         >>> api.all('base_id', 'table_name')
     """
 

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -10,7 +10,7 @@ class Base(ApiAbstract):
     except ``base_id`` is provided on init instead of provided on each method call.
 
     Usage:
-        >>> base = Base('apikey/accesstoken', 'base_id')
+        >>> base = Base('auth_token', 'base_id')
         >>> base.all()
     """
 

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -10,7 +10,7 @@ class Base(ApiAbstract):
     except ``base_id`` is provided on init instead of provided on each method call.
 
     Usage:
-        >>> base = Base('apikey', 'base_id')
+        >>> base = Base('apikey/accesstoken', 'base_id')
         >>> base.all()
     """
 

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -11,7 +11,7 @@ class Table(ApiAbstract):
     on each method call.
 
     Usage:
-        >>> table = Table('apikey', 'base_id', 'table_name')
+        >>> table = Table('apikey/accesstoken', 'base_id', 'table_name')
         >>> table.all()
     """
 


### PR DESCRIPTION
Due to the slow deprecation of API keys, it was mentioned in issue #211 that the docs should reflect access token usage.
If different verbiage is desired, please let me know!