### PR TITLE
Support readonly fields and all Airtable field types in ORM

### DIFF
--- a/docs/source/orm.rst
+++ b/docs/source/orm.rst
@@ -22,4 +22,46 @@ Fields
 ******
 
 .. automodule:: pyairtable.orm.fields
-    :members:
+
+
+Field Types
+-----------
+.. autoclass:: pyairtable.orm.fields.AutoNumberField
+.. autoclass:: pyairtable.orm.fields.BarcodeField
+.. autoclass:: pyairtable.orm.fields.ButtonField
+.. autoclass:: pyairtable.orm.fields.CheckboxField
+.. autoclass:: pyairtable.orm.fields.CollaboratorField
+.. autoclass:: pyairtable.orm.fields.CountField
+.. autoclass:: pyairtable.orm.fields.CreatedByField
+.. autoclass:: pyairtable.orm.fields.CreatedTimeField
+.. autoclass:: pyairtable.orm.fields.CurrencyField
+.. autoclass:: pyairtable.orm.fields.DateField
+.. autoclass:: pyairtable.orm.fields.DatetimeField
+.. autoclass:: pyairtable.orm.fields.DurationField
+.. autoclass:: pyairtable.orm.fields.EmailField
+.. autoclass:: pyairtable.orm.fields.ExternalSyncSourceField
+.. autoclass:: pyairtable.orm.fields.FloatField
+.. autoclass:: pyairtable.orm.fields.IntegerField
+.. autoclass:: pyairtable.orm.fields.LastModifiedByField
+.. autoclass:: pyairtable.orm.fields.LastModifiedTimeField
+.. autoclass:: pyairtable.orm.fields.LinkField
+.. autoclass:: pyairtable.orm.fields.ListField
+.. autoclass:: pyairtable.orm.fields.LookupField
+.. autoclass:: pyairtable.orm.fields.MultipleAttachmentsField
+.. autoclass:: pyairtable.orm.fields.MultipleCollaboratorsField
+.. autoclass:: pyairtable.orm.fields.MultipleSelectField
+.. autoclass:: pyairtable.orm.fields.NumberField
+.. autoclass:: pyairtable.orm.fields.PercentField
+.. autoclass:: pyairtable.orm.fields.PhoneNumberField
+.. autoclass:: pyairtable.orm.fields.RatingField
+.. autoclass:: pyairtable.orm.fields.RichTextField
+.. autoclass:: pyairtable.orm.fields.SelectField
+.. autoclass:: pyairtable.orm.fields.TextField
+.. autoclass:: pyairtable.orm.fields.UrlField
+
+
+Constants
+---------
+.. autodata:: pyairtable.orm.fields.ALL_FIELDS
+.. autodata:: pyairtable.orm.fields.READONLY_FIELDS
+.. autodata:: pyairtable.orm.fields.FIELD_TYPES_TO_CLASSES

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -78,6 +78,9 @@ class Field(metaclass=abc.ABCMeta):
     #: Types that are allowed to be passed to this field.
     valid_types: ClassVar["_ClassInfo"] = ()
 
+    #: The value we'll use when a field value is not present in the record.
+    value_if_missing: ClassVar[Any] = None
+
     def __init__(self, field_name, validate_type=True) -> None:
         self.field_name = field_name
         self.validate_type = True
@@ -95,7 +98,7 @@ class Field(metaclass=abc.ABCMeta):
             # Field Field is not yet in dict, return None
             return instance._fields[field_name]
         except (KeyError, AttributeError):
-            return None
+            return self.value_if_missing
 
     def __set__(self, instance, value):
         if not hasattr(instance, "_fields"):
@@ -178,6 +181,7 @@ class CheckboxField(Field):
     """Airtable Checkbox field. Uses ``bool`` to store value"""
 
     valid_types = bool
+    value_if_missing = False
 
     def to_internal_value(self, value: Any) -> bool:
         return bool(value)

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -88,10 +88,10 @@ class Field(metaclass=abc.ABCMeta):
     def __set_name__(self, owner, name):
         self.attribute_name = name
 
-    def __get__(self, instance, cls=None):
-        # Raise if descriptor is called on class, where instance is None
+    def __get__(self, instance, owner):
+        # allow calling Model.field to get the field object instead of a value
         if not instance:
-            raise RuntimeError("cannot access descriptors on class")
+            return self
 
         field_name = self.field_name
         try:

--- a/pyairtable/testing.py
+++ b/pyairtable/testing.py
@@ -56,3 +56,19 @@ def fake_record(fields=None, id=None, **other_fields):
         "createdTime": datetime.datetime.now().isoformat() + "Z",
         "fields": {**(fields or {}), **other_fields},
     }
+
+
+def fake_user(value=None):
+    id = fake_id("usr", value)
+    return {"id": id, "email": f"{value or id}@example.com"}
+
+
+def fake_attachment(**kwargs):
+    return {
+        "id": fake_id("att"),
+        "url": "https://example.com/",
+        "filename": "foo.txt",
+        "size": 100,
+        "type": "text/plain",
+        **kwargs,
+    }

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -11,6 +11,19 @@ from pyairtable.testing import fake_meta, fake_record
 
 
 def test_model_missing_meta():
+    """
+    Test that we throw an exception if Meta is missing.
+    """
+    with pytest.raises(AttributeError):
+
+        class Address(Model):
+            street = f.TextField("Street")
+
+
+def test_model_missing_meta_attribute():
+    """
+    Test that we throw an exception if Meta is missing a required attribute.
+    """
     with pytest.raises(ValueError):
 
         class Address(Model):
@@ -20,6 +33,17 @@ def test_model_missing_meta():
                 base_id = "required"
                 table_name = "required"
                 # api_key = "required"
+
+
+def test_model_empty_meta():
+    """
+    Test that we throw an exception when a required Meta attribute is None.
+    """
+    with pytest.raises(ValueError):
+
+        class Address(Model):
+            Meta = fake_meta(api_key=None)
+            street = f.TextField("Street")
 
 
 def test_model_overlapping():

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -117,7 +117,6 @@ def test_from_record():
             "fields": {"First Name": "X", "Timestamp": "2014-09-05T12:34:56.000Z"},
         }
         contact = Contact.from_id("recwnBLPIeQJoYVt4")
-        assert m_get.called
 
     assert m_get.called
     assert contact.id == "recwnBLPIeQJoYVt4"

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -1,6 +1,18 @@
+import datetime
+
 import pytest
 
 from pyairtable.orm import fields as f
+from pyairtable.orm.model import Model
+from tests.test_orm import fake_meta
+
+
+def fake_record(fields=None, **other_fields):
+    return {
+        "id": "recFakeTestingRec",
+        "createdTime": datetime.datetime.now().isoformat(),
+        "fields": {**(fields or {}), **other_fields},
+    }
 
 
 def test_field():
@@ -13,19 +25,102 @@ def test_field():
     assert t.__dict__["_fields"]["Name"] == "x"
 
 
-def test_field_types():
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Test",
+        1,
+        1.5,
+        True,
+        datetime.date.today(),
+        datetime.datetime.now(),
+        list(),
+        dict(),
+    ],
+    ids=type,
+)
+@pytest.mark.parametrize(
+    "field_type",
+    [
+        f.TextField,
+        f.EmailField,
+        f.NumberField,
+        f.IntegerField,
+        f.FloatField,
+        f.CheckboxField,
+        f.DateField,
+        f.DatetimeField,
+    ],
+)
+def test_type_validation(field_type, value):
+    """
+    Test that attempting to assign the wrong type of value to a field
+    will throw TypeError, but the right kind of value will work.
+    """
+
     class T:
-        name = f.TextField("Name")
-        check = f.CheckboxField("Check")
-        email = f.EmailField("Email")
+        the_field = field_type("Field Name")
 
     t = T()
-    t.name = "name"
-    t.check = True
-    t.email = "x@x.com"
-    assert t.name == "name"
-    assert t.check is True
-    assert t.email == "x@x.com"
+    if isinstance(value, field_type.valid_types):
+        t.the_field = value
+    else:
+        with pytest.raises(TypeError):
+            t.the_field = value
+
+
+@pytest.mark.parametrize(
+    argnames=("field_type", "value"),
+    argvalues=[
+        (f.TextField, "name"),
+        (f.EmailField, "x@y.com"),
+        (f.NumberField, 1),
+        (f.NumberField, 1.5),
+        (f.IntegerField, 1),
+        (f.FloatField, 1.5),
+        (f.CheckboxField, True),
+        (f.CheckboxField, False),
+    ],
+)
+def test_value_preserved(field_type, value):
+    """
+    Test that the ORM does not modify values that can be persisted as-is.
+    """
+
+    class T(Model):
+        Meta = fake_meta()
+        the_field = field_type("Field Name")
+
+    new_obj = T()
+    new_obj.the_field = value
+    assert new_obj.to_record()["fields"] == {"Field Name": value}
+
+    existing_obj = T.from_record(fake_record({"Field Name": value}))
+    assert existing_obj.the_field == value
+
+
+@pytest.mark.parametrize(
+    argnames=("field_type", "api_value", "orm_value"),
+    argvalues=[
+        (f.DateField, "2023-01-01", datetime.date(2023, 1, 1)),
+        (f.DatetimeField, "2023-04-12T09:30:00.000Z", datetime.datetime(2023, 4, 12, 9, 30, 0)),  # fmt: skip
+    ],
+)
+def test_value_converted(field_type, api_value, orm_value):
+    """
+    Test that each ORM field type converts correctly in both directions.
+    """
+
+    class T(Model):
+        Meta = fake_meta()
+        the_field = field_type("Field Name")
+
+    new_obj = T()
+    new_obj.the_field = orm_value
+    assert new_obj.to_record()["fields"] == {"Field Name": api_value}
+
+    existing_obj = T.from_record(fake_record({"Field Name": api_value}))
+    assert existing_obj.the_field == orm_value
 
 
 @pytest.mark.skip("TODO")

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -159,11 +159,9 @@ def test_datetime_field():
     class T:
         dt = f.DatetimeField("Datetime")
 
-    field = T.__dict__["dt"]
-
     dt_str_from_airtable = "2000-01-02T03:04:05.000Z"
-    rv_dt = field.to_internal_value(dt_str_from_airtable)
-    rv_str = field.to_record_value(rv_dt)
+    rv_dt = T.dt.to_internal_value(dt_str_from_airtable)
+    rv_str = T.dt.to_record_value(rv_dt)
     assert rv_str == dt_str_from_airtable
 
     assert (
@@ -180,11 +178,9 @@ def test_date_field():
     class T:
         date = f.DateField("Date")
 
-    field = T.__dict__["date"]
-
     date_str_from_airtable = "2000-01-02"
-    rv_date = field.to_internal_value(date_str_from_airtable)
-    rv_str = field.to_record_value(rv_date)
+    rv_date = T.date.to_internal_value(date_str_from_airtable)
+    rv_str = T.date.to_record_value(rv_date)
     assert rv_str == date_str_from_airtable
 
     assert rv_date.year == 2000 and rv_date.month == 1 and rv_date.day == 2
@@ -194,11 +190,9 @@ def test_lookup_field():
     class T:
         items = f.LookupField("Items")
 
-    field = T.__dict__["items"]
-
     lookup_from_airtable = ["Item 1", "Item 2", "Item 3"]
-    rv_list = field.to_internal_value(lookup_from_airtable)
-    rv_json = field.to_record_value(rv_list)
+    rv_list = T.items.to_internal_value(lookup_from_airtable)
+    rv_json = T.items.to_record_value(rv_list)
     assert rv_json == lookup_from_airtable
     assert isinstance(rv_list, list)
     assert rv_list[0] == "Item 1" and rv_list[1] == "Item 2" and rv_list[2] == "Item 3"
@@ -206,15 +200,13 @@ def test_lookup_field():
     class T:
         events = f.LookupField("Event times", model=f.DatetimeField)
 
-    field = T.__dict__["events"]
-
     lookup_from_airtable = [
         "2000-01-02T03:04:05.000Z",
         "2000-02-02T03:04:05.000Z",
         "2000-03-02T03:04:05.000Z",
     ]
-    rv_to_internal = field.to_internal_value(lookup_from_airtable)
-    rv_to_record = field.to_record_value(rv_to_internal)
+    rv_to_internal = T.events.to_internal_value(lookup_from_airtable)
+    rv_to_record = T.events.to_record_value(rv_to_internal)
     assert rv_to_record == lookup_from_airtable
     assert isinstance(rv_to_internal, list)
     assert (

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -1,18 +1,16 @@
 import datetime
+import operator
 
 import pytest
 
 from pyairtable.orm import fields as f
 from pyairtable.orm.model import Model
-from tests.test_orm import fake_meta
+from pyairtable.testing import fake_attachment, fake_meta, fake_record, fake_user
 
-
-def fake_record(fields=None, **other_fields):
-    return {
-        "id": "recFakeTestingRec",
-        "createdTime": datetime.datetime.now().isoformat(),
-        "fields": {**(fields or {}), **other_fields},
-    }
+DATE_S = "2023-01-01"
+DATE_V = datetime.date(2023, 1, 1)
+DATETIME_S = "2023-04-12T09:30:00.000Z"
+DATETIME_V = datetime.datetime(2023, 4, 12, 9, 30, 0)
 
 
 def test_field():
@@ -31,21 +29,18 @@ def test_field():
 @pytest.mark.parametrize(
     argnames=("field_type", "default_value"),
     argvalues=[
-        (f.TextField, None),
+        (f.Field, None),
         (f.CheckboxField, False),
-        (f.EmailField, None),
-        (f.NumberField, None),
-        (f.IntegerField, None),
-        (f.FloatField, None),
-        (f.DateField, None),
-        (f.DatetimeField, None),
-        (f.LookupField, None),  # TODO: should this be empty list?
+        (f.ListField, []),
+        (f.LookupField, []),
+        (f.MultipleCollaboratorsField, []),
+        (f.MultipleSelectField, []),
     ],
 )
 def test_orm_missing_values(field_type, default_value):
     """
-    Test that each ORM field type produces the correct default value
-    when a field is missing a value.
+    Test that certain field types produce the correct default value
+    when there is no field value provided from Airtable.
     """
 
     class T:
@@ -55,95 +50,163 @@ def test_orm_missing_values(field_type, default_value):
     assert t.the_field == default_value
 
 
+# Mapping from types to a test value for that type.
+TYPE_VALIDATION_TEST_VALUES = {
+    **{t: t() for t in (str, bool, list, dict, set, tuple)},
+    int: 1,  # cannot use int() because RatingField requires value >= 1
+    float: 1.0,  # cannot use float() because RatingField requires value >= 1
+    datetime.date: datetime.date.today(),
+    datetime.datetime: datetime.datetime.now(),
+    datetime.timedelta: datetime.timedelta(seconds=1),
+}
+
+
 @pytest.mark.parametrize(
-    "value",
+    "test_case",
     [
-        "Test",
-        1,
-        1.5,
-        True,
-        datetime.date.today(),
-        datetime.datetime.now(),
-        list(),
-        dict(),
+        (f.TextField, str),
+        (f.IntegerField, int),
+        (f.RichTextField, str),
+        (f.DatetimeField, datetime.datetime),
+        (f.TextField, str),
+        (f.CheckboxField, bool),
+        (f.BarcodeField, dict),
+        (f.NumberField, (int, float)),
+        (f.PhoneNumberField, str),
+        (f.DurationField, datetime.timedelta),
+        (f.RatingField, int),
+        (f.ListField, (list, tuple, set)),
+        (f.UrlField, str),
+        (f.LookupField, (list, tuple, set)),
+        (f.MultipleSelectField, (list, tuple, set)),
+        (f.PercentField, (int, float)),
+        (f.DateField, (datetime.date, datetime.datetime)),
+        (f.FloatField, float),
+        (f.CollaboratorField, dict),
+        (f.SelectField, str),
+        (f.EmailField, str),
+        (f.MultipleCollaboratorsField, (list, tuple, set)),
+        (f.CurrencyField, (int, float)),
     ],
-    ids=type,
+    ids=operator.itemgetter(0),
 )
-@pytest.mark.parametrize(
-    "field_type",
-    [
-        f.TextField,
-        f.EmailField,
-        f.NumberField,
-        f.IntegerField,
-        f.FloatField,
-        f.CheckboxField,
-        f.DateField,
-        f.DatetimeField,
-    ],
-)
-def test_type_validation(field_type, value):
+def test_type_validation(test_case):
     """
     Test that attempting to assign the wrong type of value to a field
     will throw TypeError, but the right kind of value will work.
     """
+    field_type, accepted_types = test_case
+    if isinstance(accepted_types, type):
+        accepted_types = [accepted_types]
 
     class T:
         the_field = field_type("Field Name")
+        unvalidated_field = field_type("Unvalidated", validate_type=False)
 
     t = T()
-    if isinstance(value, field_type.valid_types):
-        t.the_field = value
-    else:
-        with pytest.raises(TypeError):
-            t.the_field = value
+
+    for testing_type, test_value in TYPE_VALIDATION_TEST_VALUES.items():
+        # This statement should not raise an exception, no matter what. Caveat emptor.
+        t.unvalidated_field = test_value
+
+        if testing_type in accepted_types:
+            t.the_field = test_value
+        else:
+            with pytest.raises(TypeError):
+                t.the_field = test_value
+                pytest.fail(
+                    f"{field_type.__name__} = {test_value!r} {testing_type} did not raise TypeError"
+                )
 
 
 @pytest.mark.parametrize(
-    argnames=("field_type", "value"),
+    argnames="test_case",
     argvalues=[
+        # If a 2-tuple, the API and ORM values should be identical.
+        (f.AutoNumberField, 1),
+        (f.CountField, 1),
+        (f.ExternalSyncSourceField, "Source"),
+        (f.ButtonField, {"label": "Click me!"}),
+        # If a 3-tuple, we should be able to convert API -> ORM values.
+        (f.CreatedByField, fake_user()),
+        (f.CreatedTimeField, DATETIME_S, DATETIME_V),
+        (f.LastModifiedByField, fake_user()),
+        (f.LastModifiedTimeField, DATETIME_S, DATETIME_V),
+    ],
+    ids=operator.itemgetter(0),
+)
+def test_readonly_fields(test_case):
+    """
+    Test that a readonly field cannot be overwritten.
+    """
+    if len(test_case) == 2:
+        field_type, api_value = test_case
+        orm_value = api_value
+    else:
+        field_type, api_value, orm_value = test_case
+
+    class T(Model):
+        Meta = fake_meta()
+        the_field = field_type("Field Name")
+
+    assert orm_value == T.the_field.to_internal_value(api_value)
+    assert api_value == T.the_field.to_record_value(orm_value)
+
+    t = T.from_record(fake_record({"Field Name": api_value}))
+    assert t.the_field == orm_value
+    with pytest.raises(AttributeError):
+        t.the_field = orm_value
+
+
+@pytest.mark.parametrize(
+    argnames="test_case",
+    argvalues=[
+        # If a 2-tuple, the API and ORM values should be identical.
+        (f.Field, object()),  # accepts any value, but Airtable API *will* complain
         (f.TextField, "name"),
         (f.EmailField, "x@y.com"),
         (f.NumberField, 1),
         (f.NumberField, 1.5),
         (f.IntegerField, 1),
         (f.FloatField, 1.5),
+        (f.RatingField, 1),
+        (f.CurrencyField, 1.05),
         (f.CheckboxField, True),
-        (f.CheckboxField, False),
+        (f.CollaboratorField, {"id": "usrFakeUserId", "email": "x@y.com"}),
+        (f.ListField, ["any", "values"]),
+        (f.LookupField, ["any", "values"]),
+        (f.MultipleAttachmentsField, [fake_attachment(), fake_attachment()]),
+        (f.MultipleSelectField, ["any", "values"]),
+        (f.MultipleCollaboratorsField, [fake_user(), fake_user()]),
+        (f.BarcodeField, {"type": "upce", "text": "084114125538"}),
+        (f.PercentField, 0.5),
+        (f.PhoneNumberField, "+49 40-349180"),
+        (f.RichTextField, "Check out [Airtable](www.airtable.com)"),
+        (f.SelectField, "any value"),
+        (f.UrlField, "www.airtable.com"),
+        # If a 3-tuple, we should be able to convert API -> ORM values.
+        (f.DateField, DATE_S, DATE_V),
+        (f.DurationField, 100.5, datetime.timedelta(seconds=100, microseconds=500000)),
+        (f.DatetimeField, DATETIME_S, DATETIME_V),
     ],
+    ids=operator.itemgetter(0),
 )
-def test_value_preserved(field_type, value):
+def test_writable_fields(test_case):
     """
     Test that the ORM does not modify values that can be persisted as-is.
     """
+    if len(test_case) == 2:
+        field_type, api_value = test_case
+        orm_value = api_value
+    else:
+        field_type, api_value, orm_value = test_case
 
     class T(Model):
         Meta = fake_meta()
         the_field = field_type("Field Name")
 
-    new_obj = T()
-    new_obj.the_field = value
-    assert new_obj.to_record()["fields"] == {"Field Name": value}
-
-    existing_obj = T.from_record(fake_record({"Field Name": value}))
-    assert existing_obj.the_field == value
-
-
-@pytest.mark.parametrize(
-    argnames=("field_type", "api_value", "orm_value"),
-    argvalues=[
-        (f.DateField, "2023-01-01", datetime.date(2023, 1, 1)),
-        (f.DatetimeField, "2023-04-12T09:30:00.000Z", datetime.datetime(2023, 4, 12, 9, 30, 0)),  # fmt: skip
-    ],
-)
-def test_value_converted(field_type, api_value, orm_value):
-    """
-    Test that each ORM field type converts correctly in both directions.
-    """
-
-    class T(Model):
-        Meta = fake_meta()
-        the_field = field_type("Field Name")
+    assert orm_value == T.the_field.to_internal_value(api_value)
+    assert api_value == T.the_field.to_record_value(orm_value)
 
     new_obj = T()
     new_obj.the_field = orm_value
@@ -153,40 +216,109 @@ def test_value_converted(field_type, api_value, orm_value):
     assert existing_obj.the_field == orm_value
 
 
-@pytest.mark.skip("TODO")
+def test_completeness():
+    """
+    Ensure that we test conversion of all readonly and writable fields.
+    """
+    assert_all_fields_tested_by(test_writable_fields, test_readonly_fields)
+
+
+def assert_all_fields_tested_by(*test_fns, exclude=(f.Field, f.LinkField)):
+    """
+    Allows meta-tests that fail if any new Field classes appear in pyairtable.orm.fields
+    which are not covered by one of a few basic tests. This is intended to help remind
+    us as contributors to test our edge cases :)
+    """
+
+    def extract_fields(obj):
+        if isinstance(obj, pytest.Mark):
+            yield from [*extract_fields(obj.args), *extract_fields(obj.kwargs)]
+        elif isinstance(obj, str):
+            pass
+        elif isinstance(obj, dict):
+            yield from extract_fields(list(obj.values()))
+        elif hasattr(obj, "__iter__"):
+            for item in obj:
+                yield from extract_fields(item)
+        elif isinstance(obj, type) and issubclass(obj, f.Field):
+            yield obj
+
+    tested_field_classes = {
+        field_class
+        for test_function in test_fns
+        for pytestmark in getattr(test_function, "pytestmark", [])
+        if isinstance(pytestmark, pytest.Mark) and pytestmark.name == "parametrize"
+        for field_class in extract_fields(pytestmark)
+        if field_class not in exclude
+    }
+
+    missing = [
+        field_class_name
+        for field_class_name, field_class in vars(f).items()
+        if field_class_name.endswith("Field")
+        and isinstance(field_class, type)
+        and field_class not in tested_field_classes
+        and field_class not in exclude
+        and not field_class.__name__.startswith("_")
+    ]
+
+    if missing:
+        test_names = sorted(fn.__name__ for fn in test_fns)
+        fail_names = "\n".join(f"- {name}" for name in missing)
+        pytest.fail(f"Some fields were not tested by {test_names}:\n{fail_names}")
+
+
+@pytest.mark.parametrize(
+    argnames="values",
+    argvalues=[
+        (1, 2, 3, 4),  # tuple
+        {1, 2, 3, 4},  # set
+        (n + 1 for n in range(4)),  # generator
+    ],
+    ids=type,
+)
+def test_list_field_assignment(values):
+    """
+    Test that we can assign any sort of iterable to a list field
+    and it will result in a list being stored internally.
+    """
+
+    class T:
+        items = f.ListField("Items")
+
+    t = T()
+    t.items = values
+    assert isinstance(t.items, list)
+    assert sorted(t.items) == [1, 2, 3, 4]
+
+
+def test_list_field_with_string():
+    """
+    If we pass a string to a list field, it should not be turned
+    into a list of single-character strings; it should be an error.
+    """
+
+    class T:
+        items = f.ListField("Items")
+
+    t = T()
+    with pytest.raises(TypeError):
+        t.items = "hello!"
+
+
+def test_linked_field_must_link_to_model():
+    """
+    Tests that a LinkField cannot link to an arbitrary type.
+    """
+    with pytest.raises(TypeError):
+        f.LinkField("Field Name", model=dict)
+
+
 def test_linked_field():
-    ...
+    class T(Model):
+        Meta = fake_meta()
 
-
-def test_datetime_field():
-    class T:
-        dt = f.DatetimeField("Datetime")
-
-    dt_str_from_airtable = "2000-01-02T03:04:05.000Z"
-    rv_dt = T.dt.to_internal_value(dt_str_from_airtable)
-    rv_str = T.dt.to_record_value(rv_dt)
-    assert rv_str == dt_str_from_airtable
-
-    assert (
-        rv_dt.year == 2000
-        and rv_dt.month == 1
-        and rv_dt.day == 2
-        and rv_dt.hour == 3
-        and rv_dt.minute == 4
-        and rv_dt.second == 5
-    )
-
-
-def test_date_field():
-    class T:
-        date = f.DateField("Date")
-
-    date_str_from_airtable = "2000-01-02"
-    rv_date = T.date.to_internal_value(date_str_from_airtable)
-    rv_str = T.date.to_record_value(rv_date)
-    assert rv_str == date_str_from_airtable
-
-    assert rv_date.year == 2000 and rv_date.month == 1 and rv_date.day == 2
+    f.LinkField("Field Name", model=T)
 
 
 def test_lookup_field():

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -24,6 +24,9 @@ def test_field():
     assert t.name == "x"
     assert t.__dict__["_fields"]["Name"] == "x"
 
+    with pytest.raises(AttributeError):
+        del t.name
+
 
 @pytest.mark.parametrize(
     argnames=("field_type", "default_value"),

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -26,6 +26,33 @@ def test_field():
 
 
 @pytest.mark.parametrize(
+    argnames=("field_type", "default_value"),
+    argvalues=[
+        (f.TextField, None),
+        (f.CheckboxField, False),
+        (f.EmailField, None),
+        (f.NumberField, None),
+        (f.IntegerField, None),
+        (f.FloatField, None),
+        (f.DateField, None),
+        (f.DatetimeField, None),
+        (f.LookupField, None),  # TODO: should this be empty list?
+    ],
+)
+def test_orm_missing_values(field_type, default_value):
+    """
+    Test that each ORM field type produces the correct default value
+    when a field is missing a value.
+    """
+
+    class T:
+        the_field = field_type("Field Name")
+
+    t = T()
+    assert t.the_field == default_value
+
+
+@pytest.mark.parametrize(
     "value",
     [
         "Test",


### PR DESCRIPTION
There is a lot in this diff, so it might be easier to read it one commit at a time. In each commit I tried to add as much test coverage as I could for whatever I changed.

* b3f7dcc3357a5ed34ee7705d453cea24fa9ee583 adds a `valid_types` class variable to the Field class which controls the behavior of `valid_or_raise()`.

* 954b059ab124963dd24ace38f3021080ad284925 adds a `value_if_missing` class variable to the Field class which controls the value used when Airtable does not return a field value at all.
  * Fixes #193.

* a4efef6ce82e47ce147a66569670366e6b9f381a adds a few more tests to ensure we raise the correct errors when a `Meta` class is missing values.

* f9949602a62a633b0c3a596c0615cd0521079a5c modifes the [descriptor](https://docs.python.org/3/howto/descriptor.html) of each Field so that it can be retrieved directly from the class (i.e. `Model.field_name` instead of `Model.__dict__["field_name"]`). This will be useful when we get to stricter type checking.

* 4074c1509ce6e21339f62528b35280d5bd5dc85c modifies the  [descriptor](https://docs.python.org/3/howto/descriptor.html) of each Field so that its value cannot be deleted on a Model instance.

* defdc8e5df3abb3fdbe4e4a29063e0aada07c42a introduces a `readonly` variable on each Field class (which can be overridden at construction) that prevents implementers from reassigning the value of that field on a Model instance. We make sure not to send these fields back to Airtable on `.save()`.
  * Fixes #177 
  * Fixes #178

* 0660fc8 implements a Field subclass for (almost) every remaining field type that Airtable provides. 
  * Fixes #149
  * Fixes #179 
  * Fixes #181

* 2e3c076 updates the documentation to reflect everything above.

Right now it still feels like the ORM testing coverage is thin. We should probably have at least one integration test for every field type, to ensure we actually read and write the Airtable API responses correctly. I'm open to ideas here.