### PR TITLE
Correct pyairtable.formulas.match match_any documentation

### DIFF
--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -33,7 +33,7 @@ def match(dict_values, *, match_any=False):
         >>> match({"First Name": "John", "Age": 21})
         "AND({First Name}='John',{Age}=21)"
         >>> match({"First Name": "John", "Age": 21}, match_any=True)
-        "AND({First Name}='John',{Age}=21)"
+        "OR({First Name}='John',{Age}=21)"
         >>> match({"First Name": "John"})
         "{First Name}='John'"
         >>> match({"Registered": True})


### PR DESCRIPTION
The match documentation is incorrect for how the `match_any` argument changes the computed string expression.

In the pyairtable.formulas.match documentation:
```
    Usage:
        >>> match({"First Name": "John", "Age": 21})
        "AND({First Name}='John',{Age}=21)"
        >>> match({"First Name": "John", "Age": 21}, match_any=True)
        "AND({First Name}='John',{Age}=21)"  <<< Incorrect, should be OR
```

In my python REPL:
```
>>> match({"First Name": "John", "Age": 21})
"AND({First Name}='John',{Age}=21)"
>>> match({"First Name": "John", "Age": 21}, match_any=True)
"OR({First Name}='John',{Age}=21)"
```