### PR TITLE
Remove dependency on abandoned codecov library

### DIFF
--- a/.github/workflows/test_lint_deploy.yml
+++ b/.github/workflows/test_lint_deploy.yml
@@ -32,7 +32,12 @@ jobs:
 
       - run: tox
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          COVERAGE_FORMAT: xml
+
+      - uses: codecov/codecov-action@v3
+        if: ${{ !cancelled() && hashFiles('coverage.xml') }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 # Required to run test suite
-codecov
 mock
 pytest
 pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 [gh-actions]
 python =
     3.7: py37
-    3.8: py38, lint, coverage
+    3.8: py38, coverage
     3.9: py39
     3.10: py310
     3.11: py311
@@ -31,10 +31,9 @@ deps =
     requestsmax: requests>=2.22.0  # Keep in sync with setup.cfg
 
 [testenv:coverage]
-passenv = CODECOV_TOKEN
+passenv = COVERAGE_FORMAT
 commands =
-    python -m pytest -m 'not integration' --cov=pyairtable --cov-report=html
-    codecov
+    python -m pytest -m 'not integration' --cov=pyairtable --cov-report={env:COVERAGE_FORMAT:html}
 
 [testenv:docs]
 basepython = python3.7


### PR DESCRIPTION
On April 12, [Codecov](codecov.io) stopped supporting the `codecov` package and pulled it from PyPI, breaking many projects' continuous integration setups (including this one). This branch attempts to get it back in working order. 

See https://about.codecov.io/blog/message-regarding-the-pypi-package/