### PR TITLE
Add get_identity to metadata

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -5,7 +5,7 @@ Metadata Api
 
 .. versionadded:: 1.0.0
 
-The metadata api gives you the ability to list all of your bases, tables, fields, and views.
+The metadata api gives you the ability to list all of your bases, tables, fields, and views, and retrieve the scopes and user ID associated with your token.
 
 .. warning::
     This api is experimental

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -238,6 +238,42 @@ class ApiAbstract(metaclass=abc.ABCMeta):
             time.sleep(self.API_LIMIT)
         return deleted_records
 
+    def _get_webhook_url(self, base_id: str, webhook_id = "", resource = ""):
+        return posixpath.join(self.API_URL, "bases", base_id , 'webhooks', webhook_id, resource)
 
+    def _list_webhooks(self, base_id: str):
+        webhook_url = self._get_webhook_url(base_id)
+        return self._request('get', webhook_url).get('webhooks')
+    
+    def _get_webhook(self, base_id: str, webhook_id: str):
+        webhooks = self._list_webhooks(base_id)
+        for webhook in webhooks:
+            if webhook.get('id') == webhook_id:
+                return webhook
+    
+    def _create_webhook(self, base_id: str, specification: dict, notificationUrl = None):
+        webhook_body = {
+            "specification": specification,
+            "notificationUrl": notificationUrl
+        }
+        webhook_url = self._get_webhook_url(base_id)
+        return self._request('post', webhook_url, json_data=webhook_body)
+        
+    def _delete_webhook(self, base_id: str, webhook_id: str):
+        webhook_url = self._get_webhook_url(base_id, webhook_id=webhook_id)
+        return self._request('delete', webhook_url)
+    
+    def _toggle_notifications_webhook(self, base_id: str, webhook_id: str, enabled: bool):
+        webhook_url = self._get_webhook_url(base_id, webhook_id, 'enableNotifications')
+        return self._request('post', webhook_url, json_data={'enable':enabled})
+    
+    def _refresh_webhook(self, base_id: str, webhook_id: str):
+        webhook_url = self._get_webhook_url(base_id, webhook_id, 'refresh')
+        return self._request('post', webhook_url)
+
+    def _payloads_webhook(self, base_id: str, webhook_id: str, cursor=1, limit=50):
+        webhook_url = self._get_webhook_url(base_id, webhook_id, 'payloads')
+        return self._request('get', webhook_url, params={'cursor':str(cursor), 'limit':str(limit)})
+    
 from pyairtable.api.table import Table  # noqa
 from pyairtable.api.base import Base  # noqa

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -146,5 +146,25 @@ class Base(ApiAbstract):
     def __repr__(self) -> str:
         return "<Airtable Base id={}>".format(self.base_id)
 
+    def list_webhooks(self):
+        return self._list_webhooks(self.base_id)
+    
+    def get_webhook(self, webhook_id: str):
+        return self._get_webhook(self.base_id, webhook_id)
 
+    def create_webhook(self, specification: dict, notificationUrl = None):
+        return self._create_webhook(self.base_id, specification, notificationUrl)
+    
+    def delete_webhook(self, webhook_id: str):
+        return self._delete_webhook(self.base_id, webhook_id)
+    
+    def toggle_notifications(self, webhook_id: str, enabled: bool):
+        return self._toggle_notifications_webhook(self.base_id, webhook_id, enabled)
+    
+    def refresh_webhook(self, webhook_id: str):
+        return self._refresh_webhook(self.base_id, webhook_id)
+    
+    def get_payloads(self, webhook_id: str, cursor=1, limit=50):
+        return self._payloads_webhook(self.base_id, webhook_id, cursor, limit)
+    
 from .table import Table  # noqa

--- a/pyairtable/metadata.py
+++ b/pyairtable/metadata.py
@@ -116,3 +116,39 @@ def get_table_schema(table: Table) -> Optional[dict]:
         if table.table_name == table_record["name"]:
             return table_record
     return None
+
+
+def get_identity(api: Api) -> dict:
+    """
+    Returns the user ID and scopes (for OAuth access tokens) associated with the token used
+
+    Args:
+        api: :class:`Api` instance
+
+    Usage:
+        >>> get_identity(api)
+        {
+            "id": "usrpqeuTLdw2G5paa",
+            "scopes": [
+                "data.records:read",
+                "data.records:write",
+                "schema.bases:read",
+                "schema.bases:write",
+                "webhook:manage",
+                "data.recordComments:read",
+                "data.recordComments:write",
+                "enterprise.groups:read",
+                "workspacesAndBases:write",
+                "workspacesAndBases.shares:manage",
+                "enterprise.scim.usersAndGroups:manage",
+                "enterprise.auditLogs:read",
+                "enterprise.account:read",
+                "enterprise.user:read",
+                "enterprise.user:write",
+                "workspacesAndBases:manage"
+            ]
+        }
+    """
+    whoami_url = posixpath.join(api.API_URL, 'meta', 'whoami')
+    return api._request('get', whoami_url)
+


### PR DESCRIPTION
Addresses #223 , and the need to get scopes for OAuth. Returns user ID and associated scopes.
If the token being used is not an OAuth token, then scopes will not be returned.