### PR TITLE
Ignore extra fields in ORM (fixes #190, option 1)

### DIFF
--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -216,7 +216,7 @@ class Model(metaclass=abc.ABCMeta):
             record = table.create(fields, typecast=self.typecast)
             did_create = True
         else:
-            record = table.update(self.id, fields, replace=True, typecast=self.typecast)
+            record = table.update(self.id, fields, typecast=self.typecast)
             did_create = False
 
         self.id = record["id"]

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -260,15 +260,14 @@ class Model(metaclass=abc.ABCMeta):
         """Create instance from record dictionary"""
         name_attr_map = cls._field_name_attribute_map()
         name_field_map = cls._field_name_descriptor_map()
-        try:
-            # Convert Column Names into model field names
-            # Use field's to_internal to cast into model fields
-            kwargs = {
-                name_attr_map[k]: name_field_map[k].to_internal_value(v)
-                for k, v in record["fields"].items()
-            }
-        except KeyError as exc:
-            raise ValueError("Invalid Field Name: {} for model {}".format(exc, cls))
+        # Convert Column Names into model field names
+        kwargs = {
+            # Use field's to_internal_value to cast into model fields
+            name_attr_map[k]: name_field_map[k].to_internal_value(v)
+            for k, v in record["fields"].items()
+            # Silently proceed if Airtable returns fields we don't recognize
+            if k in name_attr_map
+        }
         instance = cls(**kwargs)
         instance.created_time = record["createdTime"]
         instance.id = record["id"]

--- a/pyairtable/testing.py
+++ b/pyairtable/testing.py
@@ -1,0 +1,58 @@
+"""
+Helper functions for writing tests that use the pyairtable library.
+"""
+import datetime
+import random
+import string
+
+
+def fake_id(type="rec", value=None):
+    """
+    Generates a fake Airtable-style ID.
+
+    Keyword Args:
+        type: the object type prefix, defaults to "rec"
+        value: any value to use as the ID, defaults to random letters and digits
+
+    >>> fake_id()
+    'rec...'
+    >>> fake_id('tbl')
+    'tbl...'
+    >>> fake_id(value='12345')
+    'rec00000000012345'
+    """
+    if value is None:
+        value = "".join(random.sample(string.ascii_letters + string.digits, 14))
+    return type + f"{value:0>14}"[:14]
+
+
+def fake_meta(
+    base_id="appFakeTestingApp",
+    table_name="tblFakeTestingTbl",
+    api_key="patFakePersonalAccessToken",
+):
+    """
+    Returns a ``Meta`` class for inclusion in a ``Model`` subclass.
+    """
+    attrs = {"base_id": base_id, "table_name": table_name, "api_key": api_key}
+    return type("Meta", (), attrs)
+
+
+def fake_record(fields=None, id=None, **other_fields):
+    """
+    Returns a fake record dict with the given field values.
+
+    >>> fake_record({"Name": "Alice"})
+    {'id': '...', 'createdTime': '...', 'fields': {'Name': 'Alice'}}
+
+    >>> fake_record(name='Alice', address='123 Fake St')
+    {'id': '...', 'createdTime': '...', 'fields': {'name': 'Alice', 'address': '123 Fake St'}}
+
+    >>> fake_record(name='Alice', id='123')
+    {'id': 'rec00000000000123', 'createdTime': '...', 'fields': {'name': 'Alice'}}
+    """
+    return {
+        "id": fake_id(value=id),
+        "createdTime": datetime.datetime.now().isoformat() + "Z",
+        "fields": {**(fields or {}), **other_fields},
+    }


### PR DESCRIPTION
I'm not sure there's a valid use case for the ORM to fail when it gets a field it doesn't recognize. If someone has a use case in mind, we can always make this a configuration flag on `Meta` later, but I think it should be permissive by default.