### PR TITLE
Fix readthedocs build failure on `urllib3==2.0.0`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+    - requirements: requirements-dev.txt


### PR DESCRIPTION
Related to #251, we're now seeing readthedocs builds fail (like [this one](https://readthedocs.org/projects/pyairtable/builds/20420433/)). I'm poking at things in the new configuration file format to see how I can get this working again.

Sample traceback:

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyairtable/envs/latest/lib/python3.7/site-packages/sphinx/config.py", line 327, in eval_config_file
    exec(code, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyairtable/checkouts/latest/docs/source/conf.py", line 7, in <module>
    from pyairtable import __version__ as version
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyairtable/envs/latest/lib/python3.7/site-packages/pyairtable-1.4.0-py3.7.egg/pyairtable/__init__.py", line 3, in <module>
    from .api import Api, Base, Table  # noqa
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyairtable/envs/latest/lib/python3.7/site-packages/pyairtable-1.4.0-py3.7.egg/pyairtable/api/__init__.py", line 1, in <module>
    from .api import Api  # noqa
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyairtable/envs/latest/lib/python3.7/site-packages/pyairtable-1.4.0-py3.7.egg/pyairtable/api/api.py", line 3, in <module>
    from .abstract import ApiAbstract, TimeoutTuple
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyairtable/envs/latest/lib/python3.7/site-packages/pyairtable-1.4.0-py3.7.egg/pyairtable/api/abstract.py", line 8, in <module>
    import requests
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyairtable/envs/latest/lib/python3.7/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyairtable/envs/latest/lib/python3.7/site-packages/urllib3/__init__.py", line 39, in <module>
    "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168
```