### PR TITLE
Pass AIRTABLE_API_KEY to tox for integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps = -r requirements-dev.txt
 commands = mypy pyairtable
 
 [testenv]
+passenv = AIRTABLE_API_KEY
 addopts = -v
 testpaths = tests
 commands = python -m pytest {posargs:-m 'not integration'}


### PR DESCRIPTION
After moving all test commands into tox in #239, I neglected to add a line that passes along the API key required to run integration tests. Here it goes. (Eventually we should consider splitting integration tests out into their own tox environment.)