### PR TITLE
Use `POST /listRecords` instead of `GET` when the URL gets too long

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -303,8 +303,8 @@ have a corresponding ``kwargs`` that can be used with fetching methods like :met
    :widths: 25 25 50
    :header-rows: 1
 
-   * - Parameter
-     - Airtable Option
+   * - Keyword Argument
+     - Airtable Parameter
      - Notes
    * - ``max_records``
      - ``maxRecords``

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -1,5 +1,6 @@
+import warnings
 from collections import OrderedDict
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 
 class InvalidParamException(ValueError):
@@ -66,6 +67,12 @@ def field_names_to_sorting_dict(field_names: List[str]) -> List[Dict[str, str]]:
 
 def to_params_dict(param_name: str, value: Any):
     """Returns a dictionary for use in Request 'params'"""
+    warnings.warn(
+        "to_params_dict will be removed in 2.0.0",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if param_name == "max_records":
         return {"maxRecords": value}
     elif param_name == "view":
@@ -92,3 +99,85 @@ def to_params_dict(param_name: str, value: Any):
     else:
         msg = "'{0}' is not a supported parameter".format(param_name)
         raise InvalidParamException(msg)
+
+
+#: Mapping of pyairtable option names to Airtable parameter names
+OPTIONS_TO_PARAMETERS = {
+    "cell_format": "cellFormat",
+    "fields": "fields",
+    "formula": "filterByFormula",
+    "max_records": "maxRecords",
+    "offset": "offset",
+    "page_size": "pageSize",
+    "return_fields_by_field_id": "returnFieldsByFieldId",
+    "sort": "sort",
+    "time_zone": "timeZone",
+    "user_locale": "userLocale",
+    "view": "view",
+}
+
+
+def _option_to_param(name: str) -> str:
+    try:
+        return OPTIONS_TO_PARAMETERS[name]
+    except KeyError:
+        raise InvalidParamException(name)
+
+
+#: List of option names that cannot be passed via POST, only GET
+#: See https://github.com/gtalarico/pyairtable/pull/210#discussion_r1046014885
+OPTIONS_NOT_SUPPORTED_VIA_POST = ("user_locale", "time_zone")
+
+
+def options_to_params(options: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Converts Airtable options to a dict of query params.
+
+    Args:
+        options: A dict of Airtable-specific options. See :ref:`parameters`.
+
+    Returns:
+        A dict of query parameters that can be passed to the ``requests`` library.
+    """
+    params = {_option_to_param(name): value for (name, value) in options.items()}
+
+    if "fields" in params:
+        params["fields[]"] = params.pop("fields")
+    if "returnFieldsByFieldId" in params:
+        params["returnFieldsByFieldId"] = int(params["returnFieldsByFieldId"])
+    if "sort" in params:
+        sorting_dict_list = field_names_to_sorting_dict(params.pop("sort"))
+        params.update(dict_list_to_request_params("sort", sorting_dict_list))
+
+    return params
+
+
+def options_to_json_and_params(
+    options: Dict[str, Any]
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """
+    Converts Airtable options to a JSON payload with (possibly) leftover query params.
+
+    Args:
+        options: A dict of Airtable-specific options. See :ref:`parameters`.
+
+    Returns:
+        A 2-tuple that contains the POST data and the non-POSTable query parameters.
+    """
+    json = {
+        _option_to_param(name): value
+        for (name, value) in options.items()
+        if name not in OPTIONS_NOT_SUPPORTED_VIA_POST
+    }
+    params = {
+        _option_to_param(name): value
+        for (name, value) in options.items()
+        if name in OPTIONS_NOT_SUPPORTED_VIA_POST
+    }
+
+    if "returnFieldsByFieldId" in json:
+        json["returnFieldsByFieldId"] = bool(json["returnFieldsByFieldId"])
+    if "sort" in json:
+        json["sort"] = field_names_to_sorting_dict(json.pop("sort"))
+
+    return (json, params)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,7 @@ def cols():
     class Columns:
         # Table should have these Columns
         TEXT = "text"  # Text
+        TEXT_ID = "fldzbVdWW4xJdZ1em"  # for returnFieldsByFieldId
         NUM = "number"  # Number, float
         BOOL = "boolean"  # Boolean
         DATETIME = "datetime"  # Datetime

--- a/tests/integration/test_integration_api.py
+++ b/tests/integration/test_integration_api.py
@@ -59,6 +59,50 @@ def test_integration_table(table, cols):
 
 
 @pytest.mark.integration
+def test_get_records_options(table: Table, cols):
+    rec = table.create({cols.TEXT: "abracadabra"})
+
+    # Test that each supported option works via GET
+    # (or, at least, that we don't get complaints from the API)
+    assert table.all(view="view") == [rec]
+    assert table.all(max_records=1) == [rec]
+    assert table.all(page_size=1) == [rec]
+    assert table.all(offset="") == [rec]
+    assert table.all(fields=[cols.TEXT, cols.NUM]) == [rec]
+    assert table.all(cell_format="json") == [rec]
+    assert table.all(sort=[cols.TEXT, cols.NUM]) == [rec]
+    assert table.all(time_zone="utc") == [rec]
+    assert table.all(user_locale="en-ie") == [rec]
+    assert table.all(return_fields_by_field_id=True) == [
+        {
+            "id": rec["id"],
+            "createdTime": rec["createdTime"],
+            "fields": {cols.TEXT_ID: rec["fields"][cols.TEXT]},
+        }
+    ]
+
+    # Test that each supported parameter works with a POST
+    # (or, at least, that we don't get complaints from the API)
+    formula = f"{cols.TEXT} != '{'x' * 17000}'"
+    assert table.all(formula=formula, view="view") == [rec]
+    assert table.all(formula=formula, max_records=1) == [rec]
+    assert table.all(formula=formula, page_size=1) == [rec]
+    assert table.all(formula=formula, offset="") == [rec]
+    assert table.all(formula=formula, fields=[cols.TEXT, cols.NUM]) == [rec]
+    assert table.all(formula=formula, cell_format="json") == [rec]
+    assert table.all(formula=formula, sort=[cols.TEXT, cols.NUM]) == [rec]
+    assert table.all(formula=formula, time_zone="utc") == [rec]
+    assert table.all(formula=formula, user_locale="en-ie") == [rec]
+    assert table.all(formula=formula, return_fields_by_field_id=True) == [
+        {
+            "id": rec["id"],
+            "createdTime": rec["createdTime"],
+            "fields": {cols.TEXT_ID: rec["fields"][cols.TEXT]},
+        }
+    ]
+
+
+@pytest.mark.integration
 def test_integration_field_equals(table: Table, cols):
     TEXT_VALUE = "Test {}".format(uuid4())
     NUM_VALUE = 12345

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -88,6 +88,22 @@ def test_first(table, mock_response_single):
     assert rv["id"] == mock_response_single["id"]
 
 
+def test_first_via_post(table, mock_response_single):
+    mock_response = {"records": [mock_response_single]}
+    with Mocker() as mock:
+        url = table.table_url + "/listRecords"
+        formula = f"RECORD_ID() != '{'x' * 17000}'"
+        mock_endpoint = mock.post(url, status_code=200, json=mock_response)
+        rv = table.first(formula=formula)
+
+    assert mock_endpoint.last_request.json() == {
+        "filterByFormula": formula,
+        "maxRecords": 1,
+        "pageSize": 1,
+    }
+    assert rv == mock_response_single
+
+
 def test_first_none(table, mock_response_single):
     mock_response = {"records": []}
     with Mocker() as mock:

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -8,6 +8,7 @@ from pyairtable.api.params import (
     field_names_to_sorting_dict,
     options_to_json_and_params,
     options_to_params,
+    to_params_dict,
 )
 
 
@@ -114,6 +115,13 @@ def test_params_integration(table, mock_records, mock_response_iterator):
 def test_convert_options_to_params(option, value, url_params):
     """Ensure kwargs received build a proper params"""
     processed_params = options_to_params({option: value})
+    request = requests.Request("get", "https://example.com", params=processed_params)
+    assert request.prepare().url.endswith(url_params)
+
+    # TODO: remove in 2.0.0
+    with pytest.deprecated_call():
+        processed_params = to_params_dict(option, value)
+
     request = requests.Request("get", "https://example.com", params=processed_params)
     assert request.prepare().url.endswith(url_params)
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -6,7 +6,8 @@ from pyairtable.api.params import (
     InvalidParamException,
     dict_list_to_request_params,
     field_names_to_sorting_dict,
-    to_params_dict,
+    options_to_json_and_params,
+    options_to_params,
 )
 
 
@@ -110,32 +111,97 @@ def test_params_integration(table, mock_records, mock_response_iterator):
         # ],
     ],
 )
-def test_process_params(option, value, url_params):
+def test_convert_options_to_params(option, value, url_params):
     """Ensure kwargs received build a proper params"""
-    # https://codepen.io/airtable/full/rLKkYB
-
-    processed_params = to_params_dict(option, value)
-    request = requests.Request("get", "https://fake.com", params=processed_params)
+    processed_params = options_to_params({option: value})
+    request = requests.Request("get", "https://example.com", params=processed_params)
     assert request.prepare().url.endswith(url_params)
+
+
+@pytest.mark.parametrize(
+    "option,value,expected",
+    [
+        ["view", "SomeView", {"view": "SomeView"}],
+        ["max_records", 5, {"maxRecords": 5}],
+        ["page_size", 5, {"pageSize": 5}],
+        ["formula", "NOT(1)", {"filterByFormula": "NOT(1)"}],
+        ["formula", "NOT(1)", {"filterByFormula": "NOT(1)"}],
+        [
+            "formula",
+            "AND({COLUMN_ID}<=6, {COLUMN_ID}>3)",
+            {"filterByFormula": "AND({COLUMN_ID}<=6, {COLUMN_ID}>3)"},
+        ],
+        ["fields", ["Name"], {"fields": ["Name"]}],
+        [
+            "fields",
+            ["Name", "Phone"],
+            {"fields": ["Name", "Phone"]},
+        ],
+        [
+            "sort",
+            ["Name"],
+            {"sort": [{"field": "Name", "direction": "asc"}]},
+        ],
+        [
+            "sort",
+            ["Name", "Phone"],
+            {
+                "sort": [
+                    {"field": "Name", "direction": "asc"},
+                    {"field": "Phone", "direction": "asc"},
+                ]
+            },
+        ],
+        [
+            "sort",
+            ["Name", "-Phone"],
+            {
+                "sort": [
+                    {"field": "Name", "direction": "asc"},
+                    {"field": "Phone", "direction": "desc"},
+                ]
+            },
+        ],
+        ["cell_format", "string", {"cellFormat": "string"}],
+        ["return_fields_by_field_id", True, {"returnFieldsByFieldId": True}],
+        ["return_fields_by_field_id", 1, {"returnFieldsByFieldId": True}],
+        ["return_fields_by_field_id", False, {"returnFieldsByFieldId": False}],
+        # userLocale and timeZone are not supported via POST, so they return "spare params"
+        ["user_locale", "en-US", ({}, {"userLocale": "en-US"})],
+        ["time_zone", "America/Chicago", ({}, {"timeZone": "America/Chicago"})],
+    ],
+)
+def test_convert_options_to_json(option, value, expected):
+    if isinstance(expected, dict):
+        expected = (expected, {})  # most of the time, this returns empty "spare params"
+    assert options_to_json_and_params({option: value}) == expected
 
 
 def test_process_params_invalid():
     with pytest.raises(InvalidParamException):
-        to_params_dict("ffields", "x")
+        options_to_params({"ffields": "x"})
 
 
 def test_dict_list_to_request_params():
     values = [{"field": "a", "direction": "asc"}, {"field": "b", "direction": "desc"}]
     rv = dict_list_to_request_params("sort", values)
-    assert rv["sort[0][field]"] == "a"
-    assert rv["sort[0][direction]"] == "asc"
-    assert rv["sort[1][field]"] == "b"
-    assert rv["sort[1][direction]"] == "desc"
+    assert rv == {
+        "sort[0][field]": "a",
+        "sort[0][direction]": "asc",
+        "sort[1][field]": "b",
+        "sort[1][direction]": "desc",
+    }
 
 
 def test_field_names_to_sorting_dict():
     rv = field_names_to_sorting_dict(["Name", "-Age"])
-    assert rv[0]["field"] == "Name"
-    assert rv[0]["direction"] == "asc"
-    assert rv[1]["field"] == "Age"
-    assert rv[1]["direction"] == "desc"
+    assert rv == [
+        {
+            "field": "Name",
+            "direction": "asc",
+        },
+        {
+            "field": "Age",
+            "direction": "desc",
+        },
+    ]


### PR DESCRIPTION
I tried this in #245 but failed to consider enough of the differences between the formatting of query parameters vs. POST parameters. (I reverted that merge in 090bf68.) This branch adds more tests to ensure that the API accepts each parameter we might generate. 

I'll leave this open for a week or so in case there's any feedback, especially if I've missed tests for any other edge cases.