### PR TITLE
Update license metadata in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,13 +11,12 @@ long_description_content_type = text/markdown
 author = Gui Talarico
 url = https://github.com/gtalarico/pyairtable
 authoremail = gtalarico.dev@gmail.com
-license = The MIT License (MIT)
+license = MIT
 copyright = Copyright 2021 Gui Talarico
 keywords = airtable, api, client, pyairtable
 classifiers =
     Intended Audience :: Developers
-    Programming Language :: Python
-    Topic :: Software Development
+    License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -25,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
+    Topic :: Software Development
 
 [options]
 packages = find:


### PR DESCRIPTION
Some automated scanning tools rely on consistent identifiers to determine what license applies to a library. "MIT" is the most common spelling of the MIT License used [(see packaging.python.org)](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#license) and the OSI classifier is unambiguous. This branch adds both of those to setup.cfg.