### PR TITLE
Fix return_fields_by_field_id on create/update, and add more tests

### DIFF
--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -200,14 +200,22 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         return all_records
 
     def _create(
-        self, base_id: str, table_name: str, fields: dict, typecast=False, **options
+        self,
+        base_id: str,
+        table_name: str,
+        fields: dict,
+        typecast=False,
+        return_fields_by_field_id=False,
     ):
         table_url = self.get_table_url(base_id, table_name)
         return self._request(
             "post",
             table_url,
-            json_data={"fields": fields, "typecast": typecast},
-            options=options,
+            json_data={
+                "fields": fields,
+                "typecast": typecast,
+                "returnFieldsByFieldId": return_fields_by_field_id,
+            },
         )
 
     def _batch_create(
@@ -216,7 +224,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         table_name: str,
         records: List[dict],
         typecast=False,
-        **options,
+        return_fields_by_field_id=False,
     ) -> List[dict]:
         table_url = self.get_table_url(base_id, table_name)
         inserted_records = []
@@ -225,8 +233,11 @@ class ApiAbstract(metaclass=abc.ABCMeta):
             response = self._request(
                 "post",
                 table_url,
-                json_data={"records": new_records, "typecast": typecast},
-                options=options,
+                json_data={
+                    "records": new_records,
+                    "typecast": typecast,
+                    "returnFieldsByFieldId": return_fields_by_field_id,
+                },
             )
             inserted_records += response["records"]
             time.sleep(self.API_LIMIT)
@@ -240,7 +251,6 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         fields: dict,
         replace=False,
         typecast=False,
-        **options,
     ) -> List[dict]:
         record_url = self._get_record_url(base_id, table_name, record_id)
 
@@ -249,7 +259,6 @@ class ApiAbstract(metaclass=abc.ABCMeta):
             method,
             record_url,
             json_data={"fields": fields, "typecast": typecast},
-            options=options,
         )
 
     def _batch_update(
@@ -259,7 +268,7 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         records: List[dict],
         replace=False,
         typecast=False,
-        **options,
+        return_fields_by_field_id=False,
     ):
         updated_records = []
         table_url = self.get_table_url(base_id, table_name)
@@ -269,8 +278,11 @@ class ApiAbstract(metaclass=abc.ABCMeta):
             response = self._request(
                 method,
                 table_url,
-                json_data={"records": chunk_records, "typecast": typecast},
-                options=options,
+                json_data={
+                    "records": chunk_records,
+                    "typecast": typecast,
+                    "returnFieldsByFieldId": return_fields_by_field_id,
+                },
             )
             updated_records += response["records"]
             time.sleep(self.API_LIMIT)

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -149,6 +149,10 @@ class Api(ApiAbstract):
             fields: |kwarg_fields|
             sort: |kwarg_sort|
             formula: |kwarg_formula|
+            cell_format: |kwarg_cell_format|
+            user_locale: |kwarg_user_locale|
+            time_zone: |kwarg_time_zone|
+            return_fields_by_field_id: |kwarg_return_fields_by_field_id|
         """
         return super()._first(base_id, table_name, **options)
 
@@ -185,7 +189,14 @@ class Api(ApiAbstract):
         """
         return super()._all(base_id, table_name, **options)
 
-    def create(self, base_id: str, table_name: str, fields: dict, typecast=False):
+    def create(
+        self,
+        base_id: str,
+        table_name: str,
+        fields: dict,
+        typecast=False,
+        return_fields_by_field_id=False,
+    ):
         """
         Creates a new record
 
@@ -200,14 +211,28 @@ class Api(ApiAbstract):
 
         Keyword Args:
             typecast: |kwarg_typecast|
+            return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
             record (``dict``): Inserted record
 
         """
-        return super()._create(base_id, table_name, fields, typecast=typecast)
+        return super()._create(
+            base_id,
+            table_name,
+            fields,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
+        )
 
-    def batch_create(self, base_id: str, table_name: str, records, typecast=False):
+    def batch_create(
+        self,
+        base_id: str,
+        table_name: str,
+        records,
+        typecast=False,
+        return_fields_by_field_id=False,
+    ):
         """
         Breaks records into chunks of 10 and inserts them in batches.
         Follows the set API rate.
@@ -225,11 +250,18 @@ class Api(ApiAbstract):
 
         Keyword Args:
             typecast: |kwarg_typecast|
+            return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
             records (``list``): list of added records
         """
-        return super()._batch_create(base_id, table_name, records, typecast=typecast)
+        return super()._batch_create(
+            base_id,
+            table_name,
+            records,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
+        )
 
     def update(
         self,
@@ -254,7 +286,7 @@ class Api(ApiAbstract):
             table_name: |arg_table_name|
             record_id: |arg_record_id|
             fields(``dict``): Fields to update.
-                Must be dictionary with Column names as Key
+                Must be a dict with column names or IDs as keys
 
         Keyword Args:
             replace (``bool``, optional): If ``True``, record is replaced in its entirety
@@ -283,6 +315,7 @@ class Api(ApiAbstract):
         records: List[dict],
         replace=False,
         typecast=False,
+        return_fields_by_field_id=False,
     ):
         """
         Updates a records by their record id's in batch.
@@ -298,12 +331,18 @@ class Api(ApiAbstract):
                 bet set to null. If False, only provided fields are updated.
                 Default is ``False``.
             typecast: |kwarg_typecast|
+            return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
             records(``list``): list of updated records
         """
         return super()._batch_update(
-            base_id, table_name, records, replace=replace, typecast=typecast
+            base_id,
+            table_name,
+            records,
+            replace=replace,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
         )
 
     def delete(self, base_id: str, table_name: str, record_id: str):

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -87,20 +87,38 @@ class Base(ApiAbstract):
         """
         return super()._all(self.base_id, table_name, **options)
 
-    def create(self, table_name: str, fields: dict, typecast=False):
+    def create(
+        self,
+        table_name: str,
+        fields: dict,
+        typecast=False,
+        return_fields_by_field_id=False,
+    ):
         """
         Same as :meth:`Api.create <pyairtable.api.Api.create>`
         but without ``base_id`` arg.
         """
-        return super()._create(self.base_id, table_name, fields, typecast=typecast)
+        return super()._create(
+            self.base_id,
+            table_name,
+            fields,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
+        )
 
-    def batch_create(self, table_name: str, records, typecast=False):
+    def batch_create(
+        self, table_name: str, records, typecast=False, return_fields_by_field_id=False
+    ):
         """
         Same as :meth:`Api.batch_create <pyairtable.api.Api.batch_create>`
         but without ``base_id`` arg.
         """
         return super()._batch_create(
-            self.base_id, table_name, records, typecast=typecast
+            self.base_id,
+            table_name,
+            records,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
         )
 
     def update(
@@ -125,14 +143,24 @@ class Base(ApiAbstract):
         )
 
     def batch_update(
-        self, table_name: str, records: List[dict], replace=False, typecast=False
+        self,
+        table_name: str,
+        records: List[dict],
+        replace=False,
+        typecast=False,
+        return_fields_by_field_id=False,
     ):
         """
         Same as :meth:`Api.batch_update <pyairtable.api.Api.batch_update>`
         but without ``base_id`` arg.
         """
         return super()._batch_update(
-            self.base_id, table_name, records, replace=replace, typecast=typecast
+            self.base_id,
+            table_name,
+            records,
+            replace=replace,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
         )
 
     def delete(self, table_name: str, record_id: str):

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -96,27 +96,43 @@ class Table(ApiAbstract):
         """
         return super()._all(self.base_id, self.table_name, **options)
 
-    def create(self, fields: dict, typecast=False, **options):
+    def create(
+        self,
+        fields: dict,
+        typecast=False,
+        return_fields_by_field_id=False,
+    ):
         """
         Same as :meth:`Api.create <pyairtable.api.Api.create>`
         but without ``base_id`` and ``table_name`` arg.
         """
         return super()._create(
-            self.base_id, self.table_name, fields, typecast=typecast, **options
+            self.base_id,
+            self.table_name,
+            fields,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
         )
 
-    def batch_create(self, records, typecast=False, **options):
+    def batch_create(
+        self,
+        records,
+        typecast=False,
+        return_fields_by_field_id=False,
+    ):
         """
         Same as :meth:`Api.batch_create <pyairtable.api.Api.batch_create>`
         but without ``base_id`` and ``table_name`` arg.
         """
         return super()._batch_create(
-            self.base_id, self.table_name, records, typecast=typecast, **options
+            self.base_id,
+            self.table_name,
+            records,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
         )
 
-    def update(
-        self, record_id: str, fields: dict, replace=False, typecast=False, **options
-    ):
+    def update(self, record_id: str, fields: dict, replace=False, typecast=False):
         """
         Same as :meth:`Api.update <pyairtable.api.Api.update>`
         but without ``base_id`` and ``table_name`` arg.
@@ -128,11 +144,14 @@ class Table(ApiAbstract):
             fields,
             replace=replace,
             typecast=typecast,
-            **options,
         )
 
     def batch_update(
-        self, records: List[dict], replace=False, typecast=False, **options
+        self,
+        records: List[dict],
+        replace=False,
+        typecast=False,
+        return_fields_by_field_id=False,
     ):
         """
         Same as :meth:`Api.batch_update <pyairtable.api.Api.batch_update>`
@@ -144,7 +163,7 @@ class Table(ApiAbstract):
             records,
             replace=replace,
             typecast=typecast,
-            **options,
+            return_fields_by_field_id=return_fields_by_field_id,
         )
 
     def delete(self, record_id: str):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,8 @@ import pytest
 
 from pyairtable import Base, Table
 
+BASE_ID = "appaPqizdsNHDvlEm"
+
 
 @pytest.fixture
 def base_name():
@@ -31,7 +33,7 @@ def cols():
 
 @pytest.fixture
 def base():
-    base_id = "appaPqizdsNHDvlEm"
+    base_id = BASE_ID
     base = Base(os.environ["AIRTABLE_API_KEY"], base_id)
     yield base
     table_name = "TEST_TABLE"
@@ -41,7 +43,7 @@ def base():
 
 @pytest.fixture
 def table():
-    base_id = "appaPqizdsNHDvlEm"
+    base_id = BASE_ID
     table_name = "TEST_TABLE"
     table = Table(os.environ["AIRTABLE_API_KEY"], base_id, table_name)
     yield table

--- a/tests/integration/test_integration_metadata.py
+++ b/tests/integration/test_integration_metadata.py
@@ -3,8 +3,9 @@ import pytest
 from pyairtable import Base, Table
 from pyairtable.metadata import get_api_bases, get_base_schema, get_table_schema
 
+pytestmark = [pytest.mark.integration]
 
-@pytest.mark.integration
+
 def test_get_api_bases(base: Base, base_name: str):
     rv = get_api_bases(base)
     assert base_name in [b["name"] for b in rv["bases"]]

--- a/tests/integration/test_integration_orm.py
+++ b/tests/integration/test_integration_orm.py
@@ -5,8 +5,9 @@ import pytest
 
 from pyairtable.orm import Model
 from pyairtable.orm import fields as f
+from tests.integration.conftest import BASE_ID
 
-BASE_ID = "appaPqizdsNHDvlEm"
+pytestmark = [pytest.mark.integration]
 
 
 @pytest.fixture
@@ -52,7 +53,6 @@ def Contact(Address):
     table.batch_delete([r["id"] for r in records])
 
 
-@pytest.mark.integration
 def test_integration_orm(Contact, Address):
     STREET = "123 Han"
     address = Address(street=STREET)


### PR DESCRIPTION
The reason this wasn't working before was that we were passing `returnFieldsByFieldId` as a query parameter, when we really needed to include it in the JSON payload in the POST body. This branch fixes that, adds some tests, and does a bit of tidying around the integration test suite.

On further digging, it doesn't look like [Create records](https://airtable.com/developers/web/api/create-records) or [Update records](https://airtable.com/developers/web/api/update-multiple-records) support _any_ of the options (besides this one) which we can pass to [List records](https://airtable.com/developers/web/api/list-records), so I removed the `**options` kwargs from those method signatures.

Fixes #194 