### PR TITLE
Release 1.5.0

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -152,6 +152,8 @@ Batch update records from a list of records.
 
 :meth:`~pyairtable.api.Table.batch_upsert`
 
+.. versionadded:: 1.5.0
+
 Batch upsert (create or update) records from a list of records. For details on the behavior
 of this Airtable API endpoint, see `Update multiple records <https://airtable.com/developers/web/api/update-multiple-records#request-performupsert-fieldstomergeon>`_.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,9 +7,9 @@ Changelog
 
 Release Date: 2023-05-15
 
-* Add support for Airtable's upsert operation (see `Updating Records`).
+* Add support for Airtable's upsert operation (see :ref:`Updating Records`).
   - `PR #255 <https://github.com/gtalarico/pyairtable/pull/255>`_.
-* Fix ``return_fields_by_field_id`` behavior on create/update API calls.
+* Fix ``return_fields_by_field_id`` in :meth:`~pyairtable.api.Api.batch_create` and :meth:`~pyairtable.api.Api.batch_update`.
   - `PR #252 <https://github.com/gtalarico/pyairtable/pull/252>`_.
 * Fix ORM crash when Airtable returned additional fields.
   - `PR #250 <https://github.com/gtalarico/pyairtable/pull/250>`_.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,21 +2,39 @@
 Changelog
 =========
 
-.. warning::
-    Looking for airtable-python-wrapper changelog? See :doc:`migrations`.
+1.5.0
+------
 
-1.5.0 (unreleased)
--------------------
-* Added ``endpoint_url=`` param to :class:`~pyairtable.api.Table`, :class:`~pyairtable.api.Base`, :class:`~pyairtable.api.Api`
+Release Date: 2023-05-15
+
+* Add support for Airtable's upsert operation (see `Updating Records`).
+  - `PR #255 <https://github.com/gtalarico/pyairtable/pull/255>`_.
+* Fix ``return_fields_by_field_id`` behavior on create/update API calls.
+  - `PR #252 <https://github.com/gtalarico/pyairtable/pull/252>`_.
+* Fix ORM crash when Airtable returned additional fields.
+  - `PR #250 <https://github.com/gtalarico/pyairtable/pull/250>`_.
+* Use POST for URLs that are longer than the 16k character limit set by the Airtable API.
+  - `PR #247 <https://github.com/gtalarico/pyairtable/pull/247>`_.
+* Added ``endpoint_url=`` param to :class:`~pyairtable.api.Table`, :class:`~pyairtable.api.Base`, :class:`~pyairtable.api.Api`.
   - `PR #243 <https://github.com/gtalarico/pyairtable/pull/243>`_.
+* Added ORM :class:`~pyairtable.orm.fields.LookupField`.
+  - `PR #182 <https://github.com/gtalarico/pyairtable/pull/182>`_.
+* Dropped support for Python 3.6 (reached end of life 2021-12-23)
+  - `PR #213 <https://github.com/gtalarico/pyairtable/pull/213>`_.
 
 1.4.0
 ------
+
+Release Date: 2022-12-14
+
 * Added :ref:`Retrying` ()
 * Misc fix in sleep for batch requests `PR #180 <https://github.com/gtalarico/pyairtable/pull/180>`_.
 
 1.3.0
 ------
+
+Release Date: 2022-08-23
+
 * Added new ``LOWER`` formula - `PR #171 <https://github.com/gtalarico/pyairtable/pull/171>`_. See updated :ref:`Formulas`.
 * Added ``match(..., match_any=True)`` to :meth:`~pyairtable.formulas.match`
 * Added ``return_fields_by_field_id`` in :meth:`~pyairtable.api.Api.get`

--- a/pyairtable/__init__.py
+++ b/pyairtable/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 from .api import Api, Base, Table  # noqa
 from .api.retrying import retry_strategy  # noqa

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -205,7 +205,11 @@ class DateField(Field):
 
 
 class LookupField(Field):
-    """Airtable Lookup Fields. Uses ``list`` to store value"""
+    """
+    Airtable Lookup Fields. Uses ``list`` to store value
+
+    .. versionadded:: 1.5.0
+    """
 
     def __init__(self, field_name, model: Optional[Type[T_Linked]] = None) -> None:
         if isinstance(model, str):


### PR DESCRIPTION
I think we've got everything done that we said we would do in #249 for the 1.5.0 release. Here's an updated changelog and some "Added in 1.5.0" notes on the bits of the API that are new. 

I'll leave this open for the week to give us time to spot any last minute changes needed, and plan to push to PyPI on May 15.