### PR TITLE
Support `mypy --strict`

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -411,3 +411,10 @@ can use if you want to compose formulas:
 .. autofunction:: pyairtable.formulas.IF
 .. autofunction:: pyairtable.formulas.STR_VALUE
 .. autofunction:: pyairtable.formulas.LOWER
+
+
+Types
+*******
+
+.. automodule:: pyairtable.api.types
+    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,7 +3,9 @@
 #
 import os
 import sys
+import typing
 
+import pyairtable.api.types
 from pyairtable import __version__ as version
 
 extensions = [
@@ -22,19 +24,6 @@ extensions = [
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# Auto Create Api Reference
-autoapi_dirs = ["../pyairtable"]
-autoapi_add_toctree_entry = True
-autoapi_options = [
-    "members",
-    "undoc-members",
-    "private-members",
-    "show-inheritance",
-    "show-module-summary",
-    "special-members",
-    "imported-members",
-]
-
 # Open Graph extension config. https://pypi.org/project/sphinxext-opengraph/
 ogp_site_url = "https://pyairtable.readthedocs.io/"
 ogp_image = "https://pyairtable.readthedocs.io/en/master/_images/logo.png"
@@ -43,6 +32,36 @@ ogp_description_length = 300
 ogp_custom_meta_tags = [
     '<meta name="twitter:card" content="summary_large_image">',
 ]
+
+# See https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
+autodoc_class_signature = "separated"
+autodoc_default_options = {
+    "exclude-members": "__new__",
+}
+
+# See https://github.com/tox-dev/sphinx-autodoc-typehints#options
+typehints_defaults = "comma"
+typehints_use_signature = True
+typehints_use_signature_return = True
+
+
+def typehints_formatter(annotation, config):
+    """
+    Provide links from function signatures to TypedDict docstrings.
+    """
+    for name, value in vars(pyairtable.api.types).items():
+        if annotation != value:
+            continue
+        if isinstance(value, type) and issubclass(value, dict):  # TypedDict
+            return f":data:`{name} <pyairtable.api.types.{name}>`"
+        if isinstance(value, typing._GenericAlias):  # Union, Dict, etc.
+            return f":data:`{name} <pyairtable.api.types.{name}>`"
+
+    return None
+
+
+# Needed for autoapi to not choke on retrying.Retry
+suppress_warnings = ["autoapi.python_import_resolution"]
 
 
 ################################
@@ -99,7 +118,7 @@ author = "Gui Talarico"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -14,13 +14,14 @@
     the connection to be established  and 5 seconds for a
     server read timeout. Default is ``None`` (no timeout).
 
-.. |arg_retry_strategy| replace:: An instance of ``urllib3.util.Retry``.
-    :func:`pyairtable.retrying.retry_strategy` returns one with reasonable
-    defaults, but you may provide your own custom instance of ``Retry``.
+.. |arg_retry_strategy| replace:: An instance of
+    `urllib3.util.Retry <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry>`__.
+    You can use :func:`~pyairtable.api.retrying.retry_strategy` to build one with reasonable
+    defaults, or provide your own custom instance of ``Retry``.
     Default is ``None`` (no retry).
 
-.. |arg_endpoint_url| replace:: The API endpoint to hit. You might want to override it if you are using an API proxy to debug your API calls.
-    Default is ``https://api.airtable.com``.
+.. |arg_endpoint_url| replace:: The API endpoint to hit. You might want to override it if you are using
+    a proxy to debug your API calls. Default is ``https://api.airtable.com``.
 
 .. |kwarg_view| replace:: The name or ID of a view.
     If set, only the records in that view will be returned.
@@ -72,6 +73,10 @@
     when using `string` as the `cell_format`. See
     https://support.airtable.com/hc/en-us/articles/216141558-Supported-timezones-for-SET-TIMEZONE
     for valid values.
+
+.. |kwarg_replace| replace:: If ``True``, record is replaced in its entirety
+    by provided fields; if a field is not included its value will
+    bet set to null. If False, only provided fields are updated.
 
 .. |kwarg_return_fields_by_field_id| replace:: An optional boolean value that lets you return field objects where the
     key is the field id. This defaults to `false`, which returns field objects where the key is the field name.

--- a/pyairtable/__init__.py
+++ b/pyairtable/__init__.py
@@ -1,4 +1,11 @@
 __version__ = "1.5.0"
 
-from .api import Api, Base, Table  # noqa
-from .api.retrying import retry_strategy  # noqa
+from .api import Api, Base, Table
+from .api.retrying import retry_strategy
+
+__all__ = [
+    "Api",
+    "Base",
+    "Table",
+    "retry_strategy",
+]

--- a/pyairtable/api/__init__.py
+++ b/pyairtable/api/__init__.py
@@ -1,3 +1,9 @@
-from .api import Api  # noqa
-from .base import Base  # noqa
-from .table import Table  # noqa
+from .api import Api
+from .base import Base
+from .table import Table
+
+__all__ = [
+    "Api",
+    "Base",
+    "Table",
+]

--- a/pyairtable/api/abstract.py
+++ b/pyairtable/api/abstract.py
@@ -127,8 +127,8 @@ class ApiAbstract(metaclass=abc.ABCMeta):
         See https://support.airtable.com/docs/enforcement-of-url-length-limit-for-web-api-requests
 
         Args:
-            method (``str``): HTTP method to use.
-            url (``str``): The URL we're attempting to call.
+            method: HTTP method to use.
+            url: The URL we're attempting to call.
 
         Keyword Args:
             fallback_post_url (``str``, optional): The URL to use if we have to convert a GET to a POST.

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,4 +1,12 @@
-from typing import List, Optional
+from typing import Any, Iterator, List, Optional
+
+from pyairtable.api.types import (
+    Fields,
+    RecordDeletedDict,
+    RecordDict,
+    RecordId,
+    UpdateRecordDict,
+)
 
 from .abstract import ApiAbstract, TimeoutTuple
 from .retrying import Retry
@@ -66,7 +74,7 @@ class Api(ApiAbstract):
             self.api_key, base_id, timeout=self.timeout, endpoint_url=self.endpoint_url
         )
 
-    def get_record_url(self, base_id: str, table_name: str, record_id: str):
+    def get_record_url(self, base_id: str, table_name: str, record_id: RecordId) -> str:
         """
         Returns a url for the provided record
 
@@ -77,7 +85,9 @@ class Api(ApiAbstract):
         """
         return super()._get_record_url(base_id, table_name, record_id)
 
-    def get(self, base_id: str, table_name: str, record_id: str, **options):
+    def get(
+        self, base_id: str, table_name: str, record_id: RecordId, **options: Any
+    ) -> RecordDict:
         """
         Retrieves a record by its id
 
@@ -96,7 +106,9 @@ class Api(ApiAbstract):
         """
         return super()._get_record(base_id, table_name, record_id, **options)
 
-    def iterate(self, base_id: str, table_name: str, **options):
+    def iterate(
+        self, base_id: str, table_name: str, **options: Any
+    ) -> Iterator[List[RecordDict]]:
         """
         Record Retriever Iterator
 
@@ -133,7 +145,9 @@ class Api(ApiAbstract):
         for i in gen:
             yield i
 
-    def first(self, base_id: str, table_name: str, **options):
+    def first(
+        self, base_id: str, table_name: str, **options: Any
+    ) -> Optional[RecordDict]:
         """
         Retrieves the first found record or ``None`` if no records are returned.
 
@@ -156,7 +170,7 @@ class Api(ApiAbstract):
         """
         return super()._first(base_id, table_name, **options)
 
-    def all(self, base_id: str, table_name: str, **options):
+    def all(self, base_id: str, table_name: str, **options: Any) -> List[RecordDict]:
         """
         Retrieves all records repetitively and returns a single list.
 
@@ -193,10 +207,10 @@ class Api(ApiAbstract):
         self,
         base_id: str,
         table_name: str,
-        fields: dict,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        fields: Fields,
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> RecordDict:
         """
         Creates a new record
 
@@ -229,10 +243,10 @@ class Api(ApiAbstract):
         self,
         base_id: str,
         table_name: str,
-        records,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        records: List[Fields],
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> List[RecordDict]:
         """
         Breaks records into chunks of 10 and inserts them in batches.
         Follows the set API rate.
@@ -267,11 +281,11 @@ class Api(ApiAbstract):
         self,
         base_id: str,
         table_name: str,
-        record_id: str,
-        fields: dict,
-        replace=False,
-        typecast=False,
-    ):
+        record_id: RecordId,
+        fields: Fields,
+        replace: bool = False,
+        typecast: bool = False,
+    ) -> RecordDict:
         """
         Updates a record by its record id.
         Only Fields passed are updated, the rest are left as is.
@@ -312,11 +326,11 @@ class Api(ApiAbstract):
         self,
         base_id: str,
         table_name: str,
-        records: List[dict],
-        replace=False,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        records: List[UpdateRecordDict],
+        replace: bool = False,
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> List[RecordDict]:
         """
         Updates a records by their record id's in batch.
 
@@ -349,12 +363,12 @@ class Api(ApiAbstract):
         self,
         base_id: str,
         table_name: str,
-        records: List[dict],
+        records: List[UpdateRecordDict],
         key_fields: List[str],
-        replace=False,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        replace: bool = False,
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> List[RecordDict]:
         """
         Updates or creates records in batches, either using ``id`` (if given) or using a set of
         fields (``key_fields``) to look for matches. For more information on how this operation
@@ -390,7 +404,9 @@ class Api(ApiAbstract):
             return_fields_by_field_id=return_fields_by_field_id,
         )
 
-    def delete(self, base_id: str, table_name: str, record_id: str):
+    def delete(
+        self, base_id: str, table_name: str, record_id: RecordId
+    ) -> RecordDeletedDict:
         """
         Deletes a record by its id
 
@@ -407,7 +423,9 @@ class Api(ApiAbstract):
         """
         return super()._delete(base_id, table_name, record_id)
 
-    def batch_delete(self, base_id: str, table_name: str, record_ids: List[str]):
+    def batch_delete(
+        self, base_id: str, table_name: str, record_ids: List[RecordId]
+    ) -> List[RecordDeletedDict]:
         """
         Breaks records into batches of 10 and deletes in batches, following set
         API Rate Limit (5/sec).

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -42,9 +42,9 @@ class Api(ApiAbstract):
             api_key: |arg_api_key|
 
         Keyword Args:
-            timeout (``Tuple``): |arg_timeout|
-            retry_strategy (``Retry``): |arg_retry_strategy|
-            endpoint_url (``str``): |arg_endpoint_url|
+            timeout: |arg_timeout|
+            retry_strategy: |arg_retry_strategy|
+            endpoint_url: |arg_endpoint_url|
         """
         super().__init__(
             api_key,
@@ -98,12 +98,7 @@ class Api(ApiAbstract):
             base_id: |arg_base_id|
             table_name: |arg_table_name|
             record_id: |arg_record_id|
-
-        Keyword Args:
             return_fields_by_field_id: |kwarg_return_fields_by_field_id|
-
-        Returns:
-            record: Record
         """
         return super()._get_record(base_id, table_name, record_id, **options)
 
@@ -139,8 +134,7 @@ class Api(ApiAbstract):
             return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
-            iterator: Record Iterator, grouped by page size
-
+            Iterator of pages of records, no greater than ``page_size``
         """
         gen = super()._iterate(base_id, table_name, **options)
         for i in gen:
@@ -197,7 +191,7 @@ class Api(ApiAbstract):
             return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
-            records (``list``): List of Records
+            List of records retrieved.
 
         >>> records = all(max_records=3, view='All')
 
@@ -221,16 +215,12 @@ class Api(ApiAbstract):
         Args:
             base_id: |arg_base_id|
             table_name: |arg_table_name|
-            fields(``dict``): Fields to insert.
-                Must be dictionary with Column names as Key.
-
-        Keyword Args:
+            fields: Fields to insert.
             typecast: |kwarg_typecast|
             return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
-            record (``dict``): Inserted record
-
+            The created record.
         """
         return super()._create(
             base_id,
@@ -260,15 +250,12 @@ class Api(ApiAbstract):
         Args:
             base_id: |arg_base_id|
             table_name: |arg_table_name|
-            records(``List[dict]``): List of dictionaries representing
-                records to be created.
-
-        Keyword Args:
+            records: List of dicts representing records to be created.
             typecast: |kwarg_typecast|
             return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
-            records (``list``): list of added records
+            List of created records.
         """
         return super()._batch_create(
             base_id,
@@ -300,18 +287,12 @@ class Api(ApiAbstract):
             base_id: |arg_base_id|
             table_name: |arg_table_name|
             record_id: |arg_record_id|
-            fields(``dict``): Fields to update.
-                Must be a dict with column names or IDs as keys
-
-        Keyword Args:
-            replace (``bool``, optional): If ``True``, record is replaced in its entirety
-                by provided fields - eg. if a field is not included its value will
-                bet set to null. If False, only provided fields are updated.
-                Default is ``False``.
+            fields: Fields to update. Must be a dict with column names or IDs as keys.
+            replace: |kwarg_replace|
             typecast: |kwarg_typecast|
 
         Returns:
-            record (``dict``): Updated record
+            The updated record.
         """
 
         return super()._update(
@@ -338,18 +319,13 @@ class Api(ApiAbstract):
         Args:
             base_id: |arg_base_id|
             table_name: |arg_table_name|
-            records(``list``): List of dict: [{"id": record_id, "fields": fields_to_update_dict}]
-
-        Keyword Args:
-            replace (``bool``, optional): If ``True``, record is replaced in its entirety
-                by provided fields - eg. if a field is not included its value will
-                bet set to null. If False, only provided fields are updated.
-                Default is ``False``.
+            records: List of dicts with ``"id"`` and ``"fields"`` as keys.
+            replace: |kwarg_replace|
             typecast: |kwarg_typecast|
             return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
-            records(``list``): list of updated records
+            List of updated records.
         """
         return super()._batch_update(
             base_id,
@@ -380,20 +356,15 @@ class Api(ApiAbstract):
         Args:
             base_id: |arg_base_id|
             table_name: |arg_table_name|
-            records (``list``): List of dict: [{"id": record_id, "fields": fields_to_update_dict}]
-            key_fields (``list``): List of field names that Airtable should use to match
+            records: List of dicts with ``"id"`` and ``"fields"`` as keys.
+            key_fields: List of field names that Airtable should use to match
                 records in the input with existing records on the server.
-
-        Keyword Args:
-            replace (``bool``, optional): If ``True``, record is replaced in its entirety
-                by provided fields - e.g. if a field is not included its value will
-                bet set to null. If False, only provided fields are updated.
-                Default is ``False``.
+            replace: |kwarg_replace|
             typecast: |kwarg_typecast|
             return_fields_by_field_id: |kwarg_return_fields_by_field_id|
 
         Returns:
-            records (``list``): list of updated records
+            List of updated records.
         """
         return super()._batch_upsert(
             base_id=base_id,
@@ -420,7 +391,7 @@ class Api(ApiAbstract):
             record_id: |arg_record_id|
 
         Returns:
-            record (``dict``): Deleted Record
+            Confirmation of the deleted record.
         """
         return super()._delete(base_id, table_name, record_id)
 
@@ -439,11 +410,10 @@ class Api(ApiAbstract):
         Args:
             base_id: |arg_base_id|
             table_name: |arg_table_name|
-            record_ids(``list``): Record Ids to delete
+            record_ids: Record IDs to delete
 
         Returns:
-            records(``list``): list of records deleted
-
+            Confirmation of each record deleted.
         """
         return super()._batch_delete(base_id, table_name, record_ids)
 

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -8,6 +8,7 @@ from pyairtable.api.types import (
     UpdateRecordDict,
 )
 
+from . import base, table
 from .abstract import ApiAbstract, TimeoutTuple
 from .retrying import Retry
 
@@ -52,12 +53,12 @@ class Api(ApiAbstract):
             endpoint_url=endpoint_url,
         )
 
-    def get_table(self, base_id: str, table_name: str) -> "Table":
+    def get_table(self, base_id: str, table_name: str) -> "table.Table":
         """
         Returns a new :class:`Table` instance using all shared
         attributes from :class:`Api`
         """
-        return Table(
+        return table.Table(
             self.api_key,
             base_id,
             table_name,
@@ -65,12 +66,12 @@ class Api(ApiAbstract):
             endpoint_url=self.endpoint_url,
         )
 
-    def get_base(self, base_id: str) -> "Base":
+    def get_base(self, base_id: str) -> "base.Base":
         """
         Returns a new :class:`Base` instance using all shared
         attributes from :class:`Api`
         """
-        return Base(
+        return base.Base(
             self.api_key, base_id, timeout=self.timeout, endpoint_url=self.endpoint_url
         )
 
@@ -448,7 +449,3 @@ class Api(ApiAbstract):
 
     def __repr__(self) -> str:
         return "<pyairtable.Api>"
-
-
-from pyairtable.api.base import Base  # noqa
-from pyairtable.api.table import Table  # noqa

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -41,8 +41,9 @@ class Base(ApiAbstract):
             base_id: |arg_base_id|
 
         Keyword Args:
-            timeout (``Tuple``): |arg_timeout|
-            retry_strategy (``Retry``): |arg_retry_strategy|
+            timeout: |arg_timeout|
+            retry_strategy: |arg_retry_strategy|
+            endpoint_url: |arg_endpoint_url|
         """
 
         self.base_id = base_id

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Iterator, List, Optional
+from typing import Any, Iterator, List, Optional
 
 from pyairtable.api.types import (
     FieldName,
@@ -9,11 +9,9 @@ from pyairtable.api.types import (
     UpdateRecordDict,
 )
 
+from . import table
 from .abstract import ApiAbstract, TimeoutTuple
 from .retrying import Retry
-
-if TYPE_CHECKING:
-    from .table import Table  # noqa
 
 
 class Base(ApiAbstract):
@@ -55,12 +53,12 @@ class Base(ApiAbstract):
             endpoint_url=endpoint_url,
         )
 
-    def get_table(self, table_name: str) -> "Table":
+    def get_table(self, table_name: str) -> "table.Table":
         """
         Returns a new :class:`Table` instance using all shared
         attributes from :class:`Base`
         """
-        return Table(self.api_key, self.base_id, table_name, timeout=self.timeout)
+        return table.Table(self.api_key, self.base_id, table_name, timeout=self.timeout)
 
     def get_record_url(self, table_name: str, record_id: RecordId) -> str:
         """

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -1,7 +1,19 @@
-from typing import List, Optional
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional
+
+from pyairtable.api.types import (
+    FieldName,
+    Fields,
+    RecordDeletedDict,
+    RecordDict,
+    RecordId,
+    UpdateRecordDict,
+)
 
 from .abstract import ApiAbstract, TimeoutTuple
 from .retrying import Retry
+
+if TYPE_CHECKING:
+    from .table import Table  # noqa
 
 
 class Base(ApiAbstract):
@@ -50,21 +62,21 @@ class Base(ApiAbstract):
         """
         return Table(self.api_key, self.base_id, table_name, timeout=self.timeout)
 
-    def get_record_url(self, table_name: str, record_id: str):
+    def get_record_url(self, table_name: str, record_id: RecordId) -> str:
         """
         Same as :meth:`Api.get_record_url <pyairtable.api.Api.get_record_url>`
         but without ``base_id`` arg.
         """
         return super()._get_record_url(self.base_id, table_name, record_id)
 
-    def get(self, table_name: str, record_id: str):
+    def get(self, table_name: str, record_id: RecordId) -> RecordDict:
         """
         Same as :meth:`Api.get <pyairtable.api.Api.get>`
         but without ``base_id`` arg.
         """
         return super()._get_record(self.base_id, table_name, record_id)
 
-    def iterate(self, table_name: str, **options):
+    def iterate(self, table_name: str, **options: Any) -> Iterator[List[RecordDict]]:
         """
         Same as :meth:`Api.iterate <pyairtable.api.Api.iterate>`
         but without ``base_id`` arg.
@@ -73,14 +85,14 @@ class Base(ApiAbstract):
         for i in gen:
             yield i
 
-    def first(self, table_name: str, **options):
+    def first(self, table_name: str, **options: Any) -> Optional[RecordDict]:
         """
         Same as :meth:`Api.first <pyairtable.api.Api.first>`
         but without ``base_id`` arg.
         """
         return super()._first(self.base_id, table_name, **options)
 
-    def all(self, table_name: str, **options):
+    def all(self, table_name: str, **options: Any) -> List[RecordDict]:
         """
         Same as :meth:`Api.all <pyairtable.api.Api.all>`
         but without ``base_id`` arg.
@@ -90,10 +102,10 @@ class Base(ApiAbstract):
     def create(
         self,
         table_name: str,
-        fields: dict,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        fields: Fields,
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> RecordDict:
         """
         Same as :meth:`Api.create <pyairtable.api.Api.create>`
         but without ``base_id`` arg.
@@ -107,8 +119,12 @@ class Base(ApiAbstract):
         )
 
     def batch_create(
-        self, table_name: str, records, typecast=False, return_fields_by_field_id=False
-    ):
+        self,
+        table_name: str,
+        records: List[Fields],
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> List[RecordDict]:
         """
         Same as :meth:`Api.batch_create <pyairtable.api.Api.batch_create>`
         but without ``base_id`` arg.
@@ -124,11 +140,11 @@ class Base(ApiAbstract):
     def update(
         self,
         table_name: str,
-        record_id: str,
-        fields: dict,
-        replace=False,
-        typecast=False,
-    ):
+        record_id: RecordId,
+        fields: Fields,
+        replace: bool = False,
+        typecast: bool = False,
+    ) -> RecordDict:
         """
         Same as :meth:`Api.update <pyairtable.api.Api.update>`
         but without ``base_id`` arg.
@@ -145,11 +161,11 @@ class Base(ApiAbstract):
     def batch_update(
         self,
         table_name: str,
-        records: List[dict],
-        replace=False,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        records: List[UpdateRecordDict],
+        replace: bool = False,
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> List[RecordDict]:
         """
         Same as :meth:`Api.batch_update <pyairtable.api.Api.batch_update>`
         but without ``base_id`` arg.
@@ -166,12 +182,12 @@ class Base(ApiAbstract):
     def batch_upsert(
         self,
         table_name: str,
-        records: List[dict],
-        key_fields: List[str],
-        replace=False,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        records: List[UpdateRecordDict],
+        key_fields: List[FieldName],
+        replace: bool = False,
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> List[RecordDict]:
         """
         Same as :meth:`Api.batch_upsert <pyairtable.api.Api.batch_upsert>`
         but without ``base_id`` arg.
@@ -186,14 +202,18 @@ class Base(ApiAbstract):
             return_fields_by_field_id=return_fields_by_field_id,
         )
 
-    def delete(self, table_name: str, record_id: str):
+    def delete(self, table_name: str, record_id: RecordId) -> RecordDeletedDict:
         """
         Same as :meth:`Api.delete <pyairtable.api.Api.delete>`
         but without ``base_id`` arg.
         """
         return super()._delete(self.base_id, table_name, record_id)
 
-    def batch_delete(self, table_name: str, record_ids: List[str]):
+    def batch_delete(
+        self,
+        table_name: str,
+        record_ids: List[RecordId],
+    ) -> List[RecordDeletedDict]:
         """
         Same as :meth:`Api.batch_delete <pyairtable.api.Api.batch_delete>`
         but without ``base_id`` arg.
@@ -202,6 +222,3 @@ class Base(ApiAbstract):
 
     def __repr__(self) -> str:
         return "<Airtable Base id={}>".format(self.base_id)
-
-
-from .table import Table  # noqa

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -28,7 +28,6 @@ def dict_list_to_request_params(
         "sort[1][field]": "FieldTwo",
         "sort[1][direction]: "desc",
     }
-
     """
     return {
         key: value

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -1,17 +1,16 @@
-import warnings
-from collections import OrderedDict
 from typing import Any, Dict, List, Tuple
 
 
 class InvalidParamException(ValueError):
-    """Raise when invalid parameters are used"""
-
-    def __init__(self, message, *args):
-        self.message = message
-        super().__init__(message, *args)
+    """
+    Raised when invalid parameters are passed to ``all()``, ``first()``, etc.
+    """
 
 
-def dict_list_to_request_params(param_name: str, values: List[dict]) -> dict:
+def dict_list_to_request_params(
+    param_name: str,
+    values: List[Dict[str, str]],
+) -> Dict[str, str]:
     """
     Returns dict to be used by request params from dict list
 
@@ -31,14 +30,14 @@ def dict_list_to_request_params(param_name: str, values: List[dict]) -> dict:
     }
 
     """
-    param_dict = {}
-    for index, dictionary in enumerate(values):
-        for key, value in dictionary.items():
-            field_name = "{param_name}[{index}][{key}]".format(
-                param_name=param_name, index=index, key=key
-            )
-            param_dict[field_name] = value
-    return OrderedDict(sorted(param_dict.items()))
+    return {
+        key: value
+        for (key, value) in sorted(
+            (f"{param_name}[{index}][{key}]", value)
+            for index, field_sort in enumerate(values)
+            for key, value in field_sort.items()
+        )
+    }
 
 
 def field_names_to_sorting_dict(field_names: List[str]) -> List[Dict[str, str]]:
@@ -63,42 +62,6 @@ def field_names_to_sorting_dict(field_names: List[str]) -> List[Dict[str, str]]:
         sort_param = {"field": field_name, "direction": direction}
         values.append(sort_param)
     return values
-
-
-def to_params_dict(param_name: str, value: Any):
-    """Returns a dictionary for use in Request 'params'"""
-    warnings.warn(
-        "to_params_dict will be removed in 2.0.0",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    if param_name == "max_records":
-        return {"maxRecords": value}
-    elif param_name == "view":
-        return {"view": value}
-    elif param_name == "page_size":
-        return {"pageSize": value}
-    elif param_name == "offset":
-        return {"offset": value}
-    elif param_name == "formula":
-        return {"filterByFormula": value}
-    elif param_name == "fields":
-        return {"fields[]": value}
-    elif param_name == "cell_format":
-        return {"cellFormat": value}
-    elif param_name == "time_zone":
-        return {"timeZone": value}
-    elif param_name == "user_locale":
-        return {"userLocale": value}
-    elif param_name == "return_fields_by_field_id":
-        return {"returnFieldsByFieldId": int(value)}
-    elif param_name == "sort":
-        sorting_dict_list = field_names_to_sorting_dict(value)
-        return dict_list_to_request_params("sort", sorting_dict_list)
-    else:
-        msg = "'{0}' is not a supported parameter".format(param_name)
-        raise InvalidParamException(msg)
 
 
 #: Mapping of pyairtable option names to Airtable parameter names

--- a/pyairtable/api/retrying.py
+++ b/pyairtable/api/retrying.py
@@ -1,3 +1,5 @@
+from typing import Any, Tuple, Union
+
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -9,10 +11,10 @@ DEFAULT_MAX_RETRIES = 5
 
 def retry_strategy(
     *,
-    status_forcelist=DEFAULT_RETRIABLE_STATUS_CODES,
-    backoff_factor=DEFAULT_BACKOFF_FACTOR,
-    total=DEFAULT_MAX_RETRIES,
-    **kwargs,
+    status_forcelist: Tuple[int, ...] = DEFAULT_RETRIABLE_STATUS_CODES,
+    backoff_factor: Union[int, float] = DEFAULT_BACKOFF_FACTOR,
+    total: int = DEFAULT_MAX_RETRIES,
+    **kwargs: Any,
 ) -> Retry:
     """
     Creates a ``Retry`` instance with optional default values.
@@ -44,3 +46,9 @@ class _RetryingSession(Session):
 
         self.mount("https://", adapter)
         self.mount("http://", adapter)
+
+
+__all__ = [
+    "Retry",
+    "_RetryingSession",
+]

--- a/pyairtable/api/retrying.py
+++ b/pyairtable/api/retrying.py
@@ -18,17 +18,17 @@ def retry_strategy(
 ) -> Retry:
     """
     Creates a ``Retry`` instance with optional default values.
-    See `urllib3 Retry docs <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html>`_
+    See `urllib3 Retry docs <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html>`__
     for more details.
 
     .. versionadded:: 1.4.0
 
     Keyword Args:
-        status_forcelist (``Tuple[int]``): list status code which should be retried.
-        backoff_factor (``float``): backoff factor.
+        status_forcelist (``Tuple[int, ...]``): list of status codes which should be retried.
+        backoff_factor (``int`` or ``float``): backoff factor.
         total (``int``): max. number of retries. Note ``0`` means no retries,
-            while``1`` will exececute a total of two requests (1 + 1 retry).
-        **kwargs: All parameters supported by ``urllib3.util.Retry`` can be used.
+            while ``1`` will execute a total of two requests (1 + 1 retry).
+        **kwargs: Any valid parameter to `urllib3.util.Retry <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry>`__.
     """
     return Retry(
         total=total,

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -1,4 +1,13 @@
-from typing import List, Optional
+from typing import Any, Iterator, List, Optional
+
+from pyairtable.api.types import (
+    FieldName,
+    Fields,
+    RecordDeletedDict,
+    RecordDict,
+    RecordId,
+    UpdateRecordDict,
+)
 
 from .abstract import ApiAbstract, TimeoutTuple
 from .retrying import Retry
@@ -48,7 +57,7 @@ class Table(ApiAbstract):
         )
 
     @property
-    def table_url(self):
+    def table_url(self) -> str:
         """Returns the table URL"""
         return super().get_table_url(self.base_id, self.table_name)
 
@@ -59,21 +68,21 @@ class Table(ApiAbstract):
         """
         return Base(self.api_key, self.base_id, timeout=self.timeout)
 
-    def get_record_url(self, record_id: str):
+    def get_record_url(self, record_id: RecordId) -> str:
         """
         Same as :meth:`Api.get_record_url <pyairtable.api.Api.get_record_url>`
         but without ``base_id`` and ``table_name`` arg.
         """
         return super()._get_record_url(self.base_id, self.table_name, record_id)
 
-    def get(self, record_id: str, **options):
+    def get(self, record_id: RecordId, **options: Any) -> RecordDict:
         """
         Same as :meth:`Api.get <pyairtable.api.Api.get>`
         but without ``base_id`` and ``table_name`` arg.
         """
         return super()._get_record(self.base_id, self.table_name, record_id, **options)
 
-    def iterate(self, **options):
+    def iterate(self, **options: Any) -> Iterator[List[RecordDict]]:
         """
         Same as :meth:`Api.iterate <pyairtable.api.Api.iterate>`
         but without ``base_id`` and ``table_name`` arg.
@@ -82,14 +91,14 @@ class Table(ApiAbstract):
         for i in gen:
             yield i
 
-    def first(self, **options):
+    def first(self, **options: Any) -> Optional[RecordDict]:
         """
         Same as :meth:`Api.first <pyairtable.api.Api.first>`
         but without ``base_id`` and ``table_name`` arg.
         """
         return super()._first(self.base_id, self.table_name, **options)
 
-    def all(self, **options):
+    def all(self, **options: Any) -> List[RecordDict]:
         """
         Same as :meth:`Api.all <pyairtable.api.Api.all>`
         but without ``base_id`` and ``table_name`` arg.
@@ -98,10 +107,10 @@ class Table(ApiAbstract):
 
     def create(
         self,
-        fields: dict,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        fields: Fields,
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> RecordDict:
         """
         Same as :meth:`Api.create <pyairtable.api.Api.create>`
         but without ``base_id`` and ``table_name`` arg.
@@ -116,10 +125,10 @@ class Table(ApiAbstract):
 
     def batch_create(
         self,
-        records,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        records: List[Fields],
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> List[RecordDict]:
         """
         Same as :meth:`Api.batch_create <pyairtable.api.Api.batch_create>`
         but without ``base_id`` and ``table_name`` arg.
@@ -132,7 +141,13 @@ class Table(ApiAbstract):
             return_fields_by_field_id=return_fields_by_field_id,
         )
 
-    def update(self, record_id: str, fields: dict, replace=False, typecast=False):
+    def update(
+        self,
+        record_id: RecordId,
+        fields: Fields,
+        replace: bool = False,
+        typecast: bool = False,
+    ) -> RecordDict:
         """
         Same as :meth:`Api.update <pyairtable.api.Api.update>`
         but without ``base_id`` and ``table_name`` arg.
@@ -148,11 +163,11 @@ class Table(ApiAbstract):
 
     def batch_update(
         self,
-        records: List[dict],
-        replace=False,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        records: List[UpdateRecordDict],
+        replace: bool = False,
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> List[RecordDict]:
         """
         Same as :meth:`Api.batch_update <pyairtable.api.Api.batch_update>`
         but without ``base_id`` and ``table_name`` arg.
@@ -168,12 +183,12 @@ class Table(ApiAbstract):
 
     def batch_upsert(
         self,
-        records: List[dict],
-        key_fields: List[str],
-        replace=False,
-        typecast=False,
-        return_fields_by_field_id=False,
-    ):
+        records: List[UpdateRecordDict],
+        key_fields: List[FieldName],
+        replace: bool = False,
+        typecast: bool = False,
+        return_fields_by_field_id: bool = False,
+    ) -> List[RecordDict]:
         """
         Same as :meth:`Api.batch_upsert <pyairtable.api.Api.batch_upsert>`
         but without ``base_id`` and ``table_name`` arg.
@@ -188,14 +203,14 @@ class Table(ApiAbstract):
             return_fields_by_field_id=return_fields_by_field_id,
         )
 
-    def delete(self, record_id: str):
+    def delete(self, record_id: RecordId) -> RecordDeletedDict:
         """
         Same as :meth:`Api.delete <pyairtable.api.Api.delete>`
         but without ``base_id`` and ``table_name`` arg.
         """
         return super()._delete(self.base_id, self.table_name, record_id)
 
-    def batch_delete(self, record_ids: List[str]):
+    def batch_delete(self, record_ids: List[RecordId]) -> List[RecordDeletedDict]:
         """
         Same as :meth:`Api.batch_delete <pyairtable.api.Api.batch_delete>`
         but without ``base_id`` and ``table_name`` arg.

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -9,6 +9,7 @@ from pyairtable.api.types import (
     UpdateRecordDict,
 )
 
+from . import base
 from .abstract import ApiAbstract, TimeoutTuple
 from .retrying import Retry
 
@@ -61,12 +62,12 @@ class Table(ApiAbstract):
         """Returns the table URL"""
         return super().get_table_url(self.base_id, self.table_name)
 
-    def get_base(self) -> "Base":
+    def get_base(self) -> "base.Base":
         """
         Returns a new :class:`Base` instance using all shared
         attributes from :class:`Table`
         """
-        return Base(self.api_key, self.base_id, timeout=self.timeout)
+        return base.Base(self.api_key, self.base_id, timeout=self.timeout)
 
     def get_record_url(self, record_id: RecordId) -> str:
         """
@@ -219,6 +220,3 @@ class Table(ApiAbstract):
 
     def __repr__(self) -> str:
         return "<Table base_id={} table_name={}>".format(self.base_id, self.table_name)
-
-
-from pyairtable.api.base import Base  # noqa

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -45,8 +45,9 @@ class Table(ApiAbstract):
             table_name: |arg_table_name|
 
         Keyword Args:
-            timeout (``Tuple``): |arg_timeout|
-            retry_strategy (``Retry``): |arg_retry_strategy|
+            timeout: |arg_timeout|
+            retry_strategy: |arg_retry_strategy|
+            endpoint_url: |arg_endpoint_url|
         """
         self.base_id = base_id
         self.table_name = table_name

--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -1,5 +1,5 @@
 """
-Types and type hinting utilities for pyAirtable.
+Types and TypedDicts for pyAirtable.
 """
 from typing import Dict, List, Literal, Optional, TypedDict, Union
 
@@ -8,76 +8,6 @@ from typing_extensions import Required, TypeAlias
 RecordId: TypeAlias = str
 Timestamp: TypeAlias = str
 FieldName: TypeAlias = str
-
-
-#: Represents the value of a field, excluding lists of values.
-RawFieldValue: TypeAlias = Union[
-    str,
-    int,
-    float,
-    bool,
-    "CollaboratorDict",
-    "BarcodeDict",
-    "ButtonDict",
-]
-
-
-#: Represents the value of a field on a particular record.
-FieldValue: TypeAlias = Union[
-    str,
-    int,
-    float,
-    bool,
-    "CollaboratorDict",
-    "BarcodeDict",
-    "ButtonDict",
-    List[str],
-    List[int],
-    List[float],
-    List[bool],
-    List["AttachmentDict"],
-    List["CollaboratorDict"],
-]
-
-
-#: A mapping of field names to values.
-Fields: TypeAlias = Dict[FieldName, FieldValue]
-
-
-class RecordDict(TypedDict):
-    """
-    Represents a record returned from the Airtable API.
-    """
-
-    id: RecordId
-    createdTime: Timestamp
-    fields: Fields
-
-
-class CreateRecordDict(TypedDict):
-    """
-    Represents the payload passed to the Airtable API to create a record.
-    """
-
-    fields: Fields
-
-
-class UpdateRecordDict(TypedDict):
-    """
-    Represents the payload passed to the Airtable API to create a record.
-    """
-
-    id: RecordId
-    fields: Fields
-
-
-class RecordDeletedDict(TypedDict):
-    """
-    Represents the payload passed to the Airtable API to create a record.
-    """
-
-    id: RecordId
-    deleted: Literal[True]
 
 
 class AttachmentDict(TypedDict, total=False):
@@ -178,3 +108,73 @@ class CollaboratorDict(TypedDict, total=False):
     email: str
     name: str
     profilePicUrl: str
+
+
+#: Represents the value of a field, excluding lists of values.
+RawFieldValue: TypeAlias = Union[
+    str,
+    int,
+    float,
+    bool,
+    CollaboratorDict,
+    BarcodeDict,
+    ButtonDict,
+]
+
+
+#: Represents the value of a field on a particular record.
+FieldValue: TypeAlias = Union[
+    str,
+    int,
+    float,
+    bool,
+    CollaboratorDict,
+    BarcodeDict,
+    ButtonDict,
+    List[str],
+    List[int],
+    List[float],
+    List[bool],
+    List[AttachmentDict],
+    List[CollaboratorDict],
+]
+
+
+#: A mapping of field names to values.
+Fields: TypeAlias = Dict[FieldName, FieldValue]
+
+
+class RecordDict(TypedDict):
+    """
+    Represents a record returned from the Airtable API.
+    """
+
+    id: RecordId
+    createdTime: Timestamp
+    fields: Fields
+
+
+class CreateRecordDict(TypedDict):
+    """
+    Represents the payload passed to the Airtable API to create a record.
+    """
+
+    fields: Fields
+
+
+class UpdateRecordDict(TypedDict):
+    """
+    Represents the payload passed to the Airtable API to create a record.
+    """
+
+    id: RecordId
+    fields: Fields
+
+
+class RecordDeletedDict(TypedDict):
+    """
+    Represents the payload passed to the Airtable API to create a record.
+    """
+
+    id: RecordId
+    deleted: Literal[True]

--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -1,0 +1,180 @@
+"""
+Types and type hinting utilities for pyAirtable.
+"""
+from typing import Dict, List, Literal, Optional, TypedDict, Union
+
+from typing_extensions import Required, TypeAlias
+
+RecordId: TypeAlias = str
+Timestamp: TypeAlias = str
+FieldName: TypeAlias = str
+
+
+#: Represents the value of a field, excluding lists of values.
+RawFieldValue: TypeAlias = Union[
+    str,
+    int,
+    float,
+    bool,
+    "CollaboratorDict",
+    "BarcodeDict",
+    "ButtonDict",
+]
+
+
+#: Represents the value of a field on a particular record.
+FieldValue: TypeAlias = Union[
+    str,
+    int,
+    float,
+    bool,
+    "CollaboratorDict",
+    "BarcodeDict",
+    "ButtonDict",
+    List[str],
+    List[int],
+    List[float],
+    List[bool],
+    List["AttachmentDict"],
+    List["CollaboratorDict"],
+]
+
+
+#: A mapping of field names to values.
+Fields: TypeAlias = Dict[FieldName, FieldValue]
+
+
+class RecordDict(TypedDict):
+    """
+    Represents a record returned from the Airtable API.
+    """
+
+    id: RecordId
+    createdTime: Timestamp
+    fields: Fields
+
+
+class CreateRecordDict(TypedDict):
+    """
+    Represents the payload passed to the Airtable API to create a record.
+    """
+
+    fields: Fields
+
+
+class UpdateRecordDict(TypedDict):
+    """
+    Represents the payload passed to the Airtable API to create a record.
+    """
+
+    id: RecordId
+    fields: Fields
+
+
+class RecordDeletedDict(TypedDict):
+    """
+    Represents the payload passed to the Airtable API to create a record.
+    """
+
+    id: RecordId
+    deleted: Literal[True]
+
+
+class AttachmentDict(TypedDict, total=False):
+    """
+    A dict representing an attachment stored in an Attachments field.
+
+    >>> record = api.get('base_id', 'table_name', 'recW8eG2x0ew1Af')
+    >>> record['fields']['Attachments']
+    [
+        {
+            'id': 'attW8eG2x0ew1Af',
+            'url': 'https://example.com/hello.jpg',
+            'filename': 'hello.jpg'
+        }
+    ]
+
+    See https://airtable.com/developers/web/api/field-model#multipleattachment
+    """
+
+    id: Required[str]
+    url: Required[str]
+    type: str
+    filename: str
+    size: int
+    height: int
+    width: int
+    thumbnails: Dict[str, Dict[str, Union[str, int]]]
+
+
+class CreateAttachmentDict(TypedDict, total=False):
+    """
+    A dict representing a new attachment to be written to the Airtable API.
+    """
+
+    url: Required[str]
+    filename: str
+
+
+class BarcodeDict(TypedDict, total=False):
+    """
+    A dict representing the value stored in a Barcode field.
+
+    >>> record = api.get('base_id', 'table_name', 'recW8eG2x0ew1Af')
+    >>> record['fields']['Barcode']
+    {'type': 'upce', 'text': '01234567'}
+
+    See https://airtable.com/developers/web/api/field-model#barcode
+    """
+
+    type: str
+    text: str
+
+
+class ButtonDict(TypedDict):
+    """
+    A dict representing the value stored in a Button field.
+
+    >>> record = api.get('base_id', 'table_name', 'recW8eG2x0ew1Af')
+    >>> record['fields']['Click Me']
+    {'label': 'Click Me', 'url': 'http://example.com'}
+
+    See https://airtable.com/developers/web/api/field-model#button
+    """
+
+    label: str
+    url: Optional[str]
+
+
+class CollaboratorDict(TypedDict, total=False):
+    """
+    A dict representing the value stored in a User field.
+
+    >>> record = api.get('base_id', 'table_name', 'recW8eG2x0ew1Af')
+    >>> record['fields']['Created By']
+    {
+        'id': 'usrAdw9EjV90xbW',
+        'email': 'alice@example.com',
+        'name': 'Alice Arnold'
+    }
+    >>> record['fields']['Collaborators']
+    [
+        {
+            'id': 'usrAdw9EjV90xbW',
+            'email': 'alice@example.com',
+            'name': 'Alice Arnold'
+        },
+        {
+            'id': 'usrAdw9EjV90xbX',
+            'email': 'bob@example.com',
+            'name': 'Bob Barker'
+        }
+    ]
+
+    See https://airtable.com/developers/web/api/field-model#collaborator
+    """
+
+    id: Required[str]
+    email: str
+    name: str
+    profilePicUrl: str

--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -3,7 +3,7 @@ pyAirtable provides a number of type aliases and TypedDicts which are used as in
 and return values to various pyAirtable methods.
 """
 from functools import lru_cache
-from typing import Any, Dict, List, Literal, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
 import pydantic
 from typing_extensions import Required, TypeAlias, TypedDict
@@ -208,7 +208,7 @@ class RecordDeletedDict(TypedDict):
     """
 
     id: RecordId
-    deleted: Literal[True]
+    deleted: bool
 
 
 @lru_cache

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -2,10 +2,12 @@ import re
 from datetime import date, datetime
 from typing import Any
 
+from pyairtable.api.types import Fields
+
 from .utils import date_to_iso_str, datetime_to_iso_str
 
 
-def match(dict_values, *, match_any=False):
+def match(dict_values: Fields, *, match_any: bool = False) -> str:
     """
     Creates one or more ``EQUAL()`` expressions for each provided dict value.
     If more than one assetions is included, the expressions are
@@ -58,7 +60,7 @@ def match(dict_values, *, match_any=False):
             return OR(*expressions)
 
 
-def escape_quotes(value: str):
+def escape_quotes(value: str) -> str:
     r"""
     Ensures any quotes are escaped. Already escaped quotes are ignored.
 
@@ -75,7 +77,7 @@ def escape_quotes(value: str):
     return escaped_value
 
 
-def to_airtable_value(value: Any):
+def to_airtable_value(value: Any) -> Any:
     """
     Cast value to appropriate airtable types and format.
     For example, to check ``bool`` values in formulas, you actually to compare
@@ -153,7 +155,7 @@ def STR_VALUE(value: str) -> str:
     return "'{}'".format(escape_quotes(str(value)))
 
 
-def IF(logical, value1, value2) -> str:
+def IF(logical: str, value1: str, value2: str) -> str:
     """
     Creates an IF statement
 
@@ -163,7 +165,7 @@ def IF(logical, value1, value2) -> str:
     return "IF({}, {}, {})".format(logical, value1, value2)
 
 
-def FIND(what: str, where: str, start_position=0) -> str:
+def FIND(what: str, where: str, start_position: int = 0) -> str:
     """
     Creates an FIND statement
 
@@ -182,7 +184,7 @@ def FIND(what: str, where: str, start_position=0) -> str:
         return "FIND({}, {})".format(what, where)
 
 
-def AND(*args) -> str:
+def AND(*args: str) -> str:
     """
     Creates an AND Statement
 
@@ -192,7 +194,7 @@ def AND(*args) -> str:
     return "AND({})".format(",".join(args))
 
 
-def OR(*args) -> str:
+def OR(*args: str) -> str:
     """
     .. versionadded:: 1.2.0
 
@@ -204,7 +206,7 @@ def OR(*args) -> str:
     return "OR({})".format(",".join(args))
 
 
-def LOWER(value) -> str:
+def LOWER(value: str) -> str:
     """
     .. versionadded:: 1.3.0
 

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -28,8 +28,9 @@ def match(dict_values: Fields, *, match_any: bool = False) -> str:
         dict_values: dictionary containing column names and values
 
     Keyword Args:
-        match_any: matches if **any** of the provided values match. Default is ``False``
-            (all values must match)
+        match_any (``bool``, default: ``False``):
+            If ``True``, matches if **any** of the provided values match.
+            Otherwise, all values must match.
 
     Usage:
         >>> match({"First Name": "John", "Age": 21})
@@ -96,7 +97,7 @@ def to_airtable_value(value: Any) -> Any:
         * - all others
           - unchanged
 
-    Arg:
+    Args:
         value: value to be cast.
 
     """

--- a/pyairtable/metadata.py
+++ b/pyairtable/metadata.py
@@ -1,9 +1,9 @@
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from pyairtable.api import Api, Base, Table
 
 
-def get_api_bases(api: Union[Api, Base]) -> dict:
+def get_api_bases(api: Union[Api, Base]) -> Dict[Any, Any]:
     """
     Return list of Bases from an Api or Base instance.
     For More Details `Metadata Api Documentation <https://airtable.com/api/meta>`_
@@ -29,10 +29,11 @@ def get_api_bases(api: Union[Api, Base]) -> dict:
             }
     """
     base_list_url = api.build_url("meta", "bases")
-    return api._request("get", base_list_url)
+    assert isinstance(response := api._request("get", base_list_url), dict)
+    return response
 
 
-def get_base_schema(base: Union[Base, Table]) -> dict:
+def get_base_schema(base: Union[Base, Table]) -> Dict[Any, Any]:
     """
     Returns Schema of a Base
     For More Details `Metadata Api Documentation <https://airtable.com/api/meta>`_
@@ -77,10 +78,11 @@ def get_base_schema(base: Union[Base, Table]) -> dict:
             }
     """
     base_schema_url = base.build_url("meta", "bases", base.base_id, "tables")
-    return base._request("get", base_schema_url)
+    assert isinstance(response := base._request("get", base_schema_url), dict)
+    return response
 
 
-def get_table_schema(table: Table) -> Optional[dict]:
+def get_table_schema(table: Table) -> Optional[Dict[Any, Any]]:
     """
     Returns the specific table schema record provided by base schema list
 
@@ -111,6 +113,7 @@ def get_table_schema(table: Table) -> Optional[dict]:
     """
     base_schema = get_base_schema(table)
     for table_record in base_schema.get("tables", {}):
+        assert isinstance(table_record, dict)
         if table.table_name == table_record["name"]:
             return table_record
     return None

--- a/pyairtable/metadata.py
+++ b/pyairtable/metadata.py
@@ -13,20 +13,20 @@ def get_api_bases(api: Union[Api, Base]) -> Dict[Any, Any]:
 
     Usage:
         >>> table.get_bases()
-            {
-                "bases": [
-                    {
-                        "id": "appY3WxIBCdKPDdIa",
-                        "name": "Apartment Hunting",
-                        "permissionLevel": "create"
-                    },
-                    {
-                        "id": "appSW9R5uCNmRmfl6",
-                        "name": "Project Tracker",
-                        "permissionLevel": "edit"
-                    }
-                ]
-            }
+        {
+            "bases": [
+                {
+                    "id": "appY3WxIBCdKPDdIa",
+                    "name": "Apartment Hunting",
+                    "permissionLevel": "create"
+                },
+                {
+                    "id": "appSW9R5uCNmRmfl6",
+                    "name": "Project Tracker",
+                    "permissionLevel": "edit"
+                }
+            ]
+        }
     """
     base_list_url = api.build_url("meta", "bases")
     assert isinstance(response := api._request("get", base_list_url), dict)
@@ -43,39 +43,39 @@ def get_base_schema(base: Union[Base, Table]) -> Dict[Any, Any]:
 
     Usage:
         >>> get_base_schema(base)
-            {
-                "tables": [
-                    {
-                        "id": "tbltp8DGLhqbUmjK1",
-                        "name": "Apartments",
-                        "primaryFieldId": "fld1VnoyuotSTyxW1",
-                        "fields": [
-                            {
-                                "id": "fld1VnoyuotSTyxW1",
-                                "name": "Name",
-                                "type": "singleLineText"
-                            },
-                            {
-                                "id": "fldoaIqdn5szURHpw",
-                                "name": "Pictures",
-                                "type": "multipleAttachment"
-                            },
-                            {
-                                "id": "fldumZe00w09RYTW6",
-                                "name": "District",
-                                "type": "multipleRecordLinks"
-                            }
-                        ],
-                        "views": [
-                            {
-                                "id": "viwQpsuEDqHFqegkp",
-                                "name": "Grid view",
-                                "type": "grid"
-                            }
-                        ]
-                    }
-                ]
-            }
+        {
+            "tables": [
+                {
+                    "id": "tbltp8DGLhqbUmjK1",
+                    "name": "Apartments",
+                    "primaryFieldId": "fld1VnoyuotSTyxW1",
+                    "fields": [
+                        {
+                            "id": "fld1VnoyuotSTyxW1",
+                            "name": "Name",
+                            "type": "singleLineText"
+                        },
+                        {
+                            "id": "fldoaIqdn5szURHpw",
+                            "name": "Pictures",
+                            "type": "multipleAttachment"
+                        },
+                        {
+                            "id": "fldumZe00w09RYTW6",
+                            "name": "District",
+                            "type": "multipleRecordLinks"
+                        }
+                    ],
+                    "views": [
+                        {
+                            "id": "viwQpsuEDqHFqegkp",
+                            "name": "Grid view",
+                            "type": "grid"
+                        }
+                    ]
+                }
+            ]
+        }
     """
     base_schema_url = base.build_url("meta", "bases", base.base_id, "tables")
     assert isinstance(response := base._request("get", base_schema_url), dict)

--- a/pyairtable/orm/__init__.py
+++ b/pyairtable/orm/__init__.py
@@ -1,1 +1,5 @@
-from .model import Model  # noqa
+from .model import Model
+
+__all__ = [
+    "Model",
+]

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -418,10 +418,6 @@ class ListField(Generic[T], Field[List[RecordId], List[T]]):
 
     def valid_or_raise(self, value: Any) -> None:
         super().valid_or_raise(value)
-        if value is None:
-            value = []
-        if not isinstance(value, list):
-            raise TypeError(type(value))
         if self.linked_model:
             for obj in value:
                 if not isinstance(obj, self.linked_model):

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -29,9 +29,8 @@ Link Fields
 -----------
 
 In addition to standard data type fields, the :class:`LinkField` class
-offers a special behaviour that can fetch linked records.
-
-In other words, you can transverse related records through their ``Link Fields``:
+offers a special behaviour that can fetch linked records, so that you can
+traverse between related records.
 
 >>> from pyairtable.orm import Model, fields
 >>> class Company(Model):
@@ -56,6 +55,7 @@ from typing import (
     Generic,
     List,
     Optional,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -76,11 +76,10 @@ from pyairtable.api.types import (
 )
 
 if TYPE_CHECKING:
-    from builtins import _ClassInfo
-
     from pyairtable.orm import Model  # noqa
 
 
+_ClassInfo: TypeAlias = Union[type, Tuple["_ClassInfo", ...]]
 T = TypeVar("T")
 T_Linked = TypeVar("T_Linked", bound="Model")
 T_API = TypeVar("T_API")  # type used to exchange values w/ Airtable API
@@ -102,7 +101,7 @@ class Field(Generic[T_API, T_ORM], metaclass=abc.ABCMeta):
     """
 
     #: Types that are allowed to be passed to this field.
-    valid_types: ClassVar["_ClassInfo"] = ()
+    valid_types: ClassVar[_ClassInfo] = ()
 
     #: Whether to allow modification of the value in this field.
     readonly: bool = False
@@ -116,8 +115,6 @@ class Field(Generic[T_API, T_ORM], metaclass=abc.ABCMeta):
         """
         Args:
             field_name: The name of the field in Airtable.
-
-        Keyword Args:
             validate_type: Whether to raise a TypeError if anything attempts to write
                 an object of an unsupported type as a field value. If ``False``, you
                 may encounter unpredictable behavior from the Airtable API.

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -49,13 +49,11 @@ In other words, you can transverse related records through their ``Link Fields``
 """
 import abc
 from datetime import date, datetime, timedelta
-from types import GeneratorType
 from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
     Generic,
-    Iterable,
     List,
     Optional,
     Type,
@@ -407,15 +405,12 @@ class ListField(Generic[T], Field[List[RecordId], List[T]]):
             setattr(model, self._attribute_name, value)
         return value
 
-    def __set__(self, instance: "Model", value: Optional[Iterable[T]]) -> None:
-        if isinstance(value, (set, tuple, GeneratorType)):
-            value = list(value)
-        elif value is not None and not isinstance(value, list):
-            raise TypeError(type(value))
-        super().__set__(instance, value)
-
     def valid_or_raise(self, value: Any) -> None:
         super().valid_or_raise(value)
+        if value is None:
+            value = []
+        if not isinstance(value, list):
+            raise TypeError(type(value))
         if self.linked_model:
             for obj in value:
                 if not isinstance(obj, self.linked_model):

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -55,14 +55,27 @@ from typing import (
     Any,
     ClassVar,
     Generic,
+    Iterable,
     List,
     Optional,
     Type,
     TypeVar,
     Union,
+    cast,
+    overload,
 )
 
+from typing_extensions import Self as SelfType
+from typing_extensions import TypeAlias
+
 from pyairtable import utils
+from pyairtable.api.types import (
+    AttachmentDict,
+    BarcodeDict,
+    ButtonDict,
+    CollaboratorDict,
+    RecordId,
+)
 
 if TYPE_CHECKING:
     from builtins import _ClassInfo
@@ -72,14 +85,26 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 T_Linked = TypeVar("T_Linked", bound="Model")
+T_API = TypeVar("T_API")  # type used to exchange values w/ Airtable API
+T_ORM = TypeVar("T_ORM")  # type used to store values internally
 
 
-class Field(metaclass=abc.ABCMeta):
+class Field(Generic[T_API, T_ORM], metaclass=abc.ABCMeta):
+    """
+    A generic class for an Airtable field descriptor that will be
+    included in an ORM model.
+
+    Type-checked subclasses should provide two type parameters,
+    ``T_API`` and ``T_ORM``, which indicate the type returned
+    by the API and the type used to store values internally.
+
+    Subclasses should also define ``valid_types`` as a type
+    or tuple of types, which will be used to validate the type
+    of field values being set via this descriptor.
+    """
+
     #: Types that are allowed to be passed to this field.
     valid_types: ClassVar["_ClassInfo"] = ()
-
-    #: The value we'll use when a field value is not present in the record.
-    value_if_missing: ClassVar[Any] = None
 
     #: Whether to allow modification of the value in this field.
     readonly: bool = False
@@ -112,23 +137,43 @@ class Field(metaclass=abc.ABCMeta):
         if readonly is not None:
             self.readonly = readonly
 
-    def __set_name__(self, owner, name) -> None:
+    def __set_name__(self, owner: Any, name: str) -> None:
         self._model = owner
         self._attribute_name = name
 
-    def __get__(self, instance, owner):
+    # __get__ and __set__ are called when accessing an instance of Field on an object.
+    # Model.field should return the Field instance itself, whereas
+    # obj.field should return the field's value from the Model instance obj.
+
+    # Model.field will call __get__(instance=None, owner=Model)
+    @overload
+    def __get__(self, instance: None, owner: Type[Any]) -> SelfType:
+        ...
+
+    # obj.field will call __get__(instance=obj, owner=Model)
+    @overload
+    def __get__(self, instance: "Model", owner: Type[Any]) -> Optional[T_ORM]:
+        ...
+
+    def __get__(
+        self, instance: Optional["Model"], owner: Type[Any]
+    ) -> Union[SelfType, Optional[T_ORM]]:
         # allow calling Model.field to get the field object instead of a value
         if not instance:
             return self
+        return self.get_value(instance)
 
-        field_name = self.field_name
+    def get_value(self, instance: "Model") -> Optional[T_ORM]:
+        """
+        Given an instance of the Model, retrieve the field value from it.
+        Easier for subclasses to override than __get__.
+        """
         try:
-            # Field Field is not yet in dict, return None
-            return instance._fields[field_name]
+            return cast(T_ORM, instance._fields[self.field_name])
         except (KeyError, AttributeError):
-            return self.value_if_missing
+            return self._missing_value()
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: "Model", value: Optional[T_ORM]) -> None:
         self._raise_if_readonly()
         if not hasattr(instance, "_fields"):
             instance._fields = {}
@@ -136,10 +181,13 @@ class Field(metaclass=abc.ABCMeta):
             self.valid_or_raise(value)
         instance._fields[self.field_name] = value
 
-    def __delete__(self, instance):
+    def __delete__(self, instance: "Model") -> None:
         raise AttributeError(
             f"cannot delete {self._model.__name__}.{self._attribute_name}"
         )
+
+    def _missing_value(self) -> Optional[T_ORM]:
+        return None
 
     def to_record_value(self, value: Any) -> Any:
         return value
@@ -147,7 +195,7 @@ class Field(metaclass=abc.ABCMeta):
     def to_internal_value(self, value: Any) -> Any:
         return value
 
-    def valid_or_raise(self, value) -> None:
+    def valid_or_raise(self, value: Any) -> None:
         if self.valid_types and not isinstance(value, self.valid_types):
             raise TypeError(
                 f"{self.__class__.__name__} value must be {self.valid_types}; got {type(value)}"
@@ -159,11 +207,19 @@ class Field(metaclass=abc.ABCMeta):
                 f"{self._model.__name__}.{self._attribute_name} is read-only"
             )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{} field_name='{}'>".format(self.__class__.__name__, self.field_name)
 
 
-class TextField(Field):
+#: A generic Field whose internal and API representations are the same type.
+BasicField: TypeAlias = Field[T, T]
+
+
+#: An alias for any type of Field.
+AnyField: TypeAlias = BasicField[Any]
+
+
+class TextField(BasicField[str]):
     """
     Used for all Airtable text fields. Accepts `str`.
     """
@@ -173,14 +229,11 @@ class TextField(Field):
     def to_internal_value(self, value: Any) -> str:
         return str(value)
 
-    def __get__(self, *args, **kwargs) -> Optional[str]:
-        return super().__get__(*args, **kwargs)
 
-
-class _NumericField(Field):
+class _NumericField(Generic[T], BasicField[T]):
     """Base class for Number, Float, and Integer. Shares a common validation rule."""
 
-    def valid_or_raise(self, value) -> None:
+    def valid_or_raise(self, value: Any) -> None:
         # Because `bool` is a subclass of `int`, we have to explicitly check for it here.
         if isinstance(value, bool):
             raise TypeError(
@@ -189,7 +242,7 @@ class _NumericField(Field):
         return super().valid_or_raise(value)
 
 
-class NumberField(_NumericField):
+class NumberField(_NumericField[Union[int, float]]):
     """
     Number field with unspecified precision. Accepts either `int` or `float`.
     """
@@ -201,13 +254,10 @@ class NumberField(_NumericField):
             raise TypeError(type(value))
         return value
 
-    def __get__(self, *args, **kwargs) -> Optional[Union[int, float]]:
-        return super().__get__(*args, **kwargs)
-
 
 # This cannot inherit from NumberField because valid_types would be more restrictive
 # in the subclass than what is defined in the parent class.
-class IntegerField(_NumericField):
+class IntegerField(_NumericField[int]):
     """
     Number field with integer precision. Accepts only `int` values.
     """
@@ -217,13 +267,10 @@ class IntegerField(_NumericField):
     def to_internal_value(self, value: Any) -> int:
         return int(value)
 
-    def __get__(self, *args, **kwargs) -> Optional[int]:
-        return super().__get__(*args, **kwargs)
-
 
 # This cannot inherit from NumberField because valid_types would be more restrictive
 # in the subclass than what is defined in the parent class.
-class FloatField(_NumericField):
+class FloatField(_NumericField[float]):
     """
     Number field with decimal precision. Accepts only `float` values.
     """
@@ -232,9 +279,6 @@ class FloatField(_NumericField):
 
     def to_internal_value(self, value: Any) -> float:
         return float(value)
-
-    def __get__(self, *args, **kwargs) -> Optional[float]:
-        return super().__get__(*args, **kwargs)
 
 
 class RatingField(IntegerField):
@@ -248,22 +292,21 @@ class RatingField(IntegerField):
             raise ValueError("rating cannot be below 1")
 
 
-class CheckboxField(Field):
+class CheckboxField(BasicField[bool]):
     """
     Returns `False` instead of `None` if the field is empty on the Airtable base.
     """
 
     valid_types = bool
-    value_if_missing = False
+
+    def _missing_value(self) -> bool:
+        return False
 
     def to_internal_value(self, value: Any) -> bool:
         return bool(value)
 
-    def __get__(self, *args, **kwargs) -> Optional[bool]:
-        return super().__get__(*args, **kwargs)
 
-
-class DatetimeField(Field):
+class DatetimeField(Field[str, datetime]):
     """
     DateTime field. Accepts only `datetime <https://docs.python.org/3/library/datetime.html#datetime-objects>`_ values.
     """
@@ -278,11 +321,8 @@ class DatetimeField(Field):
         """Airtable returns ISO 8601 string datetime eg. "2014-09-05T07:00:00.000Z" """
         return utils.datetime_from_iso_str(value)
 
-    def __get__(self, *args, **kwargs) -> Optional[datetime]:
-        return super().__get__(*args, **kwargs)
 
-
-class DateField(Field):
+class DateField(Field[str, date]):
     """
     Date field. Accepts only `date <https://docs.python.org/3/library/datetime.html#date-objects>`_ values.
     """
@@ -297,11 +337,8 @@ class DateField(Field):
         """Airtable returns ISO 8601 date string eg. "2014-09-05"""
         return utils.date_from_iso_str(value)
 
-    def __get__(self, *args, **kwargs) -> Optional[date]:
-        return super().__get__(*args, **kwargs)
 
-
-class DurationField(Field):
+class DurationField(Field[int, timedelta]):
     """
     Duration field. Accepts only `timedelta <https://docs.python.org/3/library/datetime.html#timedelta-objects>`_ values.
     Airtable's API returns this as a number of seconds.
@@ -315,11 +352,8 @@ class DurationField(Field):
     def to_internal_value(self, value: Union[int, float]) -> timedelta:
         return timedelta(seconds=value)
 
-    def __get__(self, *args, **kwargs) -> Optional[timedelta]:
-        return super().__get__(*args, **kwargs)
 
-
-class _DictField(Field):
+class _DictField(Generic[T], BasicField[T]):
     """
     Generic field type that stores a single dict. Not for use via API;
     should be subclassed by concrete field types (below).
@@ -327,11 +361,8 @@ class _DictField(Field):
 
     valid_types = dict
 
-    def __get__(self, *args, **kwargs) -> Optional[dict]:
-        return super().__get__(*args, **kwargs)
 
-
-class ListField(Field, Generic[T]):
+class ListField(Generic[T], Field[List[RecordId], List[T]]):
     """
     Generic type for a field that stores a list of values. Can be used
     to refer to a lookup field that might return more than one value.
@@ -369,19 +400,21 @@ class ListField(Field, Generic[T]):
         if model is not None:
             self.linked_model = model
 
-    def __get__(self, instance, owner) -> List[T]:
-        value = super().__get__(instance, owner)
+    def get_value(self, model: "Model") -> List[T]:
+        value = super().get_value(model)
         if value is None:
             value = []
-            setattr(instance, self._attribute_name, value)
+            setattr(model, self._attribute_name, value)
         return value
 
-    def __set__(self, instance, value) -> None:
+    def __set__(self, instance: "Model", value: Optional[Iterable[T]]) -> None:
         if isinstance(value, (set, tuple, GeneratorType)):
             value = list(value)
+        elif value is not None and not isinstance(value, list):
+            raise TypeError(type(value))
         super().__set__(instance, value)
 
-    def valid_or_raise(self, value) -> None:
+    def valid_or_raise(self, value: Any) -> None:
         super().valid_or_raise(value)
         if self.linked_model:
             for obj in value:
@@ -401,7 +434,12 @@ class LinkField(ListField[T_Linked]):
     See :ref:`Link Fields`.
     """
 
-    def __init__(self, field_name: str, model: Union[str, Type[T_Linked]], lazy=True):
+    def __init__(
+        self,
+        field_name: str,
+        model: Union[str, Type[T_Linked]],
+        lazy: bool = True,
+    ):
         """
         Args:
             field_name: Name of Airtable Column
@@ -427,7 +465,7 @@ class LinkField(ListField[T_Linked]):
             raise RuntimeError(f"{self.__class__.__name__} must be declared with model")
         should_fetch = not self._lazy
         linked_models = [
-            self.linked_model._linked_cache.get(id_)
+            cast(T_Linked, self.linked_model._linked_cache.get(id_))
             or self.linked_model.from_id(id_, fetch=should_fetch)
             for id_ in value
         ]
@@ -454,7 +492,7 @@ class AutoNumberField(IntegerField):
     readonly = True
 
 
-class BarcodeField(_DictField):
+class BarcodeField(_DictField[BarcodeDict]):
     """
     Accepts a `dict` that should conform to the format detailed in the
     `Barcode <https://airtable.com/developers/web/api/field-model#barcode>`_
@@ -462,7 +500,7 @@ class BarcodeField(_DictField):
     """
 
 
-class ButtonField(_DictField):
+class ButtonField(_DictField[ButtonDict]):
     """
     Read-only field that returns a `dict`. For more information, read the
     `Button <https://airtable.com/developers/web/api/field-model#button>`_
@@ -472,7 +510,7 @@ class ButtonField(_DictField):
     readonly = True
 
 
-class CollaboratorField(_DictField):
+class CollaboratorField(_DictField[CollaboratorDict]):
     """
     Accepts a `dict` that should conform to the format detailed in the
     `Collaborator <https://airtable.com/developers/web/api/field-model#collaborator>`_
@@ -549,24 +587,24 @@ class LookupField(ListField[str]):
     linked_model = str
 
 
-class MultipleAttachmentsField(ListField[dict]):
+class MultipleAttachmentsField(ListField[AttachmentDict]):
     """
     Accepts a list of dicts that should conform to the format detailed in the
     `Attachments <https://airtable.com/developers/web/api/field-model#multipleattachment>`_
     documentation.
     """
 
-    linked_model = dict
+    linked_model = cast(Type[AttachmentDict], dict)
 
 
-class MultipleCollaboratorsField(ListField[dict]):
+class MultipleCollaboratorsField(ListField[CollaboratorDict]):
     """
     Accepts a list of dicts that should conform to the format detailed in the
     `Multiple Collaborators <https://airtable.com/developers/web/api/field-model#multicollaborator>`_
     documentation.
     """
 
-    linked_model = dict
+    linked_model = cast(Type[CollaboratorDict], dict)
 
 
 class MultipleSelectField(ListField[str]):

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -203,7 +203,15 @@ class Field(Generic[T_API, T_ORM], metaclass=abc.ABCMeta):
             )
 
     def __repr__(self) -> str:
-        return "<{} field_name='{}'>".format(self.__class__.__name__, self.field_name)
+        args = [repr(self.field_name)]
+        args += [f"{key}={val!r}" for (key, val) in self._repr_fields()]
+        return self.__class__.__name__ + "(" + ", ".join(args) + ")"
+
+    def _repr_fields(self) -> List[Tuple[str, Any]]:
+        return [
+            ("readonly", self.readonly),
+            ("validate_type", self.validate_type),
+        ]
 
 
 #: A generic Field whose internal and API representations are the same type.
@@ -395,6 +403,12 @@ class ListField(Generic[T], Field[List[RecordId], List[T]]):
         if model is not None:
             self.linked_model = model
 
+    def _repr_fields(self) -> List[Tuple[str, Any]]:
+        return [
+            ("model", self.linked_model),
+            *super()._repr_fields(),
+        ]
+
     def get_value(self, model: "Model") -> List[T]:
         value = super().get_value(model)
         if value is None:
@@ -449,6 +463,12 @@ class LinkField(ListField[T_Linked]):
 
         self._lazy = lazy
         super().__init__(field_name, model=model)
+
+    def _repr_fields(self) -> List[Tuple[str, Any]]:
+        return [
+            ("model", self.linked_model),
+            ("lazy", self._lazy),
+        ]
 
     def to_internal_value(self, value: Any) -> List[T_Linked]:
         # If Lazy, create empty from model class and set id

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -59,10 +59,8 @@ Finally, you can use :meth:`~pyairtable.orm.model.Model.delete` to delete the re
 >>> contact.delete()
 True
 """
-from __future__ import annotations
-
 import abc
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from typing_extensions import Self as SelfType
 
@@ -96,15 +94,15 @@ class Model(metaclass=abc.ABCMeta):
     id: str = ""
     created_time: str = ""
     _table: Table
-    _fields: dict[FieldName, Any] = {}
-    _linked_cache: dict[RecordId, SelfType] = {}
+    _fields: Dict[FieldName, Any] = {}
+    _linked_cache: Dict[RecordId, SelfType] = {}
 
     def __init_subclass__(cls, **kwargs: Any):
         cls._validate_class()
         super().__init_subclass__(**kwargs)
 
     @classmethod
-    def _attribute_descriptor_map(cls) -> dict[str, AnyField]:
+    def _attribute_descriptor_map(cls) -> Dict[str, AnyField]:
         """
         Returns a dictionary mapping the model's attribute names to the field's
 
@@ -121,7 +119,7 @@ class Model(metaclass=abc.ABCMeta):
         return {k: v for k, v in cls.__dict__.items() if isinstance(v, Field)}
 
     @classmethod
-    def _field_name_descriptor_map(cls) -> dict[FieldName, AnyField]:
+    def _field_name_descriptor_map(cls) -> Dict[FieldName, AnyField]:
         """
         Returns a dictionary that maps Fields 'Names' to descriptor fields
 
@@ -138,7 +136,7 @@ class Model(metaclass=abc.ABCMeta):
         return {f.field_name: f for f in cls._attribute_descriptor_map().values()}
 
     @classmethod
-    def _field_name_attribute_map(cls) -> dict[FieldName, str]:
+    def _field_name_attribute_map(cls) -> Dict[FieldName, str]:
         """
         Returns a dictionary that maps Fields 'Names' to the model attribute name:
 
@@ -330,31 +328,3 @@ class Model(metaclass=abc.ABCMeta):
 
     def __repr__(self) -> str:
         return "<Model={} {}>".format(self.__class__.__name__, hex(id(self)))
-
-    # TODO - see metadata.py
-    # def verify_schema(cls) -> Tuple[bool, dict]:
-    #     """verify local airtable models"""
-
-    #     base_list = cls.get_base_list()
-    #     base_id_exists = cls.base_id in [b["id"] for b in base_list["bases"]]
-
-    #     if base_id_exists:
-    #         base_schema = cls.get_base_schema()
-    #         table_schema: dict = next(
-    #             (t for t in base_schema["tables"] if t["name"] == cls.table_name), {}
-    #         )
-    #         table_exists = bool(table_schema)
-    #     else:
-    #         table_exists = False
-
-    #     if table_exists:
-    #         airtable_field_names = [f["name"] for f in table_schema["fields"]]
-    #         # Fields.NAME = "|NAME|", Fields.ID = "|ID|") -> ["|NAME|", "|ID|"]
-    #         local_field_names = [v for k, v in vars(cls.Fields).items() if k.isupper()]
-    #         fields = {n: n in airtable_field_names for n in local_field_names}
-    #     else:
-    #         fields = {}
-
-    #     in_sync = base_id_exists and table_exists and all(fields.values())
-    #     details = {"base": base_id_exists, "table": table_exists, "fields": fields}
-    #     return (in_sync, details)

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -33,7 +33,7 @@ False
 >>> contact.exists()
 True
 >>> contact.id
-rec123asa23
+'rec123asa23'
 
 
 You can read and modify attributes. If record already exists,
@@ -44,13 +44,13 @@ You can read and modify attributes. If record already exists,
 >>> assert contact.is_registered is True
 >>> contact.to_record()
 {
-    "id": recS6qSLw0OCA6Xul",
+    "id": "recS6qSLw0OCA6Xul",
     "createdTime": "2021-07-14T06:42:37.000Z",
     "fields": {
         "First Name": "Mike",
         "Last Name": "McDonalds",
         "Email": "mike@mcd.com",
-        "Resgistered": True
+        "Registered": True
     }
 }
 
@@ -232,7 +232,7 @@ class Model(metaclass=abc.ABCMeta):
         return did_create
 
     def delete(self) -> bool:
-        """Deleted record. Must have 'id' field"""
+        """Deletes record. Must have 'id' field"""
         if not self.id:
             raise ValueError("cannot be deleted because it does not have id")
         table = self.get_table()
@@ -268,7 +268,7 @@ class Model(metaclass=abc.ABCMeta):
         ISO 8601 string
 
         Args:
-            only_writable (``bool``): If ``True``, the result will exclude any
+            only_writable: If ``True``, the result will exclude any
                 values which are associated with readonly fields.
         """
         map_ = self._field_name_descriptor_map()
@@ -306,14 +306,9 @@ class Model(metaclass=abc.ABCMeta):
 
         Args:
             record_id: |arg_record_id|
-
-        Keyward Args:
             fetch: If `True`, record will be fetched and fields will be
                 updated. If `False`, a new instance is created with the provided `id`,
                 but field values are unset. Default is `True`.
-
-        Returns:
-            (``Model``): Instance of model
         """
         if fetch:
             table = cls.get_table()

--- a/pyairtable/testing.py
+++ b/pyairtable/testing.py
@@ -4,9 +4,18 @@ Helper functions for writing tests that use the pyairtable library.
 import datetime
 import random
 import string
+from typing import Any, Optional
+
+from pyairtable.api.types import (
+    AttachmentDict,
+    CollaboratorDict,
+    Fields,
+    FieldValue,
+    RecordDict,
+)
 
 
-def fake_id(type="rec", value=None):
+def fake_id(type: str = "rec", value: Any = None) -> str:
     """
     Generates a fake Airtable-style ID.
 
@@ -27,10 +36,10 @@ def fake_id(type="rec", value=None):
 
 
 def fake_meta(
-    base_id="appFakeTestingApp",
-    table_name="tblFakeTestingTbl",
-    api_key="patFakePersonalAccessToken",
-):
+    base_id: str = "appFakeTestingApp",
+    table_name: str = "tblFakeTestingTbl",
+    api_key: str = "patFakePersonalAccessToken",
+) -> type:
     """
     Returns a ``Meta`` class for inclusion in a ``Model`` subclass.
     """
@@ -38,7 +47,11 @@ def fake_meta(
     return type("Meta", (), attrs)
 
 
-def fake_record(fields=None, id=None, **other_fields):
+def fake_record(
+    fields: Optional[Fields] = None,
+    id: Optional[str] = None,
+    **other_fields: FieldValue,
+) -> RecordDict:
     """
     Returns a fake record dict with the given field values.
 
@@ -58,17 +71,16 @@ def fake_record(fields=None, id=None, **other_fields):
     }
 
 
-def fake_user(value=None):
+def fake_user(value: Any = None) -> CollaboratorDict:
     id = fake_id("usr", value)
     return {"id": id, "email": f"{value or id}@example.com"}
 
 
-def fake_attachment(**kwargs):
+def fake_attachment() -> AttachmentDict:
     return {
         "id": fake_id("att"),
         "url": "https://example.com/",
         "filename": "foo.txt",
         "size": 100,
         "type": "text/plain",
-        **kwargs,
     }

--- a/pyairtable/testing.py
+++ b/pyairtable/testing.py
@@ -19,7 +19,7 @@ def fake_id(type: str = "rec", value: Any = None) -> str:
     """
     Generates a fake Airtable-style ID.
 
-    Keyword Args:
+    Args:
         type: the object type prefix, defaults to "rec"
         value: any value to use as the ID, defaults to random letters and digits
 

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -1,5 +1,9 @@
 from datetime import date, datetime
-from typing import Union
+from typing import Iterator, Sequence, TypeVar, Union
+
+from pyairtable.api.types import CreateAttachmentDict
+
+T = TypeVar("T")
 
 
 def datetime_to_iso_str(value: datetime) -> str:
@@ -46,9 +50,9 @@ def date_from_iso_str(value: str) -> date:
     return datetime.strptime(value, "%Y-%m-%d").date()
 
 
-def attachment(url: str, filename="") -> dict:
+def attachment(url: str, filename: str = "") -> CreateAttachmentDict:
     """
-    Returns a dictionary using the expected dicitonary format for attachments.
+    Returns a dictionary using the expected dictionary format for creating attachments.
 
     When creating an attachment, ``url`` is required, and ``filename`` is optional.
     Airtable will download the file at the given url and keep its own copy of it.
@@ -78,3 +82,11 @@ def attachment(url: str, filename="") -> dict:
 
     """
     return {"url": url} if not filename else {"url": url, "filename": filename}
+
+
+def chunked(iterable: Sequence[T], chunk_size: int) -> Iterator[Sequence[T]]:
+    """
+    Break a sequence into chunks
+    """
+    for i in range(0, len(iterable), chunk_size):
+        yield iterable[i : i + chunk_size]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 # Docs
-Sphinx==4.1.2
-sphinx-autoapi==1.7.0
-sphinxext-opengraph==0.4.2
+Sphinx==4.5.0
+sphinx-autoapi
+sphinxext-opengraph
 revitron-sphinx-theme @ git+https://github.com/gtalarico/revitron-sphinx-theme.git@40f4b09fa5c199e3844153ef973a1155a56981dd
-sphinx-autodoc-typehints==1.12.0
+sphinx-autodoc-typehints
 
 # Packaging
 wheel==0.38.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
+    pydantic
     requests >= 2.22.0
     typing_extensions
     urllib3 < 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,3 @@ install_requires =
 
 [aliases]
 test=pytest
-
-[mypy]
-mypy_path = pyairtable
-python_version = 3.8
-warn_return_any = False
-warn_unused_configs = False

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -263,7 +263,7 @@ def test_batch_upsert__missing_field(table, requests_mock):
 
 def test_delete(table, mock_response_single):
     id_ = mock_response_single["id"]
-    expected = {"delete": True, "id": id_}
+    expected = {"deleted": True, "id": id_}
     with Mocker() as mock:
         mock.delete(urljoin(table.table_url, id_), status_code=201, json=expected)
         resp = table.delete(id_)
@@ -274,7 +274,7 @@ def test_batch_delete(table, mock_records):
     ids = [i["id"] for i in mock_records]
     with Mocker() as mock:
         for chunk in _chunk(ids, 10):
-            json_response = {"records": [{"delete": True, "id": id_} for id_ in chunk]}
+            json_response = {"records": [{"deleted": True, "id": id_} for id_ in chunk]}
             url_match = (
                 Request("get", table.table_url, params={"records[]": chunk})
                 .prepare()
@@ -287,7 +287,7 @@ def test_batch_delete(table, mock_records):
             )
 
         resp = table.batch_delete(ids)
-    expected = [{"delete": True, "id": i} for i in ids]
+    expected = [{"deleted": True, "id": i} for i in ids]
     assert resp == expected
 
 

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -5,6 +5,7 @@ from requests import Request
 from requests_mock import Mocker
 
 from pyairtable import Table
+from pyairtable.utils import chunked
 
 
 def test_repr(table):
@@ -25,7 +26,7 @@ def test_url(base_id, table_name, table_url_suffix):
 
 
 def test_chunk(table):
-    chunks = [chunk for chunk in table._chunk([0, 0, 1, 1, 2, 2, 3], 2)]
+    chunks = [chunk for chunk in chunked([0, 0, 1, 1, 2, 2, 3], 2)]
     assert chunks[0] == [0, 0]
     assert chunks[1] == [1, 1]
     assert chunks[2] == [2, 2]

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -58,3 +58,8 @@ def test_assert_not_typed_dict(cls, value):
         T.assert_typed_dict(cls, value)
     with pytest.raises(TypeError):
         T.assert_typed_dicts(cls, [value])
+
+
+def test_assert_typed_dicts__not_list():
+    with pytest.raises(TypeError):
+        T.assert_typed_dicts(T.RecordDict, object())

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -1,0 +1,60 @@
+import pytest
+
+from pyairtable.api import types as T
+from pyairtable.testing import fake_attachment, fake_id, fake_record, fake_user
+
+
+@pytest.mark.parametrize(
+    "cls,value",
+    [
+        (T.AttachmentDict, fake_attachment()),
+        (T.BarcodeDict, {"type": "upc", "text": "0123456"}),
+        (T.BarcodeDict, {"text": "0123456"}),
+        (T.ButtonDict, {"label": "My Button", "url": "http://example.com"}),
+        (T.ButtonDict, {"label": "My Button", "url": None}),
+        (T.CollaboratorDict, fake_user()),
+        (T.CreateAttachmentDict, {"url": "http://example.com", "filename": "test.jpg"}),
+        (T.CreateAttachmentDict, {"url": "http://example.com"}),
+        (T.CreateRecordDict, {"fields": {}}),
+        (T.RecordDeletedDict, {"deleted": True, "id": fake_id()}),
+        (T.RecordDict, fake_record()),
+        (T.UpdateRecordDict, {"id": fake_id(), "fields": {}}),
+        # Test that we won't fail if Airtable adds new fields in the fuutre
+        (T.RecordDict, {**fake_record(), "comments": []}),
+    ],
+)
+def test_assert_typed_dict(cls, value):
+    """
+    Test that we can assert that a dict does conform to a TypedDict.
+    """
+    T.assert_typed_dict(cls, value)
+    T.assert_typed_dicts(cls, [value])
+    # Test that a mix of valid and invalid values still raises TypeError
+    with pytest.raises(TypeError):
+        T.assert_typed_dicts(cls, [value, -1])
+
+
+@pytest.mark.parametrize(
+    "cls,value",
+    [
+        (T.AttachmentDict, {}),
+        (T.BarcodeDict, {"type": "upc"}),
+        (T.ButtonDict, {}),
+        (T.CollaboratorDict, {}),
+        (T.CreateAttachmentDict, {}),
+        (T.CreateRecordDict, {}),
+        (T.RecordDeletedDict, {}),
+        (T.RecordDict, {}),
+        (T.UpdateRecordDict, {}),
+        # test failure for other data types
+        (T.RecordDict, -1),
+    ],
+)
+def test_assert_not_typed_dict(cls, value):
+    """
+    Test that we can assert that a dict does *not* conform to a TypedDict.
+    """
+    with pytest.raises(TypeError):
+        T.assert_typed_dict(cls, value)
+    with pytest.raises(TypeError):
+        T.assert_typed_dicts(cls, [value])

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -107,6 +107,29 @@ def test_model():
     assert record["fields"]["First Name"] == contact.first_name
 
 
+def test_first():
+    with mock.patch.object(Table, "first") as m_first:
+        m_first.return_value = {
+            "id": "recwnBLPIeQJoYVt4",
+            "createdTime": "",
+            "fields": {
+                "First Name": "X",
+                "Created At": "2014-09-05T12:34:56.000Z",
+            },
+        }
+        contact = Contact.first()
+
+    assert contact.first_name == "X"
+
+
+def test_first_none():
+    with mock.patch.object(Table, "first") as m_first:
+        m_first.return_value = None
+        contact = Contact.first()
+
+    assert contact is None
+
+
 def test_from_record():
     # Fetch = True
     with mock.patch.object(Table, "get") as m_get:

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -52,7 +52,7 @@ def test_orm_missing_values(field_type, default_value):
 
 # Mapping from types to a test value for that type.
 TYPE_VALIDATION_TEST_VALUES = {
-    **{t: t() for t in (str, bool, list, dict, set, tuple)},
+    **{t: t() for t in (str, bool, list, dict)},
     int: 1,  # cannot use int() because RatingField requires value >= 1
     float: 1.0,  # cannot use float() because RatingField requires value >= 1
     datetime.date: datetime.date.today(),
@@ -75,17 +75,17 @@ TYPE_VALIDATION_TEST_VALUES = {
         (f.PhoneNumberField, str),
         (f.DurationField, datetime.timedelta),
         (f.RatingField, int),
-        (f.ListField, (list, tuple, set)),
+        (f.ListField, list),
         (f.UrlField, str),
-        (f.LookupField, (list, tuple, set)),
-        (f.MultipleSelectField, (list, tuple, set)),
+        (f.LookupField, list),
+        (f.MultipleSelectField, list),
         (f.PercentField, (int, float)),
         (f.DateField, (datetime.date, datetime.datetime)),
         (f.FloatField, float),
         (f.CollaboratorField, dict),
         (f.SelectField, str),
         (f.EmailField, str),
-        (f.MultipleCollaboratorsField, (list, tuple, set)),
+        (f.MultipleCollaboratorsField, list),
         (f.CurrencyField, (int, float)),
     ],
     ids=operator.itemgetter(0),
@@ -266,30 +266,6 @@ def assert_all_fields_tested_by(*test_fns, exclude=(f.Field, f.LinkField)):
         test_names = sorted(fn.__name__ for fn in test_fns)
         fail_names = "\n".join(f"- {name}" for name in missing)
         pytest.fail(f"Some fields were not tested by {test_names}:\n{fail_names}")
-
-
-@pytest.mark.parametrize(
-    argnames="values",
-    argvalues=[
-        (1, 2, 3, 4),  # tuple
-        {1, 2, 3, 4},  # set
-        (n + 1 for n in range(4)),  # generator
-    ],
-    ids=type,
-)
-def test_list_field_assignment(values):
-    """
-    Test that we can assign any sort of iterable to a list field
-    and it will result in a list being stored internally.
-    """
-
-    class T:
-        items = f.ListField("Items")
-
-    t = T()
-    t.items = values
-    assert isinstance(t.items, list)
-    assert sorted(t.items) == [1, 2, 3, 4]
 
 
 def test_list_field_with_string():

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -27,6 +27,35 @@ def test_field():
 
 
 @pytest.mark.parametrize(
+    "instance,expected",
+    [
+        (
+            f.Field("Name"),
+            "Field('Name', readonly=False, validate_type=True)",
+        ),
+        (
+            f.CollaboratorField("Collaborator"),
+            "CollaboratorField('Collaborator', readonly=False, validate_type=True)",
+        ),
+        (
+            f.LastModifiedByField("User"),
+            "LastModifiedByField('User', readonly=True, validate_type=True)",
+        ),
+        (
+            f.ListField("Items", dict, validate_type=False),
+            "ListField('Items', model=<class 'dict'>, readonly=False, validate_type=False)",
+        ),
+        (
+            f.LinkField("Records", type("TestModel", (Model,), {"Meta": fake_meta()})),
+            "LinkField('Records', model=<class 'abc.TestModel'>, lazy=True)",
+        ),
+    ],
+)
+def test_repr(instance, expected):
+    assert repr(instance) == expected
+
+
+@pytest.mark.parametrize(
     argnames=("field_type", "default_value"),
     argvalues=[
         (f.Field, None),

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -8,7 +8,6 @@ from pyairtable.api.params import (
     field_names_to_sorting_dict,
     options_to_json_and_params,
     options_to_params,
-    to_params_dict,
 )
 
 
@@ -115,13 +114,6 @@ def test_params_integration(table, mock_records, mock_response_iterator):
 def test_convert_options_to_params(option, value, url_params):
     """Ensure kwargs received build a proper params"""
     processed_params = options_to_params({option: value})
-    request = requests.Request("get", "https://example.com", params=processed_params)
-    assert request.prepare().url.endswith(url_params)
-
-    # TODO: remove in 2.0.0
-    with pytest.deprecated_call():
-        processed_params = to_params_dict(option, value)
-
     request = requests.Request("get", "https://example.com", params=processed_params)
     assert request.prepare().url.endswith(url_params)
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,62 @@
+"""
+Tests that pyairtable.api functions/methods return appropriately typed responses.
+"""
+from typing import TYPE_CHECKING, Iterator, List, Optional
+
+from typing_extensions import assert_type
+
+import pyairtable.api
+import pyairtable.api.types as T
+
+if TYPE_CHECKING:
+    # This section does not actually get executed; it is only parsed by mypy.
+    access_token = "patFakeAccessToken"
+    base_id = "appTheTestingBase"
+    table_name = "tblImaginaryTable"
+    record_id = "recSomeFakeRecord"
+    now = "2023-01-01T00:00:00.0000Z"
+
+    # Ensure the type signatures for pyairtable.api.Api don't change.
+    api = pyairtable.api.Api(access_token)
+    assert_type(api.get(base_id, table_name, record_id), T.RecordDict)
+    assert_type(api.iterate(base_id, table_name), Iterator[List[T.RecordDict]])
+    assert_type(api.all(base_id, table_name), List[T.RecordDict])
+    assert_type(api.first(base_id, table_name), Optional[T.RecordDict])
+    assert_type(api.create(base_id, table_name, {}), T.RecordDict)
+    assert_type(api.update(base_id, table_name, record_id, {}), T.RecordDict)
+    assert_type(api.delete(base_id, table_name, record_id), T.RecordDeletedDict)
+    assert_type(api.batch_create(base_id, table_name, []), List[T.RecordDict])
+    assert_type(api.batch_update(base_id, table_name, []), List[T.RecordDict])
+    assert_type(api.batch_upsert(base_id, table_name, [], []), List[T.RecordDict])
+    assert_type(api.batch_delete(base_id, table_name, []), List[T.RecordDeletedDict])
+    assert_type(api.get_base(base_id), pyairtable.api.Base)
+    assert_type(api.get_table(base_id, table_name), pyairtable.api.Table)
+
+    # Ensure the type signatures for pyairtable.api.Base don't change.
+    base = pyairtable.api.Base(access_token, base_id)
+    assert_type(base.get(table_name, record_id), T.RecordDict)
+    assert_type(base.iterate(table_name), Iterator[List[T.RecordDict]])
+    assert_type(base.all(table_name), List[T.RecordDict])
+    assert_type(base.first(table_name), Optional[T.RecordDict])
+    assert_type(base.create(table_name, {}), T.RecordDict)
+    assert_type(base.update(table_name, record_id, {}), T.RecordDict)
+    assert_type(base.delete(table_name, record_id), T.RecordDeletedDict)
+    assert_type(base.batch_create(table_name, []), List[T.RecordDict])
+    assert_type(base.batch_update(table_name, []), List[T.RecordDict])
+    assert_type(base.batch_upsert(table_name, [], []), List[T.RecordDict])
+    assert_type(base.batch_delete(table_name, []), List[T.RecordDeletedDict])
+    assert_type(base.get_table(table_name), pyairtable.api.Table)
+
+    # Ensure the type signatures for pyairtable.api.Table don't change.
+    table = pyairtable.api.Table(access_token, base_id, table_name)
+    assert_type(table.get(record_id), T.RecordDict)
+    assert_type(table.iterate(), Iterator[List[T.RecordDict]])
+    assert_type(table.all(), List[T.RecordDict])
+    assert_type(table.first(), Optional[T.RecordDict])
+    assert_type(table.create({}), T.RecordDict)
+    assert_type(table.update(record_id, {}), T.RecordDict)
+    assert_type(table.delete(record_id), T.RecordDeletedDict)
+    assert_type(table.batch_create([]), List[T.RecordDict])
+    assert_type(table.batch_update([]), List[T.RecordDict])
+    assert_type(table.batch_upsert([], []), List[T.RecordDict])
+    assert_type(table.batch_delete([]), List[T.RecordDeletedDict])

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = pre-commit run --all-files
 
 [testenv:mypy]
 deps = -r requirements-dev.txt
-commands = mypy --strict pyairtable
+commands = mypy --strict pyairtable tests/test_typing.py
 
 [testenv]
 passenv = AIRTABLE_API_KEY

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = pre-commit run --all-files
 
 [testenv:mypy]
 deps = -r requirements-dev.txt
-commands = mypy pyairtable
+commands = mypy --strict pyairtable
 
 [testenv]
 passenv = AIRTABLE_API_KEY


### PR DESCRIPTION
This branch adds type annotations to the entire library, along with a number of Airtable-specific types and `TypedDict`s. It is not compatible with Python 3.7 but it works on all later versions. As with some of the other big branches, it might be easier to review each commit individually.

* https://github.com/gtalarico/pyairtable/commit/821e435df80c4cf518116cb81032a7c73249ff68 introduces a number of types and `TypedDict`s in a new `pyairtable.api.types` module. 
    * There are some aliases here (like `RecordId` and `FieldName`) that simply point to `str`. This is not strictly necessary, but without them there are so many places where we have things like `List[str]` or `Dict[str, str]`, and this might make it a bit easier for developers to remember what goes where. 
    * I'm open to adding more but I didn't want to go overboard on the first pass. (I'm not _opposed_ to seeing `str` in type annotations as long as it's obvious what they represent.)

* https://github.com/gtalarico/pyairtable/commit/4aab9e077d3828bc5fd8c20de6ad49062f69a017 switches up how we call `mypy` to use strict mode and not silence any warnings.

* https://github.com/gtalarico/pyairtable/commit/5345b048cc1f56533b3bf73f039c737c037b3313 fills in most of the missing annotations on function/method signatures. It also removes the (deprecated) `params.to_params_dict` function and introduces `Model._get_meta()` as a helper for reading the `Meta` class.

* https://github.com/gtalarico/pyairtable/commit/8a28f3470988a0e758df0a1ca8bdc805bec6c054 does a few things:

* Turns `pyairtable.orm.fields.Field` into a generically-typed class, `Field[T_API, T_ORM]`, whose subclasses need to define the API and ORM data types (which might not always match). 
    * Provides the alias `BasicField[T]` for field classes which do not convert values between types. 
    * Provides the alias `AnyField` for when a type annotation doesn't care what kind of field it gets.
    * Renames `Field.value_if_missing` to `Field._missing_value()` so it can be typed more flexibly.

* https://github.com/gtalarico/pyairtable/commit/b618b55409c2306e66fba26687a2d3fd86fdb5c2 uses `typing.cast()` on values returned by the Airtable API to conform them to the types introduced above; this assumes the API responses will conform to the data structures we expect. (See below.)

* https://github.com/gtalarico/pyairtable/commit/3d9be4731a51605ea1dd581f91ee0bdc0f76a5ca fixes some issues with forward references that caused sphinx_autodoc_typehints to crash.

* https://github.com/gtalarico/pyairtable/commit/ffa5c431223f9a0bcde22edaf61147c80eabbea6 introduces some basic types to `pyairtable.metadata`. I expect to deprecate this module soon, so I didn't spend too much time on it.

* https://github.com/gtalarico/pyairtable/commit/46b0950750a3dd9021cbc87e30816de5a40ada05 removes support (introduced in an earlier branch) for setting `model.list_field = iterable_object`, where `iterable_object` is a non-list (such as a set, tuple, or generator). Defining this correctly as a type annotation became problematic, and it seems reasonable to expect developers to convert those types to lists _before_ setting field values on a model.

* https://github.com/gtalarico/pyairtable/commit/8364a4f916f33d077383851828152199c980ae58 adds a special test file, `tests/test_typing.py`, which makes a number of type assertions that mypy will validate on each run.

* https://github.com/gtalarico/pyairtable/commit/94a93cda63237d3220aae0a6a25a1443d17f87eb changes the approach used in b618b554 (above) to actively validate Airtable's API responses against our TypedDict definitions, instead of simply assuming they match what we expect. This introduces [pydantic](https://docs.pydantic.dev/latest/) as a dependency, which we've already discussed using for metadata models in #258.

* 34eb19f updates the Sphinx configuration to include type annotations and default values in function signatures and parameter descriptions. It also adds a "Types" section.

* 9b5ecd0 fixes a bug that popped up when I pushed the previous commit, but which I hadn't run across before. I'm stumped why GitHub Actions didn't catch it when I pushed 94a93cda but :shrug: it was a quick fix.

This branch resolves #202.