### PR TITLE
Run GitHub Actions on every pull request

### DIFF
--- a/.github/workflows/test_lint_deploy.yml
+++ b/.github/workflows/test_lint_deploy.yml
@@ -1,35 +1,36 @@
-name: Test, Lint, Publish
+name: CI
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches: [main]
 
 jobs:
   test:
+    name: Run tests on ${{ matrix.python }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Setup Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ hashFiles('setup.cfg') }}-${{ hashFiles('requirements-test.txt') }}
 
-      - name: Install Depedencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install tox-gh-actions
-          pip install -r requirements-test.txt
 
-      - name: Run Tox Tests
-        run: tox
+      - run: tox
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -37,13 +38,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     # Only Publish if it's a tagged commit
-    if: startsWith(github.ref, 'refs/tags/')
+    if: >-
+      startsWith(github.ref, 'refs/tags/')
+      && github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 


### PR DESCRIPTION
Right now GitHub Actions only trigger on a push. This will trigger them on every pull request against `main`, which should have the added benefit of putting them into the "Checks" UI at the bottom of the pull request.