### PR TITLE
Use pre-commit and tox, then apply black/flake8 to all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
     -   id: end-of-file-fixer
     -   id: fix-byte-order-marker
     -   id: trailing-whitespace
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: [--profile, black]
 -   repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: check-added-large-files
+    -   id: check-json
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: fix-byte-order-marker
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
-.PHONY: test docs setup
-
+.PHONY: usage
 usage:
-	cat Makefile
+	@grep '^[^#[:space:]].*:' Makefile | grep -v '^\.PHONY:' | cut -d: -f1
 
-setup:
-	git config core.hooksPath scripts/githooks
-	pip install -e .
-	pip install -r requirements-test.txt -r requirements-dev.txt
+.PHONY: setup hooks
+setup: hooks
 
+hooks:
+	@(git config --local core.hooksPath && git config --unset core.hooksPath) || true
+	tox -re pre-commit --notest
+	.tox/pre-commit/bin/pre-commit install
+	.tox/pre-commit/bin/pre-commit install-hooks
+
+.PHONY: release release-test bump
 release:
 	make clean
 	python -m build --sdist --wheel --outdir ./dist
@@ -21,6 +25,7 @@ release-test:
 bump:
 	@bash -c "./scripts/bump.sh"
 
+.PHONY: test test-e2e tox coverage lint format docs clean
 test:
 	pytest -v -m 'not integration'
 
@@ -40,11 +45,10 @@ lint:
 	black --diff .
 
 format:
-	black .
+	tox -e pre-commit
 
 docs:
 	tox -e docs
 
 clean:
 	@bash -c "./scripts/clean.sh"
-

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ usage:
 setup: hooks
 
 hooks:
-	@(git config --local core.hooksPath && git config --unset core.hooksPath) || true
 	tox -re pre-commit --notest
 	.tox/pre-commit/bin/pre-commit install
 	.tox/pre-commit/bin/pre-commit install-hooks

--- a/Makefile
+++ b/Makefile
@@ -26,22 +26,18 @@ bump:
 
 .PHONY: test test-e2e tox coverage lint format docs clean
 test:
-	pytest -v -m 'not integration'
-
-test-e2e:
-	pytest -v
-
-tox:
 	tox -e py
 
+test-e2e:
+	tox -e py -- ""
+
+tox: test
+
 coverage:
-	pytest --cov=pyairtable --cov-report=html
+	tox -e coverage
 	open htmlcov/index.html
 
-lint:
-	mypy pyairtable
-	flake8 .
-	black --diff .
+lint: format
 
 format:
 	tox -e pre-commit

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -392,4 +392,3 @@ can use if you want to compose formulas:
 .. autofunction:: pyairtable.formulas.IF
 .. autofunction:: pyairtable.formulas.STR_VALUE
 .. autofunction:: pyairtable.formulas.LOWER
-

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -44,5 +44,3 @@ Release Date: 2021-08-11
 ------
 
 Release Date: 2021-07-26
-
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-import sys
 import os
+import sys
+
 from pyairtable import __version__ as version
 
 extensions = [

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,3 @@ pyAirtable
    Airtable Api Docs <https://airtable.com/api>
    GitHub <https://github.com/gtalarico/pyairtable>
    PyPI <https://pypi.org/project/pyairtable/>
-
-
-

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -20,6 +20,3 @@ The metadata api gives you the ability to list all of your bases, tables, fields
 
 .. automodule:: pyairtable.metadata
     :members:
-
-
-

--- a/docs/source/orm.rst
+++ b/docs/source/orm.rst
@@ -23,6 +23,3 @@ Fields
 
 .. automodule:: pyairtable.orm.fields
     :members:
-
-
-

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -5,6 +5,3 @@ Utilities
 
 .. automodule:: pyairtable.utils
     :members:
-
-
-

--- a/e2e/write.py
+++ b/e2e/write.py
@@ -5,8 +5,9 @@ https://airtable.com/appaPqizdsNHDvlEm/tblfbOcVkVnnKxurq/viwhi8Qtuw2psSdGG?block
 
 import os
 from datetime import datetime
+
 from pyairtable import Table
-from pyairtable.utils import datetime_to_iso_str, date_to_iso_str
+from pyairtable.utils import date_to_iso_str, datetime_to_iso_str
 
 apikey = os.environ["AIRTABLE_KEY"]
 base_id = "appaPqizdsNHDvlEm"

--- a/pyairtable/api/__init__.py
+++ b/pyairtable/api/__init__.py
@@ -1,3 +1,3 @@
 from .api import Api  # noqa
-from .table import Table  # noqa
 from .base import Base  # noqa
+from .table import Table  # noqa

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -32,7 +32,6 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
     ):
-
         if not retry_strategy:
             self.session = Session()
         else:
@@ -146,21 +145,26 @@ class ApiAbstract(metaclass=abc.ABCMeta):
             all_records.extend(records)
         return all_records
 
-    def _create(self, base_id: str, table_name: str, fields: dict, typecast=False, **options):
-
+    def _create(
+        self, base_id: str, table_name: str, fields: dict, typecast=False, **options
+    ):
         table_url = self.get_table_url(base_id, table_name)
         params = self._options_to_params(**options)
         return self._request(
             "post",
             table_url,
             json_data={"fields": fields, "typecast": typecast},
-            params=params
+            params=params,
         )
 
     def _batch_create(
-        self, base_id: str, table_name: str, records: List[dict], typecast=False, **options
+        self,
+        base_id: str,
+        table_name: str,
+        records: List[dict],
+        typecast=False,
+        **options,
     ) -> List[dict]:
-
         table_url = self.get_table_url(base_id, table_name)
         inserted_records = []
         params = self._options_to_params(**options)
@@ -170,7 +174,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
                 "post",
                 table_url,
                 json_data={"records": new_records, "typecast": typecast},
-                params=params
+                params=params,
             )
             inserted_records += response["records"]
             time.sleep(self.API_LIMIT)
@@ -184,15 +188,17 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         fields: dict,
         replace=False,
         typecast=False,
-        **options
+        **options,
     ) -> List[dict]:
         record_url = self._get_record_url(base_id, table_name, record_id)
 
         method = "put" if replace else "patch"
         params = self._options_to_params(**options)
         return self._request(
-            method, record_url, json_data={"fields": fields, "typecast": typecast},
-            params=params
+            method,
+            record_url,
+            json_data={"fields": fields, "typecast": typecast},
+            params=params,
         )
 
     def _batch_update(
@@ -202,7 +208,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         records: List[dict],
         replace=False,
         typecast=False,
-        **options
+        **options,
     ):
         updated_records = []
         table_url = self.get_table_url(base_id, table_name)
@@ -214,7 +220,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
                 method,
                 table_url,
                 json_data={"records": chunk_records, "typecast": typecast},
-                params=params
+                params=params,
             )
             updated_records += response["records"]
             time.sleep(self.API_LIMIT)

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -1,17 +1,15 @@
 import abc
 import posixpath
-import requests
 import time
 from functools import lru_cache
 from typing import List, Optional, Tuple
-
 from urllib.parse import quote
+
+import requests
 from requests.sessions import Session
 
 from .params import to_params_dict
-from .retrying import _RetryingSession
-from .retrying import Retry
-
+from .retrying import Retry, _RetryingSession
 
 TimeoutTuple = Tuple[int, int]
 
@@ -245,5 +243,5 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         return deleted_records
 
 
-from pyairtable.api.table import Table  # noqa
 from pyairtable.api.base import Base  # noqa
+from pyairtable.api.table import Table  # noqa

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+
 from .abstract import ApiAbstract, TimeoutTuple
 from .retrying import Retry
 
@@ -333,5 +334,5 @@ class Api(ApiAbstract):
         return "<pyairtable.Api>"
 
 
-from pyairtable.api.table import Table  # noqa
 from pyairtable.api.base import Base  # noqa
+from pyairtable.api.table import Table  # noqa

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -1,5 +1,5 @@
-from typing import List, Dict, Any
 from collections import OrderedDict
+from typing import Any, Dict, List
 
 
 class InvalidParamException(ValueError):

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -53,7 +53,6 @@ def field_names_to_sorting_dict(field_names: List[str]) -> List[Dict[str, str]]:
     values = []
 
     for field_name in field_names:
-
         if field_name.startswith("-"):
             direction = "desc"
             field_name = field_name[1:]

--- a/pyairtable/api/retrying.py
+++ b/pyairtable/api/retrying.py
@@ -2,7 +2,6 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-
 DEFAULT_RETRIABLE_STATUS_CODES = (429, 500, 502, 503, 504)
 DEFAULT_BACKOFF_FACTOR = 0.3
 DEFAULT_MAX_RETRIES = 5

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -95,7 +95,9 @@ class Table(ApiAbstract):
         Same as :meth:`Api.create <pyairtable.api.Api.create>`
         but without ``base_id`` and ``table_name`` arg.
         """
-        return super()._create(self.base_id, self.table_name, fields, typecast=typecast, **options)
+        return super()._create(
+            self.base_id, self.table_name, fields, typecast=typecast, **options
+        )
 
     def batch_create(self, records, typecast=False, **options):
         """
@@ -107,12 +109,7 @@ class Table(ApiAbstract):
         )
 
     def update(
-        self,
-        record_id: str,
-        fields: dict,
-        replace=False,
-        typecast=False,
-        **options
+        self, record_id: str, fields: dict, replace=False, typecast=False, **options
     ):
         """
         Same as :meth:`Api.update <pyairtable.api.Api.update>`
@@ -125,16 +122,23 @@ class Table(ApiAbstract):
             fields,
             replace=replace,
             typecast=typecast,
-            **options
+            **options,
         )
 
-    def batch_update(self, records: List[dict], replace=False, typecast=False, **options):
+    def batch_update(
+        self, records: List[dict], replace=False, typecast=False, **options
+    ):
         """
         Same as :meth:`Api.batch_update <pyairtable.api.Api.batch_update>`
         but without ``base_id`` and ``table_name`` arg.
         """
         return super()._batch_update(
-            self.base_id, self.table_name, records, replace=replace, typecast=typecast, **options
+            self.base_id,
+            self.table_name,
+            records,
+            replace=replace,
+            typecast=typecast,
+            **options,
         )
 
     def delete(self, record_id: str):

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -1,5 +1,5 @@
-from datetime import datetime, date
 import re
+from datetime import date, datetime
 from typing import Any
 
 from .utils import date_to_iso_str, datetime_to_iso_str

--- a/pyairtable/metadata.py
+++ b/pyairtable/metadata.py
@@ -1,5 +1,6 @@
 import posixpath
-from typing import Union, Optional
+from typing import Optional, Union
+
 from pyairtable.api import Api, Base, Table
 
 

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -229,7 +229,9 @@ class LookupField(Field):
 
     def valid_or_raise(self, value) -> None:
         if not isinstance(value, list):
-            raise ValueError(f"LookupField '{self.field_name}' value ({value}) must be a 'list'")
+            raise ValueError(
+                f"LookupField '{self.field_name}' value ({value}) must be a 'list'"
+            )
 
     def __get__(self, *args, **kwargs) -> Optional[list]:
         return super().__get__(*args, **kwargs)

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -52,16 +52,7 @@ In other words, you can transverse related records through their ``Link Fields``
 """
 import abc
 from datetime import date, datetime
-from typing import (
-    Any,
-    TypeVar,
-    Type,
-    Generic,
-    Optional,
-    List,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Generic, List, Optional, Type, TypeVar, Union
 
 from pyairtable import utils
 

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -61,8 +61,9 @@ True
 
 """
 import abc
+from typing import List, Type, TypeVar
+
 from pyairtable import Table
-from typing import TypeVar, Type, List
 
 from .fields import Field
 

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, date
+from datetime import date, datetime
 from typing import Union
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,9 @@ wheel==0.38.1
 twine==3.3.0
 build==0.6.0.post1
 
+# Hooks
+pre-commit
+
 # Formatting, Linting
 black
 flake8

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,20 +1,8 @@
-#!/bin/bash
+#!/bin/bash -e
 
-source ./scripts/console.sh
-
-info 'Pre-Commit Hook'
-
-info "Checking for breakpoints"
-
-breakpoint=$(git grep breakpoint -- '*.py')
-if [ -n "$breakpoint" ]
-then
-    error "COMMIT REJECTED: Please remove breakpoint before commiting."
-    error $breakpoint
-    exit 1
-fi
-
-set -e
-
-make lint
-make docs
+# This script is deprecated and just replaces itself with pre-commit.
+echo "$0: deprecated githooks script; replacing with pre-commit"
+cd $(dirname $0)/../..
+git config --local core.hooksPath && git config --local --unset core.hooksPath
+make setup
+.git/hooks/pre-commit "$@"

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -1,9 +1,7 @@
-#!/bin/bash
+#!/bin/bash -e
 
-set -e
-
-echo "> Linting"
-make lint
-
-echo "> Testing"
-make test
+# This script is deprecated and just replaces itself with pre-commit.
+echo "$0: deprecated githooks script; replacing with pre-commit"
+cd $(dirname $0)/../..
+git config --local core.hooksPath && git config --local --unset core.hooksPath
+make setup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
+from collections import OrderedDict
+from posixpath import join as urljoin
+from urllib.parse import quote, urlencode
+
 import pytest
 from mock import Mock
-
-from posixpath import join as urljoin
 from requests import HTTPError
-from urllib.parse import urlencode, quote
 
-from pyairtable.api import Api, Table, Base
-from collections import OrderedDict
+from pyairtable.api import Api, Base, Table
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from pyairtable import Base, Table

--- a/tests/integration/test_integration_api.py
+++ b/tests/integration/test_integration_api.py
@@ -1,10 +1,11 @@
 from datetime import datetime
+from uuid import uuid4
 
 import pytest
+
 from pyairtable import Table
 from pyairtable import formulas as fo
 from pyairtable.utils import attachment
-from uuid import uuid4
 
 
 @pytest.mark.integration

--- a/tests/integration/test_integration_metadata.py
+++ b/tests/integration/test_integration_metadata.py
@@ -1,6 +1,7 @@
 import pytest
+
 from pyairtable import Base, Table
-from pyairtable.metadata import get_base_schema, get_api_bases, get_table_schema
+from pyairtable.metadata import get_api_bases, get_base_schema, get_table_schema
 
 
 @pytest.mark.integration

--- a/tests/integration/test_integration_orm.py
+++ b/tests/integration/test_integration_orm.py
@@ -1,9 +1,10 @@
-import pytest
 import os
 from datetime import datetime
+
+import pytest
+
 from pyairtable.orm import Model
 from pyairtable.orm import fields as f
-
 
 BASE_ID = "appaPqizdsNHDvlEm"
 

--- a/tests/test_api_api.py
+++ b/tests/test_api_api.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
-from pyairtable.api.abstract import ApiAbstract
 from pyairtable import Api, Table
+from pyairtable.api.abstract import ApiAbstract
 
 
 def test_repr(api):

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
+from pyairtable import Base, Table
 from pyairtable.api.abstract import ApiAbstract
-from pyairtable import Table, Base
 
 
 def test_repr(base):

--- a/tests/test_api_retrying.py
+++ b/tests/test_api_retrying.py
@@ -1,12 +1,12 @@
 """
 For these tests Mocker cannot be used because Retry is operating on a lower level
 """
-import pytest
-from unittest import mock
-
 import io
 import json
 from http.client import HTTPMessage, HTTPResponse
+from unittest import mock
+
+import pytest
 import requests
 
 from pyairtable.api.retrying import retry_strategy

--- a/tests/test_api_retrying.py
+++ b/tests/test_api_retrying.py
@@ -29,7 +29,6 @@ def table_with_retry_strategy(constants):
 
 @mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
 def test_retry_exceed(m, table_with_retry_strategy):
-
     strategy = retry_strategy(total=2, status_forcelist=[429])
     table = table_with_retry_strategy(strategy)
 
@@ -47,7 +46,6 @@ def test_retry_exceed(m, table_with_retry_strategy):
 
 @mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
 def test_retry_status_not_allowed(m, table_with_retry_strategy, mock_response_single):
-
     strategy = retry_strategy(total=2, status_forcelist=[429, 500])
     table = table_with_retry_strategy(strategy)
 
@@ -66,7 +64,6 @@ def test_retry_status_not_allowed(m, table_with_retry_strategy, mock_response_si
 
 @mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
 def test_retry_eventual_success(m, table_with_retry_strategy, mock_response_single):
-
     strategy = retry_strategy(total=2, status_forcelist=[429, 500])
     table = table_with_retry_strategy(strategy)
 

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -1,5 +1,6 @@
-import pytest
 from posixpath import join as urljoin
+
+import pytest
 from requests import Request
 from requests_mock import Mocker
 

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -127,7 +127,6 @@ def test_all(table, mock_response_list, mock_records):
 
 def test_iterate(table, mock_response_list, mock_records):
     with Mocker() as mock:
-
         mock.get(
             table.table_url,
             status_code=200,

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -1,15 +1,16 @@
 import pytest
+
 from pyairtable.formulas import (
     AND,
-    OR,
     EQUAL,
     FIELD,
-    STR_VALUE,
-    IF,
-    match,
-    escape_quotes,
     FIND,
+    IF,
     LOWER,
+    OR,
+    STR_VALUE,
+    escape_quotes,
+    match,
 )
 
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -8,7 +8,6 @@ from pyairtable.orm import fields as f
 
 
 def test_model_missing_meta():
-
     with pytest.raises(ValueError):
 
         class Address(Model):
@@ -21,7 +20,6 @@ def test_model_missing_meta():
 
 
 def test_model_overlapping():
-
     # Should raise error because conflicts with .exists()
     with pytest.raises(ValueError):
 
@@ -45,7 +43,6 @@ def test_model():
             api_key = "fake"
 
     class Contact(Model):
-
         first_name = f.TextField("First Name")
         last_name = f.TextField("Last Name")
         email = f.EmailField("Email")
@@ -93,7 +90,6 @@ def test_model():
 
 def test_from_record():
     class Contact(Model):
-
         first_name = f.TextField("First Name")
         timestamp = f.DatetimeField("Timestamp")
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from unittest import mock
-from requests_mock import Mocker
+
 import pytest
+from requests_mock import Mocker
+
 from pyairtable import Table
 from pyairtable.orm import Model
 from pyairtable.orm import fields as f

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pyairtable.orm import fields as f
 
 

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -78,24 +78,24 @@ def test_lookup_field():
     rv_json = field.to_record_value(rv_list)
     assert rv_json == lookup_from_airtable
     assert isinstance(rv_list, list)
-    assert (
-        rv_list[0] == 'Item 1'
-        and rv_list[1] == 'Item 2'
-        and rv_list[2] == 'Item 3'
-    )
+    assert rv_list[0] == "Item 1" and rv_list[1] == "Item 2" and rv_list[2] == "Item 3"
 
     class T:
         events = f.LookupField("Event times", model=f.DatetimeField)
 
     field = T.__dict__["events"]
 
-    lookup_from_airtable = ["2000-01-02T03:04:05.000Z", "2000-02-02T03:04:05.000Z", "2000-03-02T03:04:05.000Z"]
+    lookup_from_airtable = [
+        "2000-01-02T03:04:05.000Z",
+        "2000-02-02T03:04:05.000Z",
+        "2000-03-02T03:04:05.000Z",
+    ]
     rv_to_internal = field.to_internal_value(lookup_from_airtable)
     rv_to_record = field.to_record_value(rv_to_internal)
     assert rv_to_record == lookup_from_airtable
     assert isinstance(rv_to_internal, list)
     assert (
-        rv_to_internal[0] == '2000-01-02T03:04:05.000Z'
-        and rv_to_internal[1] == '2000-02-02T03:04:05.000Z'
-        and rv_to_internal[2] == '2000-03-02T03:04:05.000Z'
+        rv_to_internal[0] == "2000-01-02T03:04:05.000Z"
+        and rv_to_internal[1] == "2000-02-02T03:04:05.000Z"
+        and rv_to_internal[2] == "2000-03-02T03:04:05.000Z"
     )

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -3,10 +3,10 @@ import requests
 from requests_mock import Mocker
 
 from pyairtable.api.params import (
-    to_params_dict,
+    InvalidParamException,
     dict_list_to_request_params,
     field_names_to_sorting_dict,
-    InvalidParamException,
+    to_params_dict,
 )
 
 

--- a/tests/test_request_errors.py
+++ b/tests/test_request_errors.py
@@ -1,6 +1,6 @@
 import pytest
-from requests import HTTPError
 from mock import Mock
+from requests import HTTPError
 
 
 def test_error_mesg_in_json(table, response):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
-import pytest
-from pyairtable import utils
+from datetime import date, datetime
 
-from datetime import datetime, date
+import pytest
+
+from pyairtable import utils
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
+    pre-commit
+    mypy
     py3{7,8,9,10,11}-requests{min,max}
-    lint
     coverage
 
 [gh-actions]
@@ -12,6 +13,14 @@ python =
     3.10: py310
     3.11: py311
 
+[testenv:pre-commit]
+deps = pre-commit
+commands = pre-commit run --all-files
+
+[testenv:mypy]
+deps = -r requirements-dev.txt
+commands = mypy pyairtable
+
 [testenv]
 addopts = -v
 testpaths = tests
@@ -20,14 +29,6 @@ deps =
     -r requirements-test.txt
     requestsmin: requests==2.22.0  # Keep in sync with setup.cfg
     requestsmax: requests>=2.22.0  # Keep in sync with setup.cfg
-
-[testenv:lint]
-deps =
-    -r requirements-dev.txt
-commands =
-    mypy pyairtable
-    black --diff pyairtable tests
-    flake8 .
 
 [testenv:coverage]
 passenv = CODECOV_TOKEN

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands = mypy pyairtable
 [testenv]
 addopts = -v
 testpaths = tests
-commands = python -m pytest -m 'not integration'
+commands = python -m pytest {posargs:-m 'not integration'}
 deps =
     -r requirements-test.txt
     requestsmin: requests==2.22.0  # Keep in sync with setup.cfg
@@ -33,7 +33,7 @@ deps =
 [testenv:coverage]
 passenv = CODECOV_TOKEN
 commands =
-    python -m pytest -m 'not integration' --cov=pyairtable
+    python -m pytest -m 'not integration' --cov=pyairtable --cov-report=html
     codecov
 
 [testenv:docs]


### PR DESCRIPTION
[pre-commit](pre-commit.com) is a great framework for applying consistent rules across a repository on every commit, in a way that's not very disruptive for contributors. When coupled with highly opinionated formatters (like [black](https://github.com/psf/black)), it keeps diffs small and avoids any argument over stylistic disagreements.

In order to make these hooks' behavior as reproducible as possible, this branch moves linting/formatting commands into `tox.ini`. This branch also applies the black, flake8, and isort formatters across all files so that contributors have a reasonable baseline to work against. Reviewing one commit at a time might be easier than reviewing all at once.