### PR TITLE
configurable api_base_url

### DIFF
--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -19,6 +19,9 @@
     defaults, but you may provide your own custom instance of ``Retry``.
     Default is ``None`` (no retry).
 
+.. |arg_endpoint_url| replace:: The API endpoint to hit. You might want to override it if you are using an API proxy to debug your API calls.
+    Default is ``https://api.airtable.com``.
+
 .. |kwarg_view| replace:: The name or ID of a view.
     If set, only the records in that view will be returned.
     The records will be sorted according to the order of the view.

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -21,7 +21,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     DEFAULT_API_BASE_URL = "https://api.airtable.com/"
 
     session: Session
-    api_base_url = DEFAULT_API_BASE_URL
+    endpoint_url = DEFAULT_API_BASE_URL
     api_url: str
     tiemout: TimeoutTuple
 
@@ -30,17 +30,17 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         api_key: str,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        api_base_url: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
     ):
         if not retry_strategy:
             self.session = Session()
         else:
             self.session = _RetryingSession(retry_strategy)
 
-        if api_base_url:
-            self.api_base_url = api_base_url
+        if endpoint_url:
+            self.endpoint_url = endpoint_url
 
-        self.api_url = posixpath.join(self.api_base_url, self.VERSION)    
+        self.api_url = posixpath.join(self.endpoint_url, self.VERSION)    
         self.timeout = timeout
         self.api_key = api_key
 

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -21,7 +21,6 @@ class ApiAbstract(metaclass=abc.ABCMeta):
 
     session: Session
     endpoint_url: str
-    api_url: str
     tiemout: TimeoutTuple
 
     def __init__(
@@ -36,8 +35,11 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         else:
             self.session = _RetryingSession(retry_strategy)
 
-        self.endpoint_url = endpoint_url
-        self.api_url = posixpath.join(self.endpoint_url, self.VERSION)    
+        if not endpoint_url.endswith(self.VERSION):
+            self.endpoint_url = posixpath.join(endpoint_url, self.VERSION)
+        else:
+            self.endpoint_url = endpoint_url
+        print(self.endpoint_url)
         self.timeout = timeout
         self.api_key = api_key
 
@@ -58,7 +60,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     @lru_cache()
     def get_table_url(self, base_id: str, table_name: str):
         url_safe_table_name = quote(table_name, safe="")
-        table_url = posixpath.join(self.api_url, base_id, url_safe_table_name)
+        table_url = posixpath.join(self.endpoint_url, base_id, url_safe_table_name)
         return table_url
 
     @lru_cache()

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -29,7 +29,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         api_key: str,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        endpoint_url: Optional[str] = "https://api.airtable.com",
+        endpoint_url: str = "https://api.airtable.com",
     ):
         if not retry_strategy:
             self.session = Session()

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -29,16 +29,14 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         api_key: str,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        endpoint_url: Optional[str] = "https://api.airtable.com/",
+        endpoint_url: Optional[str] = "https://api.airtable.com",
     ):
         if not retry_strategy:
             self.session = Session()
         else:
             self.session = _RetryingSession(retry_strategy)
 
-        if endpoint_url:
-            self.endpoint_url = endpoint_url
-
+        self.endpoint_url = endpoint_url
         self.api_url = posixpath.join(self.endpoint_url, self.VERSION)    
         self.timeout = timeout
         self.api_key = api_key

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -39,7 +39,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
             self.endpoint_url = posixpath.join(endpoint_url, self.VERSION)
         else:
             self.endpoint_url = endpoint_url
-        print(self.endpoint_url)
+
         self.timeout = timeout
         self.api_key = api_key
 

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -18,10 +18,9 @@ class ApiAbstract(metaclass=abc.ABCMeta):
     VERSION = "v0"
     API_LIMIT = 1.0 / 5  # 5 per second
     MAX_RECORDS_PER_REQUEST = 10
-    DEFAULT_API_BASE_URL = "https://api.airtable.com/"
 
     session: Session
-    endpoint_url = DEFAULT_API_BASE_URL
+    endpoint_url: str
     api_url: str
     tiemout: TimeoutTuple
 
@@ -30,7 +29,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         api_key: str,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        endpoint_url: Optional[str] = None,
+        endpoint_url: Optional[str] = "https://api.airtable.com/",
     ):
         if not retry_strategy:
             self.session = Session()

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -25,7 +25,7 @@ class Api(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        endpoint_url: Optional[str] = None,
+        endpoint_url: Optional[str] = "https://api.airtable.com",
     ):
         """
 

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -25,6 +25,7 @@ class Api(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
+        api_base_url: Optional[str] = None,
     ):
         """
 
@@ -36,21 +37,21 @@ class Api(ApiAbstract):
             retry_strategy (``Retry``): |arg_retry_strategy|
 
         """
-        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy)
+        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy, api_base_url=api_base_url)
 
     def get_table(self, base_id: str, table_name: str) -> "Table":
         """
         Returns a new :class:`Table` instance using all shared
         attributes from :class:`Api`
         """
-        return Table(self.api_key, base_id, table_name, timeout=self.timeout)
+        return Table(self.api_key, base_id, table_name, timeout=self.timeout, api_base_url=self.api_base_url)
 
     def get_base(self, base_id: str) -> "Base":
         """
         Returns a new :class:`Base` instance using all shared
         attributes from :class:`Api`
         """
-        return Base(self.api_key, base_id, timeout=self.timeout)
+        return Base(self.api_key, base_id, timeout=self.timeout, api_base_url=self.api_base_url)
 
     def get_record_url(self, base_id: str, table_name: str, record_id: str):
         """

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -35,7 +35,7 @@ class Api(ApiAbstract):
         Keyword Args:
             timeout (``Tuple``): |arg_timeout|
             retry_strategy (``Retry``): |arg_retry_strategy|
-
+            endpoint_url (``str``): |arg_endpoint_url|
         """
         super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy, endpoint_url=endpoint_url)
 

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -25,7 +25,7 @@ class Api(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        endpoint_url: Optional[str] = "https://api.airtable.com",
+        endpoint_url: str = "https://api.airtable.com",
     ):
         """
 

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -25,7 +25,7 @@ class Api(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        api_base_url: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
     ):
         """
 
@@ -37,21 +37,21 @@ class Api(ApiAbstract):
             retry_strategy (``Retry``): |arg_retry_strategy|
 
         """
-        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy, api_base_url=api_base_url)
+        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy, endpoint_url=endpoint_url)
 
     def get_table(self, base_id: str, table_name: str) -> "Table":
         """
         Returns a new :class:`Table` instance using all shared
         attributes from :class:`Api`
         """
-        return Table(self.api_key, base_id, table_name, timeout=self.timeout, api_base_url=self.api_base_url)
+        return Table(self.api_key, base_id, table_name, timeout=self.timeout, endpoint_url=self.endpoint_url)
 
     def get_base(self, base_id: str) -> "Base":
         """
         Returns a new :class:`Base` instance using all shared
         attributes from :class:`Api`
         """
-        return Base(self.api_key, base_id, timeout=self.timeout, api_base_url=self.api_base_url)
+        return Base(self.api_key, base_id, timeout=self.timeout, endpoint_url=self.endpoint_url)
 
     def get_record_url(self, base_id: str, table_name: str, record_id: str):
         """

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -23,7 +23,7 @@ class Base(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        endpoint_url: Optional[str] = "https://api.airtable.com",
+        endpoint_url: str = "https://api.airtable.com",
     ):
         """
         Args:

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -23,6 +23,7 @@ class Base(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
+        api_base_url: Optional[str] = None,
     ):
         """
         Args:
@@ -35,7 +36,7 @@ class Base(ApiAbstract):
         """
 
         self.base_id = base_id
-        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy)
+        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy, api_base_url=api_base_url)
 
     def get_table(self, table_name: str) -> "Table":
         """

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -23,7 +23,7 @@ class Base(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        api_base_url: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
     ):
         """
         Args:
@@ -36,7 +36,7 @@ class Base(ApiAbstract):
         """
 
         self.base_id = base_id
-        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy, api_base_url=api_base_url)
+        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy, endpoint_url=endpoint_url)
 
     def get_table(self, table_name: str) -> "Table":
         """

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -23,7 +23,7 @@ class Base(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        endpoint_url: Optional[str] = None,
+        endpoint_url: Optional[str] = "https://api.airtable.com",
     ):
         """
         Args:

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -26,7 +26,7 @@ class Table(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        endpoint_url: Optional[str] = "https://api.airtable.com",
+        endpoint_url: str = "https://api.airtable.com",
     ):
         """
         Args:

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -26,6 +26,7 @@ class Table(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
+        api_base_url: Optional[str] = None,
     ):
         """
         Args:
@@ -39,7 +40,8 @@ class Table(ApiAbstract):
         """
         self.base_id = base_id
         self.table_name = table_name
-        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy)
+        self.api_base_url = api_base_url
+        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy, api_base_url=api_base_url)
 
     @property
     def table_url(self):

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -26,7 +26,7 @@ class Table(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        api_base_url: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
     ):
         """
         Args:
@@ -40,8 +40,8 @@ class Table(ApiAbstract):
         """
         self.base_id = base_id
         self.table_name = table_name
-        self.api_base_url = api_base_url
-        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy, api_base_url=api_base_url)
+        self.endpoint_url = endpoint_url
+        super().__init__(api_key, timeout=timeout, retry_strategy=retry_strategy, endpoint_url=endpoint_url)
 
     @property
     def table_url(self):

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -26,7 +26,7 @@ class Table(ApiAbstract):
         *,
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Retry] = None,
-        endpoint_url: Optional[str] = None,
+        endpoint_url: Optional[str] = "https://api.airtable.com",
     ):
         """
         Args:

--- a/pyairtable/metadata.py
+++ b/pyairtable/metadata.py
@@ -29,7 +29,7 @@ def get_api_bases(api: Union[Api, Base]) -> dict:
                 ]
             }
     """
-    base_list_url = posixpath.join(api.api_url, "meta", "bases")
+    base_list_url = posixpath.join(api.endpoint_url, "meta", "bases")
     return api._request("get", base_list_url)
 
 
@@ -78,7 +78,7 @@ def get_base_schema(base: Union[Base, Table]) -> dict:
             }
     """
     base_schema_url = posixpath.join(
-        base.api_url, "meta", "bases", base.base_id, "tables"
+        base.endpoint_url, "meta", "bases", base.base_id, "tables"
     )
     return base._request("get", base_schema_url)
 

--- a/pyairtable/metadata.py
+++ b/pyairtable/metadata.py
@@ -29,7 +29,7 @@ def get_api_bases(api: Union[Api, Base]) -> dict:
                 ]
             }
     """
-    base_list_url = posixpath.join(api.API_URL, "meta", "bases")
+    base_list_url = posixpath.join(api.api_url, "meta", "bases")
     return api._request("get", base_list_url)
 
 
@@ -78,7 +78,7 @@ def get_base_schema(base: Union[Base, Table]) -> dict:
             }
     """
     base_schema_url = posixpath.join(
-        base.API_URL, "meta", "bases", base.base_id, "tables"
+        base.api_url, "meta", "bases", base.base_id, "tables"
     )
     return base._request("get", base_schema_url)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def url_builder():
 
     def _url_builder(base_id, table_name, params=None):
         urltable_name = quote(table_name, safe="")
-        url = urljoin(Api.api_url, base_id, urltable_name)
+        url = urljoin(Api.endpoint_url, base_id, urltable_name)
         if params:
             params = OrderedDict(sorted(params.items()))
             url += "?" + urlencode(params)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,15 @@ def constants():
 def api(constants):
     return Api(constants["API_KEY"])
 
+
 @pytest.fixture()
 def api_with_endpoint_url(constants):
     return Api(constants["API_KEY"], endpoint_url="https://api.example.com")
+
+
+@pytest.fixture()
+def api_with_endpoint_url_trailing_slash(constants):
+    return Api(constants["API_KEY"], endpoint_url="https://api.example.com/")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def url_builder():
 
     def _url_builder(base_id, table_name, params=None):
         urltable_name = quote(table_name, safe="")
-        url = urljoin(Api.API_URL, base_id, urltable_name)
+        url = urljoin(Api.api_url, base_id, urltable_name)
         if params:
             params = OrderedDict(sorted(params.items()))
             url += "?" + urlencode(params)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,11 +42,6 @@ def api_with_endpoint_url(constants):
 
 
 @pytest.fixture()
-def api_with_endpoint_url_trailing_slash(constants):
-    return Api(constants["API_KEY"], endpoint_url="https://api.example.com/")
-
-
-@pytest.fixture()
 def base(constants):
     return Base(constants["API_KEY"], constants["BASE_ID"])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,10 @@ def constants():
 def api(constants):
     return Api(constants["API_KEY"])
 
+@pytest.fixture()
+def api_with_endpoint_url(constants):
+    return Api(constants["API_KEY"], endpoint_url="https://api.example.com")
+
 
 @pytest.fixture()
 def base(constants):

--- a/tests/test_api_api.py
+++ b/tests/test_api_api.py
@@ -19,6 +19,13 @@ def test_get_table(api: Api):
     assert rv.base_id == "x"
     assert rv.table_name == "y"
 
+    
+def test_default_endpoint_url(api: Api):
+    assert api.endpoint_url == "https://api.airtable.com"
+
+
+def test_endpoint_url(api_with_endpoint_url: Api):
+    assert api_with_endpoint_url.endpoint_url == "https://api.example.com"
 
 @mock.patch.object(ApiAbstract, "_get_record")
 def test_get(m, api: Api, mock_response_single):

--- a/tests/test_api_api.py
+++ b/tests/test_api_api.py
@@ -21,15 +21,15 @@ def test_get_table(api: Api):
 
     
 def test_default_endpoint_url(api: Api):
-    assert api.endpoint_url == "https://api.airtable.com"
+    assert api.endpoint_url == "https://api.airtable.com/" + api.VERSION
 
 
 def test_endpoint_url(api_with_endpoint_url: Api):
-    assert api_with_endpoint_url.endpoint_url == "https://api.example.com"
+    assert api_with_endpoint_url.endpoint_url == "https://api.example.com/" + api_with_endpoint_url.VERSION
 
 
 def test_api_url(api_with_endpoint_url_trailing_slash: Api):
-    assert api_with_endpoint_url_trailing_slash.api_url == "https://api.example.com/" + api_with_endpoint_url_trailing_slash.VERSION
+    assert api_with_endpoint_url_trailing_slash.endpoint_url == "https://api.example.com/" + api_with_endpoint_url_trailing_slash.VERSION
 
 
 @mock.patch.object(ApiAbstract, "_get_record")

--- a/tests/test_api_api.py
+++ b/tests/test_api_api.py
@@ -28,9 +28,9 @@ def test_endpoint_url(api_with_endpoint_url: Api):
     assert api_with_endpoint_url.endpoint_url == "https://api.example.com/" + api_with_endpoint_url.VERSION
 
 
-def test_api_url(api_with_endpoint_url_trailing_slash: Api):
-    assert api_with_endpoint_url_trailing_slash.endpoint_url == "https://api.example.com/" + api_with_endpoint_url_trailing_slash.VERSION
-
+def test_endpoint_url_with_trailing_slash():
+    api = Api("apikey", endpoint_url="https://api.example.com/")
+    assert api.endpoint_url == "https://api.example.com/" + api.VERSION
 
 @mock.patch.object(ApiAbstract, "_get_record")
 def test_get(m, api: Api, mock_response_single):

--- a/tests/test_api_api.py
+++ b/tests/test_api_api.py
@@ -27,6 +27,11 @@ def test_default_endpoint_url(api: Api):
 def test_endpoint_url(api_with_endpoint_url: Api):
     assert api_with_endpoint_url.endpoint_url == "https://api.example.com"
 
+
+def test_api_url(api_with_endpoint_url_trailing_slash: Api):
+    assert api_with_endpoint_url_trailing_slash.api_url == "https://api.example.com/" + api_with_endpoint_url_trailing_slash.VERSION
+
+
 @mock.patch.object(ApiAbstract, "_get_record")
 def test_get(m, api: Api, mock_response_single):
     m.return_value = mock_response_single

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -21,7 +21,7 @@ def test_repr(table):
 )
 def test_url(base_id, table_name, table_url_suffix):
     table = Table("apikey", base_id, table_name)
-    assert table.table_url == "{0}/{1}".format(table.api_url, table_url_suffix)
+    assert table.table_url == "{0}/{1}".format(table.endpoint_url, table_url_suffix)
 
 
 def test_chunk(table):

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -21,7 +21,7 @@ def test_repr(table):
 )
 def test_url(base_id, table_name, table_url_suffix):
     table = Table("apikey", base_id, table_name)
-    assert table.table_url == "{0}/{1}".format(table.API_URL, table_url_suffix)
+    assert table.table_url == "{0}/{1}".format(table.api_url, table_url_suffix)
 
 
 def test_chunk(table):


### PR DESCRIPTION
Adds configurable `api_base_url` when creating `Api`

```python
api = Api(token, api_base_url="https://api.airwalker.io/")
```

airtable.js implements this as `endpointUrl` 
https://github.com/Airtable/airtable.js/blob/2d36eb64249a51e99cc7f2ea3dfb59cd3522a188/README.md?plain=1#L68