### PR TITLE
Add Various Comment Methods to Table class

### DIFF
--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -139,7 +139,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     def _delete_comment(self, base_id: str, table_name: str, record_id: str, comment_id: str):
         url = posixpath.join(self.API_URL, base_id, table_name, record_id, 'comments', comment_id)
         response = self._request('delete', url)
-        return response.get('deleted')
+        return response
 
     def _iterate(self, base_id: str, table_name: str, **options):
         offset = None

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -116,6 +116,10 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         params = self._options_to_params(**options)
         return self._request("get", record_url, params=params)
     
+    def _get_comments_url(self, base_id: str, table_name: str, record_id: str, comment_id: str):
+        url = posixpath.join(self.API_URL, base_id, table_name, record_id, 'comments', comment_id)
+        return url
+    
     def _get_comments(self, base_id: str, table_name: str, record_id: str, offset=None):
         url = posixpath.join(self.API_URL, base_id, table_name, record_id, 'comments')
         params = {} if offset == None else {"offset":offset}

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -115,6 +115,31 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         record_url = self._get_record_url(base_id, table_name, record_id)
         params = self._options_to_params(**options)
         return self._request("get", record_url, params=params)
+    
+    def _get_comments(self, base_id: str, table_name: str, record_id: str, offset=None):
+        url = posixpath.join(self.API_URL, base_id, table_name, record_id, 'comments')
+        params = {} if offset == None else {"offset":offset}
+        response = self._request("get", url, params = params)
+        return response
+    
+    def _create_comment(self, base_id: str, table_name: str, record_id: str, text: str):
+        url = posixpath.join(self.API_URL, base_id, table_name, record_id, 'comments')
+        response = self._request('post', url, json_data={
+            "text": text
+        })
+        return response
+    
+    def _update_comment(self, base_id: str, table_name: str, record_id: str, comment_id: str, text: str):
+        url = posixpath.join(self.API_URL, base_id, table_name, record_id, 'comments', comment_id)
+        response = self._request('patch', url, json_data={
+            "text": text
+        })
+        return response
+    
+    def _delete_comment(self, base_id: str, table_name: str, record_id: str, comment_id: str):
+        url = posixpath.join(self.API_URL, base_id, table_name, record_id, 'comments', comment_id)
+        response = self._request('delete', url)
+        return response.get('deleted')
 
     def _iterate(self, base_id: str, table_name: str, **options):
         offset = None

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -116,10 +116,6 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         params = self._options_to_params(**options)
         return self._request("get", record_url, params=params)
     
-    def _get_comments_url(self, base_id: str, table_name: str, record_id: str, comment_id: str):
-        url = posixpath.join(self.API_URL, base_id, table_name, record_id, 'comments', comment_id)
-        return url
-    
     def _get_comments(self, base_id: str, table_name: str, record_id: str, offset=None):
         url = posixpath.join(self.API_URL, base_id, table_name, record_id, 'comments')
         params = {} if offset == None else {"offset":offset}

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -161,6 +161,9 @@ class Table(ApiAbstract):
             offset = meta_response.get('offset')
         return comments
     
+    def get_comments_url(self, record_id: str, comment_id: str = ''):
+        return super()._get_comments_url(self.base_id, self.table_name, record_id, comment_id)
+    
     def update_comment(self, record_id: str, comment_id: str, text: str):
         return super()._update_comment(self.base_id, self.table_name, record_id, comment_id, text)
     

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -150,6 +150,25 @@ class Table(ApiAbstract):
         but without ``base_id`` and ``table_name`` arg.
         """
         return super()._batch_delete(self.base_id, self.table_name, record_ids)
+    
+    def get_comments(self, record_id: str):
+        meta_response = super()._get_comments(self.base_id, self.table_name, record_id)
+        comments = meta_response.get('comments')
+        offset = meta_response.get('offset')
+        while offset is not None:
+            meta_response = super()._get_comments(self.base_id, self.table_name, record_id, offset=offset)
+            comments += meta_response.get('comments')
+            offset = meta_response.get('offset')
+        return comments
+    
+    def update_comment(self, record_id: str, comment_id: str, text: str):
+        return super()._update_comment(self.base_id, self.table_name, record_id, comment_id, text)
+    
+    def create_comment(self, record_id: str, text: str):
+        return super()._create_comment(self.base_id, self.table_name, record_id, text)
+    
+    def delete_comment(self, record_id: str, comment_id: str):
+        return super()._delete_comment(self.base_id, self.table_name, record_id, comment_id)
 
     def __repr__(self) -> str:
         return "<Table base_id={} table_name={}>".format(self.base_id, self.table_name)

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -161,9 +161,6 @@ class Table(ApiAbstract):
             offset = meta_response.get('offset')
         return comments
     
-    def get_comments_url(self, record_id: str, comment_id: str = ''):
-        return super()._get_comments_url(self.base_id, self.table_name, record_id, comment_id)
-    
     def update_comment(self, record_id: str, comment_id: str, text: str):
         return super()._update_comment(self.base_id, self.table_name, record_id, comment_id, text)
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,54 @@ def base(constants):
 def table(constants):
     return Table(constants["API_KEY"], constants["BASE_ID"], constants["TABLE_NAME"])
 
+@pytest.fixture
+def mock_comments():
+    return [
+        {
+            "author": {
+                "email": "foo@bam.com", "id": "usrsOEchC9xuwRgKk", "name": "Foo Bam"
+            },
+            "createdTime": "2021-03-01T10:00:00.000Z",
+            "id": "comeNPu0X9K4Rxzid",
+            "lastUpdatedTime": None,
+            "mentioned": {
+                    "usrL2PNC5o3H4lBEi": {
+                        "displayName": "Foo Bar", 
+                        "email": "foo@bar.com", 
+                        "id": "usrL2PNC5o3H4lBEi", 
+                        "type": "user"
+                }
+            },
+            "text": "Hello world! Hello @[usrL2PNC5o3H4lBEi]"
+        },
+        {
+            "author": {
+                "email": "foo@bar.com", "id": "usrL2PNC5o3H4lBEi","name": "Foo Bar"
+            },
+            "createdTime": "2021-03-01T09:00:00.000Z",
+            "id": "comB5z37Mg9zaEPw6",
+            "lastUpdatedTime": None,
+            "text": "Hello, world!"
+        }
+    ]
+
+@pytest.fixture
+def mock_comment_update():
+    return {
+        "author": {
+            "email": "foo@bar.com",
+            "id": "usrL2PNC5o3H4lBEi",
+            "name": "Foo Bar"
+        },
+        "createdTime": "2021-03-01T09:00:00.000Z",
+        "id": "comB5z37Mg9zaEPw6",
+        "lastUpdatedTime": "2021-04-01T09:00:00.000Z",
+        "text": "Update, world!"
+        }
+
+@pytest.fixture
+def mock_comment_single(mock_comments):
+    return mock_comments[0]
 
 @pytest.fixture
 def mock_records():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def mock_comment_update():
         "id": "comB5z37Mg9zaEPw6",
         "lastUpdatedTime": "2021-04-01T09:00:00.000Z",
         "text": "Update, world!"
-        }
+    }
 
 @pytest.fixture
 def mock_comment_single(mock_comments):

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -243,6 +243,45 @@ def test_comment_mentioned(mock_comment_single):
     _usr_mentioned = list(mock_comment_single["mentioned"])[0]
     assert _usr_mentioned in mock_comment_single['text']
 
+def test_comment_update(table, mock_comment_update, mock_response_single):
+    comment_id_ = mock_comment_update["id"]
+    record_id_ = mock_response_single["id"]
+    text = mock_comment_update['text']
+
+    expected = {"author":{"email":"foo@bar.com","id":"usrL2PNC5o3H4lBEi","name":"Foo Bar"},"createdTime":"2021-03-01T09:00:00.000Z","id": comment_id_,"lastUpdatedTime":"2021-04-01T09:00:00.000Z","text":"Update, world!"}
+    with Mocker() as mock:
+        mock.patch(urljoin(table.table_url, record_id_, 'comments', comment_id_), status_code=200, json=expected)
+        resp = table.update_comment(record_id_, comment_id_, text)
+    assert resp == expected
+
+def test_comment_delete(table, mock_comment_update, mock_response_single):
+    comment_id_ = mock_comment_update["id"]
+    record_id_ = mock_response_single["id"]
+    expected = {"delete": True, "id": comment_id_}
+
+    with Mocker() as mock:
+        mock.delete(urljoin(table.table_url, record_id_, 'comments', comment_id_), status_code=200, json=expected)
+        resp = table.delete_comment(record_id_, comment_id_)
+    assert resp == expected
+
+def test_comment_create(table, mock_comment_single, mock_response_single):
+    record_id_ = mock_response_single["id"]
+    text = mock_comment_single['text']
+    expected = mock_comment_single
+
+    with Mocker() as mock:
+        mock.post(urljoin(table.table_url, record_id_, 'comments'), status_code=200, json=expected)
+        resp = table.create_comment(record_id_, text)
+    assert resp == expected
+
+def test_comment_list(table, mock_comments, mock_response_single):
+    record_id_ = mock_response_single["id"]
+    expected = {"comments":mock_comments}
+    with Mocker() as mock:
+        mock.get(urljoin(table.table_url, record_id_, 'comments'), status_code=200, json=expected)
+        resp = table.get_comments(record_id_)
+    assert resp == expected['comments']
+
 # Helpers
 
 

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -72,7 +72,6 @@ def test_get(table, mock_response_single):
         resp = table.get(_id)
     assert dict_equals(resp, mock_response_single)
 
-
 def test_first(table, mock_response_single):
     mock_response = {"records": [mock_response_single]}
     with Mocker() as mock:
@@ -240,6 +239,18 @@ def test_batch_delete(table, mock_records):
     expected = [{"delete": True, "id": i} for i in ids]
     assert resp == expected
 
+def test_comment_update(table, mock_comment_update, mock_response_single):
+    _comment_id = mock_comment_update["id"]
+    _record_id = mock_response_single["id"]
+    _text = mock_comment_update['text']
+    with Mocker() as mock:
+        mock.patch(table.get_comments_url(_record_id, _comment_id), status_code=200, json=mock_comment_update)
+        resp = table.update_comment(_record_id, _comment_id, _text)
+    assert dict_equals(resp, mock_comment_update)
+
+def test_comment_mentioned(mock_comment_single):
+    _usr_mentioned = list(mock_comment_single["mentioned"])[0]
+    assert _usr_mentioned in mock_comment_single['text']
 
 # Helpers
 

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -239,15 +239,6 @@ def test_batch_delete(table, mock_records):
     expected = [{"delete": True, "id": i} for i in ids]
     assert resp == expected
 
-def test_comment_update(table, mock_comment_update, mock_response_single):
-    _comment_id = mock_comment_update["id"]
-    _record_id = mock_response_single["id"]
-    _text = mock_comment_update['text']
-    with Mocker() as mock:
-        mock.patch(table.get_comments_url(_record_id, _comment_id), status_code=200, json=mock_comment_update)
-        resp = table.update_comment(_record_id, _comment_id, _text)
-    assert dict_equals(resp, mock_comment_update)
-
 def test_comment_mentioned(mock_comment_single):
     _usr_mentioned = list(mock_comment_single["mentioned"])[0]
     assert _usr_mentioned in mock_comment_single['text']


### PR DESCRIPTION
Adds methods for listing comments in a record, updating comments, creating new comments, and deleting existing comments.
Part of a number of Airtable API updates as referenced in #208 