### PR TITLE
Update get_api_bases to paginate with offset cursor

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -1,21 +1,16 @@
 .. include:: substitutions.rst
 
-Metadata Api
-==============
+Metadata
+========
 
 .. versionadded:: 1.0.0
 
-The metadata api gives you the ability to list all of your bases, tables, fields, and views.
+These functions give you the ability to list all bases your access token can read as well as retrieve the schema (tables, fields, and views) for a given base.
 
 .. warning::
-    This api is experimental
-
-.. warning::
-    If you want to develop an integration using the Metadata API,
-    you must register `here <https://airtable.com/api/meta>`_ for access
-    and to receive a client secret.
-    Enterprise Airtable accounts do not require a
-    separate Metadata API client secret.
+    The Metadata API previously required specific registration with Airtable.
+    As of `November 2022 <https://airtable.com/developers/web/api/changelog#anchor-2022-11-15>`_, any developer can use these methods when authenticating
+    with a Personal Access or OAuth token (with the correct `scopes <https://airtable.com/developers/web/api/scopes>`_).
 
 
 .. automodule:: pyairtable.metadata

--- a/pyairtable/metadata.py
+++ b/pyairtable/metadata.py
@@ -6,7 +6,7 @@ from pyairtable.api import Api, Base, Table
 def get_api_bases(api: Union[Api, Base]) -> dict:
     """
     Return list of Bases from an Api or Base instance.
-    For More Details `Metadata Api Documentation <https://airtable.com/api/meta>`_
+    For More Details `List bases endpoint <https://airtable.com/developers/web/api/list-bases>`_
 
     Args:
         api: :class:`Api` or :class:`Base` instance
@@ -35,7 +35,7 @@ def get_api_bases(api: Union[Api, Base]) -> dict:
 def get_base_schema(base: Union[Base, Table]) -> dict:
     """
     Returns Schema of a Base
-    For More Details `Metadata Api Documentation <https://airtable.com/api/meta>`_
+    For More Details `Get get base schema endpoint <https://airtable.com/developers/web/api/get-base-schema>`_
 
     Args:
         base: :class:`Base` or :class:`Table` instance

--- a/tests/integration/test_integration_metadata.py
+++ b/tests/integration/test_integration_metadata.py
@@ -7,6 +7,7 @@ from pyairtable.metadata import get_base_schema, get_api_bases, get_table_schema
 def test_get_api_bases(base: Base, base_name: str):
     rv = get_api_bases(base)
     assert base_name in [b["name"] for b in rv["bases"]]
+    assert "offset" not in rv.keys()
 
 
 @pytest.mark.skip("metadata api returning 404 for base schema")


### PR DESCRIPTION
Currently, if the token used to call the [list bases endpoint](https://airtable.com/developers/web/api/list-bases) has access to more than 1,000 bases, pyairtable will return only the first page of 1,000 bases.

This PR fixes that.

Issue #230