### PR TITLE
Remove references/support for Python 3.7

### DIFF
--- a/.github/workflows/test_lint_deploy.yml
+++ b/.github/workflows/test_lint_deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,5 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py37']
+target-version = ['py38']
 include = '\.pyi?$'

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,11 @@
 envlist =
     pre-commit
     mypy
-    py3{7,8,9,10,11}-requests{min,max}
+    py3{8,9,10,11}-requests{min,max}
     coverage
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38, coverage
     3.9: py39
     3.10: py310
@@ -37,7 +36,7 @@ commands =
     python -m pytest -m 'not integration' --cov=pyairtable --cov-report={env:COVERAGE_FORMAT:html}
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.8
 deps =
     -r requirements-dev.txt
 commands =


### PR DESCRIPTION
Python 3.7 will be end-of-life at the end of June. I think we can stop supporting it in `main` in anticipation of our next release being 2.0.0. If we need to patch the 1.5.0 release for whatever reason, we can do that from a branch.