### PR TITLE
Fix typos in documentation code blocks

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -89,8 +89,8 @@ table, whichever is shorter.
 
   >>> for records in table.iterate(page_size=100, max_records=1000):
   ...     print(records)
-  [{id:'rec123asa23', fields': {'Last Name': 'Alfred', "Age": 84}, ...}, ... ]
-  [{id:'rec123asa23', fields': {'Last Name': 'Jameson', "Age": 42}, ...}, ... ]
+  [{'id': 'rec123asa23', 'fields': {'Last Name': 'Alfred', 'Age': 84}, ...}, ...]
+  [{'id': 'rec123asa23', 'fields': {'Last Name': 'Jameson', 'Age': 42}, ...}, ...]
 
 :meth:`~pyairtable.api.Table.all`
 
@@ -100,7 +100,7 @@ hood it uses :meth:`~pyairtable.api.Table.iterate` to fetch records so multiple 
 .. code-block:: python
 
   >>> table.all(sort=["First Name", "-Age"]):
-  [{id:'rec123asa23', fields': {'Last Name': 'Alfred', "Age": 84}, ...}, ... ]
+  [{'id': 'rec123asa23', 'fields': {'Last Name': 'Alfred', 'Age': 84}, ...}, ...]
 
 
 Creating Records
@@ -113,7 +113,7 @@ Creates a single record from a dictionary representing the table's fields.
 .. code-block:: python
 
   >>> table.create({'First Name': 'John'})
-  {id:'rec123asa23', fields': {'First Name': 'John', ...}}
+  {'id': 'rec123asa23', 'fields': {'First Name': 'John', ...}}
 
 
 :meth:`~pyairtable.api.Table.batch_create`
@@ -123,7 +123,7 @@ Batch create records from a list of dictionaries representing the table's fields
 .. code-block:: python
 
   >>> table.batch_create([{'First Name': 'John'}, ...])
-  [{id:'rec123asa23', fields': {'First Name': 'John', ...}}, ...]
+  [{'id': 'rec123asa23', 'fields': {'First Name': 'John'}}, ...]
 
 
 Updating Records
@@ -137,7 +137,7 @@ dictionary representing the table's fields.
 .. code-block:: python
 
   >>> table.update('recwPQIfs4wKPyc9D', {"Age": 21})
-  [{id:'recwPQIfs4wKPyc9D', fields': {"First Name": "John", "Age": 21, ...}}, ...]
+  [{'id': 'recwPQIfs4wKPyc9D', 'fields': {"First Name": "John", "Age": 21}}, ...]
 
 
 :meth:`~pyairtable.api.Table.batch_update`
@@ -147,7 +147,7 @@ Batch update records from a list of records.
 .. code-block:: python
 
   >>> table.batch_update([{"id": "recwPQIfs4wKPyc9D", "fields": {"First Name": "Matt"}}, ...])
-  [{id:'recwPQIfs4wKPyc9D', fields': {"First Name": "Matt", "Age": 21, ...}}, ...]
+  [{'id': 'recwPQIfs4wKPyc9D', 'fields': {"First Name": "Matt", ...}}, ...]
 
 
 Deleting Records
@@ -160,7 +160,7 @@ Deletes a single record using the provided ``record_id``.
 .. code-block:: python
 
   >>> table.delete('recwPQIfs4wKPyc9D')
-  { "deleted": True, ... }
+  {'deleted': True, 'id': 'recwPQIfs4wKPyc9D'}
 
 :meth:`~pyairtable.api.Table.batch_delete`
 
@@ -168,8 +168,9 @@ Batch delete records using a list of record ids.
 
 .. code-block:: python
 
-  >>> table.batch_delete(['recwPQIfs4wKPyc9D', 'recwAcQdqwe21as'])
-  [  { "deleted": True, ... }, ... ]
+  >>> table.batch_delete(['recwPQIfs4wKPyc9D', 'recwAcQdqwe21asdf'])
+  [{'deleted': True, 'id': 'recwPQIfs4wKPyc9D'},
+   {'deleted': True, 'id': 'recwAcQdqwe21asdf'}]
 
 
 Return Values
@@ -181,43 +182,46 @@ will most often be a list of Airtable records (dictionary) in a format as shown 
 .. code-block:: python
 
   >>> table.all()
-  ... [{
-  ...     "records": [
-  ...         {
-  ...             "id": "recwPQIfs4wKPyc9D",
-  ...             "fields": {
-  ...                 "COLUMN_ID": "1",
-  ...             },
-  ...             "createdTime": "2017-03-14T22:04:31.000Z"
-  ...         },
-  ...         {
-  ...             "id": "rechOLltN9SpPHq5o",
-  ...             "fields": {
-  ...                 "COLUMN_ID": "2",
-  ...             },
-  ...             "createdTime": "2017-03-20T15:21:50.000Z"
-  ...         },
-  ...         {
-  ...             "id": "rec5eR7IzKSAOBHCz",
-  ...             "fields": {
-  ...                 "COLUMN_ID": "3",
-  ...             },
-  ...             "createdTime": "2017-08-05T21:47:52.000Z"
-  ...         }
-  ...     ],
-  ...     "offset": "rec5eR7IzKSAOBHCz"
-  ... }, ... ]
+  [
+      {
+          "records": [
+              {
+                  "id": "recwPQIfs4wKPyc9D",
+                  "fields": {
+                      "COLUMN_ID": "1",
+                  },
+                  "createdTime": "2017-03-14T22:04:31.000Z"
+              },
+              {
+                  "id": "rechOLltN9SpPHq5o",
+                  "fields": {
+                      "COLUMN_ID": "2",
+                  },
+                  "createdTime": "2017-03-20T15:21:50.000Z"
+              },
+              {
+                  "id": "rec5eR7IzKSAOBHCz",
+                  "fields": {
+                      "COLUMN_ID": "3",
+                  },
+                  "createdTime": "2017-08-05T21:47:52.000Z"
+              }
+          ],
+          "offset": "rec5eR7IzKSAOBHCz"
+      },
+      ...
+  ]
 
 
-The :class:`~pyairtable.api.Base` class is similar to :class:`~pyairtable.api.Table`, the main difference is that .
+The :class:`~pyairtable.api.Base` class is similar to :class:`~pyairtable.api.Table`, the main difference is that
 `table_name` is not provided during initialization. Instead, it can be
 specified on each request.
 
 .. code-block:: python
 
   >>> base = Base('auth_token', 'base_id')
-  >>> base.all('Contacts)
-  [{id:'rec123asa23', fields': {'Last Name': 'Alfred', "Age": 84}, ... ]
+  >>> base.all('Contacts')
+  [{'id': 'rec123asa23', 'fields': {'Last Name': 'Alfred', 'Age': 84}, ...]
 
 
 -------------------------
@@ -357,7 +361,6 @@ against a Python dictionary:
 
   >>> from pyairtable import Table
   >>> from pyairtable.formulas import match
-  >>>
   >>> table = Table("auth_token", "base_id", "Contact")
   >>> formula = match({"First Name": "John", "Age": 21})
   >>> table.first(formula=formula)

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -51,12 +51,26 @@ or update your records:
     >>> api_key = os.environ['AIRTABLE_API_KEY']
     >>> table = Table(api_key, 'base_id', 'table_name')
     >>> table.all()
-    [ {"id": "rec5eR7IzKSAOBHCz", "fields": { ... }}]
+    [
+        {
+            "id": "rec5eR7IzKSAOBHCz",
+            "createdTime": "2017-03-14T22:04:31.000Z",
+            "fields": {...}
+        }
+    ]
     >>> table.create({"Foo": "Bar"})
-    {"id": "recwAcQdqwe21as", "fields": { "Foo": "Bar" }}]
-    >>> table.update("recwAcQdqwe21as", {"Foo": "Foo"})
-    {"id": "recwAcQdqwe21as", "fields": { "Foo": "Foo" }}]
-    >>> table.delete("recwAcQdqwe21as")
-    True
+    {
+        "id": "recwAcQdqwe21asdf",
+        "createdTime": "...",
+        "fields": {"Foo": "Bar"}
+    }
+    >>> table.update("recwAcQdqwe21asdf", {"Foo": "Foo"})
+    {
+        "id": "recwAcQdqwe21asdf",
+        "createdTime": "...",
+        "fields": {"Foo": "Foo"}
+    }
+    >>> table.delete("recwAcQdqwe21asdf")
+    {'id': 'recwAcQdqwe21asdf', 'deleted': True}
 
 For more details on the available classes and methods check out the :doc:`api` section.


### PR DESCRIPTION
These are pretty straightforward, so I'll plan to merge them tomorrow if there are no comments. For the 2.0 release I'd like to use doctest to actually run these examples and make sure they work, but that'll require some extra effort around mocking the API.