### PR TITLE
Add meta methods for creating new tables and bases

### DIFF
--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -67,6 +67,31 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         table_url = self.get_table_url(base_id, table_name)
         return posixpath.join(table_url, record_id)
 
+    def _get_meta_bases_url(self, base_id=None):
+        meta_bases_url = posixpath.join(self.API_URL, "meta", "bases")
+        if base_id is not None:
+            meta_bases_url = posixpath.join(meta_bases_url, base_id, "tables")
+        return meta_bases_url
+
+    def _create_table(self, base_id: str, table_name: str, fields:list, description=None):
+        meta_bases_url = self._get_meta_bases_url(base_id)
+        params = {
+            "fields": fields,
+            "name": table_name
+        }
+        if description is not None:
+            params['description'] = description
+        return self._request("post", meta_bases_url, json_data=params)
+    
+    def _create_base(self, workspace_id: str, base_name:str, tables:list):
+        meta_bases_url = self._get_meta_bases_url() 
+        params = {
+            "tables": tables,
+            "name": base_name,
+            "workspaceId": workspace_id
+        }
+        return self._request("post", meta_bases_url, json_data=params)
+
     def _options_to_params(self, **options):
         """
         Process params names or values as needed using filters

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -52,6 +52,27 @@ class Api(ApiAbstract):
         """
         return Base(self.api_key, base_id, timeout=self.timeout)
 
+    def create_table(
+            self, base_id: str, table_name: str, fields:list, description=None
+    )  -> "Table":
+        """
+        Creates and returns a new :class:`Table` instance using all shared
+        attributes from :class:`Api` and the ID of the new table
+        """
+        create_table_response = super()._create_table(base_id, table_name, fields, description)
+        return self.get_table(base_id, table_name)
+    
+    def create_base(
+            self, workspace_id: str, base_name:str, tables:list
+    )  -> "Base":
+        """
+        Creates and returns a new :class:`Base` instance using all shared
+        attributes from :class:`Api` and the ID of the new Base
+        """
+        create_base_response = super()._create_base(workspace_id, base_name, tables)
+        base_id = create_base_response.get('id')
+        return self.get_base(base_id)    
+
     def get_record_url(self, base_id: str, table_name: str, record_id: str):
         """
         Returns a url for the provided record

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -44,6 +44,16 @@ class Base(ApiAbstract):
         """
         return Table(self.api_key, self.base_id, table_name, timeout=self.timeout)
 
+    def create_table(
+            self, table_name: str, fields:list, description=None
+    )  -> "Table":
+        """
+        Creates and returns a new :class:`Table` instance using all shared
+        attributes from :class:`Base` and the ID of the new table
+        """
+        super()._create_table(self.base_id, table_name, fields, description)
+        return self.get_table(table_name)
+
     def get_record_url(self, table_name: str, record_id: str):
         """
         Same as :meth:`Api.get_record_url <pyairtable.api.Api.get_record_url>`


### PR DESCRIPTION
Adds meta functions for creating new bases and tables as referenced in #235. I think separating out into a new "meta" file is probably a good idea.
- **api.create_table()** (https://api.airtable.com/v0/meta/bases/{baseId}/tables): takes a base ID, table name, list of fields, and an optional description and returns a new Table object after creating. 
- **api.create_base()** (https://api.airtable.com/v0/meta/bases): takes a workspace ID, a base name, and a list of dictionary-represented tables and returns a new Base object after creating.