### PR TITLE
{Api,Base,Table}.batch_upsert and docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -150,6 +150,20 @@ Batch update records from a list of records.
   [{'id': 'recwPQIfs4wKPyc9D', 'fields': {"First Name": "Matt", ...}}, ...]
 
 
+:meth:`~pyairtable.api.Table.batch_upsert`
+
+Batch upsert (create or update) records from a list of records. For details on the behavior
+of this Airtable API endpoint, see `Update multiple records <https://airtable.com/developers/web/api/update-multiple-records#request-performupsert-fieldstomergeon>`_.
+
+.. code-block:: python
+
+  >>> table.batch_upsert(
+  ...     [{"id": "recwPQIfs4wKPyc9D", "fields": {"First Name": "Matt"}}, ...],
+  ...     key_fields=["First Name"]
+  ... )
+  [{'id': 'recwPQIfs4wKPyc9D', 'fields': {'First Name': 'Matt', 'Age': 21, ...}}, ...]
+
+
 Deleting Records
 -----------------
 

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -345,6 +345,48 @@ class Api(ApiAbstract):
             return_fields_by_field_id=return_fields_by_field_id,
         )
 
+    def batch_upsert(
+        self,
+        base_id: str,
+        table_name: str,
+        records: List[dict],
+        key_fields: List[str],
+        replace=False,
+        typecast=False,
+        return_fields_by_field_id=False,
+    ):
+        """
+        Updates or creates records in batches, either using ``id`` (if given) or using a set of
+        fields (``key_fields``) to look for matches. For more information on the mechanics,
+        see `Update multiple records <https://airtable.com/developers/web/api/update-multiple-records#request-performupsert-fieldstomergeon>`_.
+
+        Args:
+            base_id: |arg_base_id|
+            table_name: |arg_table_name|
+            records (``list``): List of dict: [{"id": record_id, "fields": fields_to_update_dict}]
+            key_fields (``list``): List of field names that Airtable should use to match
+                records in the input with existing records on the server.
+
+        Keyword Args:
+            replace (``bool``, optional): If ``True``, record is replaced in its entirety
+                by provided fields - e.g. if a field is not included its value will
+                bet set to null. If False, only provided fields are updated.
+                Default is ``False``.
+            typecast: |kwarg_typecast|
+
+        Returns:
+            records (``list``): list of updated records
+        """
+        return super()._batch_upsert(
+            base_id=base_id,
+            table_name=table_name,
+            records=records,
+            key_fields=key_fields,
+            replace=replace,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
+        )
+
     def delete(self, base_id: str, table_name: str, record_id: str):
         """
         Deletes a record by its id

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -357,8 +357,10 @@ class Api(ApiAbstract):
     ):
         """
         Updates or creates records in batches, either using ``id`` (if given) or using a set of
-        fields (``key_fields``) to look for matches. For more information on the mechanics,
-        see `Update multiple records <https://airtable.com/developers/web/api/update-multiple-records#request-performupsert-fieldstomergeon>`_.
+        fields (``key_fields``) to look for matches. For more information on how this operation
+        behaves, see Airtable's API documentation for `Update multiple records <https://airtable.com/developers/web/api/update-multiple-records#request-performupsert-fieldstomergeon>`_.
+
+        .. versionadded:: 1.5.0
 
         Args:
             base_id: |arg_base_id|
@@ -373,6 +375,7 @@ class Api(ApiAbstract):
                 bet set to null. If False, only provided fields are updated.
                 Default is ``False``.
             typecast: |kwarg_typecast|
+            return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
             records (``list``): list of updated records

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -163,6 +163,29 @@ class Base(ApiAbstract):
             return_fields_by_field_id=return_fields_by_field_id,
         )
 
+    def batch_upsert(
+        self,
+        table_name: str,
+        records: List[dict],
+        key_fields: List[str],
+        replace=False,
+        typecast=False,
+        return_fields_by_field_id=False,
+    ):
+        """
+        Same as :meth:`Api.batch_upsert <pyairtable.api.Api.batch_upsert>`
+        but without ``base_id`` arg.
+        """
+        return super()._batch_upsert(
+            self.base_id,
+            table_name,
+            records,
+            key_fields=key_fields,
+            replace=replace,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
+        )
+
     def delete(self, table_name: str, record_id: str):
         """
         Same as :meth:`Api.delete <pyairtable.api.Api.delete>`

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -166,6 +166,28 @@ class Table(ApiAbstract):
             return_fields_by_field_id=return_fields_by_field_id,
         )
 
+    def batch_upsert(
+        self,
+        records: List[dict],
+        key_fields: List[str],
+        replace=False,
+        typecast=False,
+        return_fields_by_field_id=False,
+    ):
+        """
+        Same as :meth:`Api.batch_upsert <pyairtable.api.Api.batch_upsert>`
+        but without ``base_id`` and ``table_name`` arg.
+        """
+        return super()._batch_upsert(
+            self.base_id,
+            self.table_name,
+            records,
+            key_fields=key_fields,
+            replace=replace,
+            typecast=typecast,
+            return_fields_by_field_id=return_fields_by_field_id,
+        )
+
     def delete(self, record_id: str):
         """
         Same as :meth:`Api.delete <pyairtable.api.Api.delete>`

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,6 +24,7 @@ def cols():
         TEXT = "text"  # Text
         TEXT_ID = "fldzbVdWW4xJdZ1em"  # for returnFieldsByFieldId
         NUM = "number"  # Number, float
+        NUM_ID = "fldFLyuxGuWobyMV2"  # for returnFieldsByFieldId
         BOOL = "boolean"  # Boolean
         DATETIME = "datetime"  # Datetime
         ATTACHMENT = "attachment"  # attachment

--- a/tests/integration/test_integration_orm.py
+++ b/tests/integration/test_integration_orm.py
@@ -90,7 +90,6 @@ def test_integration_orm(Contact, Address):
     assert rv_address_2.street == rv_address.street == STREET
 
 
-@pytest.mark.integration
 def test_undeclared_fields():
     """
     Test that if our ORM is missing some fields, it does not fail on retrieval


### PR DESCRIPTION
This adds support and documentation for the `performUpsert` mechanism described in [Update multiple records](https://airtable.com/developers/web/api/update-multiple-records).

One thing that might merit discussion: Before making any API calls, this implementation will validate that each record provided has the required "key fields", so that implementers don't have to worry about a single malformed record halting an incomplete operation (and we don't have to worry about how to represent that scenario). There are a lot of circumstances where I don't think we should be second-guessing what an implementer passes into the library; in this case we can _reliably_ predict a failure, so I think we should save them the trouble.

This would close #209 and resolve #216. @marks @dhanaschenniappan @marekvigas FYI