### PR TITLE
Fix tests to pass with urllib3 2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ install_requires =
     pydantic
     requests >= 2.22.0
     typing_extensions
-    urllib3 < 2
 
 [aliases]
 test=pytest

--- a/tests/test_api_retrying.py
+++ b/tests/test_api_retrying.py
@@ -4,17 +4,19 @@ Instead we use a real HTTP server running in a separate thread, which we can pro
 to respond with various HTTP status codes.
 """
 import json
-import os
 import threading
+import time
+from collections import deque
 from http import HTTPStatus
 from urllib.parse import urljoin
-from wsgiref.simple_server import make_server
+from wsgiref.simple_server import WSGIRequestHandler, make_server
 
 import pytest
 import requests
 
 from pyairtable.api.retrying import retry_strategy
 from pyairtable.api.table import Table
+from pyairtable.testing import fake_record
 
 
 # Adapted from https://github.com/kevin1024/pytest-httpbin
@@ -23,12 +25,8 @@ class Server:
     HTTP server running a WSGI application in its own thread.
     """
 
-    port_envvar = "HTTPBIN_HTTP_PORT"
-
     def __init__(self, host="127.0.0.1", port=0, application=None, **kwargs):
         self.app = application
-        if self.port_envvar in os.environ:
-            port = int(os.environ[self.port_envvar])
         self._server = make_server(host, port, self.app, **kwargs)
         self.host = self._server.server_address[0]
         self.port = self._server.server_address[1]
@@ -38,6 +36,10 @@ class Server:
             name=self.__class__,
             target=self._server.serve_forever,
         )
+
+    def set_app(self, app):
+        self.app = app
+        self._server.set_app(app)
 
     def __del__(self):
         if hasattr(self, "_server"):
@@ -70,34 +72,84 @@ class Server:
         return urljoin(self.url, url, allow_fragments=allow_fragments)
 
 
+class QuietWSGIRequestHandler(WSGIRequestHandler):
+    """
+    Silences all log messages from the WSGI server.
+    """
+
+    def log_message(self, *args, **kwargs):
+        return
+
+
 class MockApi:
     """
-    Dumb WSGI app that returns responses from a stack.
+    WSGI app that returns responses from a stack.
     """
 
-    def __init__(self, responses=None):
-        self.responses = responses or []
+    QPS = 5
+
+    def __init__(self, responses=None, enforce_limit=True):
+        """
+        :param responses: If provided, should be a list of responses
+            for the server to respond with, in first in first out order.
+            Format should be ``list[tuple[status, serializable]]``,
+            where ``status`` is either an ``int`` or ``str``,
+            and ``serializable`` can be encoded by ``json.dumps``.
+
+        :param enforce_limit: If ``True``, the MockApi will return
+            a 429 whenever if there has been more than five requests
+            within the past second. This is an attempt to simulate
+            `Airtable's API limits <https://airtable.com/developers/web/api/rate-limits>`_.
+        """
+        self.canned_responses = responses or []
+        self.enforce_limit = enforce_limit
+        self.timestamps = deque(maxlen=self.QPS)  # limit is 5 requests/sec
 
     def __call__(self, environ, start_response):
-        if not self.responses:
+        status, response = self.next_response()
+        start_response(status, [("Content-Type", "application/json")])
+        return [response]
+
+    def next_response(self):
+        if (
+            self.enforce_limit
+            and len(self.timestamps) == self.QPS
+            and (time.time() - self.timestamps[0] < 1)
+        ):
+            return ("429 Too Many Requests", b"")
+        if not self.canned_responses:
             raise RuntimeError("MockApi.responses is empty")
-        status, jsondata = self.responses.pop(0)
+        self.timestamps.append(time.time())
+        status, jsondata = self.canned_responses.pop(0)
         if isinstance(status, int):
             status = f"{status} {HTTPStatus(status).phrase}"
-        start_response(status, [("Content-Type", "application/json")])
-        if jsondata is None:
-            return []
-        return [json.dumps(jsondata).encode("utf8")]
+        response = b"" if jsondata is None else json.dumps(jsondata).encode("utf8")
+        return (status, response)
 
 
 @pytest.fixture(scope="session")
-def mock_endpoint():
-    with Server(application=MockApi()) as server:
+def mock_endpoint_server():
+    """
+    Fixture that starts a simple WSGI server running in a separate thread.
+    Only created once per session; expects us to call `set_app()` on each test.
+    """
+    with Server(handler_class=QuietWSGIRequestHandler) as server:
         yield server
 
 
+@pytest.fixture(autouse=True)
+def mock_endpoint(mock_endpoint_server):
+    """
+    Fixture that creates a MockApi and attaches it to the running server.
+    Sets ``autouse=True`` to ensure no cross-test pollution.
+    """
+    app = MockApi()
+    mock_endpoint_server.set_app(app)
+    return app
+
+
 @pytest.fixture
-def table_with_retry_strategy(constants, mock_endpoint):
+def table_with_retry_strategy(constants, mock_endpoint_server):
     def _table_with_retry(retry_strategy):
         return Table(
             constants["API_KEY"],
@@ -105,17 +157,20 @@ def table_with_retry_strategy(constants, mock_endpoint):
             constants["TABLE_NAME"],
             timeout=(0.1, 0.1),
             retry_strategy=retry_strategy,
-            endpoint_url=mock_endpoint.url,
+            endpoint_url=mock_endpoint_server.url,
         )
 
     return _table_with_retry
 
 
 def test_retry_exceed(table_with_retry_strategy, mock_endpoint):
+    """
+    Test that we raise a RetryError if we get too many retryable error codes.
+    """
     strategy = retry_strategy(total=2, status_forcelist=[429])
     table = table_with_retry_strategy(strategy)
 
-    mock_endpoint.app.responses = [(429, None)] * 3
+    mock_endpoint.canned_responses = [(429, None)] * 3
 
     with pytest.raises(requests.exceptions.RetryError):
         table.get("record")
@@ -126,10 +181,13 @@ def test_retry_status_not_allowed(
     mock_endpoint,
     mock_response_single,
 ):
+    """
+    Test that our retry logic does not affect other HTTP error codes.
+    """
     strategy = retry_strategy(total=2, status_forcelist=[429, 500])
     table = table_with_retry_strategy(strategy)
 
-    mock_endpoint.app.responses = [
+    mock_endpoint.canned_responses = [
         (401, None),
         (200, mock_response_single),
     ]
@@ -143,13 +201,34 @@ def test_retry_eventual_success(
     mock_endpoint,
     mock_response_single,
 ):
+    """
+    Test that our retry logic succeeds if we eventually get a valid result.
+    """
     strategy = retry_strategy(total=2, status_forcelist=[429, 500])
     table = table_with_retry_strategy(strategy)
 
-    mock_endpoint.app.responses = [
+    mock_endpoint.canned_responses = [
         (429, None),
         (500, None),
         (200, mock_response_single),
     ]
 
     assert table.get("record") == mock_response_single
+
+
+def test_retry_during_iterate(table_with_retry_strategy, mock_endpoint):
+    """
+    Test that our default retry logic will be enough to get through several pages of data.
+    Relies on ``mock_endpoint`` to return 429s whenever QPS goes over the limit.
+    """
+    # TODO: remove `time.sleep` everywhere and make retry_strategy() the default.
+    table = table_with_retry_strategy(retry_strategy())
+
+    page_count = 10
+    per_page = 5  # real world number is 100, but we don't need that much data here
+    page = {"records": [fake_record()] * per_page}
+    mock_endpoint.canned_responses = [(200, {**page, "offset": "offset"})] * page_count
+    mock_endpoint.canned_responses[-1] = (200, page)  # no offset on the last page
+
+    records = table.all()
+    assert len(records) == page_count * per_page

--- a/tests/test_api_retrying.py
+++ b/tests/test_api_retrying.py
@@ -1,10 +1,14 @@
 """
-For these tests Mocker cannot be used because Retry is operating on a lower level
+For these tests Mocker cannot be used because Retry is operating on a lower level.
+Instead we use a real HTTP server running in a separate thread, which we can program
+to respond with various HTTP status codes.
 """
-import io
 import json
-from http.client import HTTPMessage, HTTPResponse
-from unittest import mock
+import os
+import threading
+from http import HTTPStatus
+from urllib.parse import urljoin
+from wsgiref.simple_server import make_server
 
 import pytest
 import requests
@@ -13,8 +17,87 @@ from pyairtable.api.retrying import retry_strategy
 from pyairtable.api.table import Table
 
 
+# Adapted from https://github.com/kevin1024/pytest-httpbin
+class Server:
+    """
+    HTTP server running a WSGI application in its own thread.
+    """
+
+    port_envvar = "HTTPBIN_HTTP_PORT"
+
+    def __init__(self, host="127.0.0.1", port=0, application=None, **kwargs):
+        self.app = application
+        if self.port_envvar in os.environ:
+            port = int(os.environ[self.port_envvar])
+        self._server = make_server(host, port, self.app, **kwargs)
+        self.host = self._server.server_address[0]
+        self.port = self._server.server_address[1]
+        self.protocol = "http"
+
+        self._thread = threading.Thread(
+            name=self.__class__,
+            target=self._server.serve_forever,
+        )
+
+    def __del__(self):
+        if hasattr(self, "_server"):
+            self.stop()
+
+    def start(self):
+        self._thread.start()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.stop()
+        suppress_exc = self._server.__exit__(*args, **kwargs)
+        self._thread.join()
+        return suppress_exc
+
+    def __add__(self, other):
+        return self.url + other
+
+    def stop(self):
+        self._server.shutdown()
+
+    @property
+    def url(self):
+        return f"{self.protocol}://{self.host}:{self.port}"
+
+    def join(self, url, allow_fragments=True):
+        return urljoin(self.url, url, allow_fragments=allow_fragments)
+
+
+class MockApi:
+    """
+    Dumb WSGI app that returns responses from a stack.
+    """
+
+    def __init__(self, responses=None):
+        self.responses = responses or []
+
+    def __call__(self, environ, start_response):
+        if not self.responses:
+            raise RuntimeError("MockApi.responses is empty")
+        status, jsondata = self.responses.pop(0)
+        if isinstance(status, int):
+            status = f"{status} {HTTPStatus(status).phrase}"
+        start_response(status, [("Content-Type", "application/json")])
+        if jsondata is None:
+            return []
+        return [json.dumps(jsondata).encode("utf8")]
+
+
+@pytest.fixture(scope="session")
+def mock_endpoint():
+    with Server(application=MockApi()) as server:
+        yield server
+
+
 @pytest.fixture
-def table_with_retry_strategy(constants):
+def table_with_retry_strategy(constants, mock_endpoint):
     def _table_with_retry(retry_strategy):
         return Table(
             constants["API_KEY"],
@@ -22,92 +105,51 @@ def table_with_retry_strategy(constants):
             constants["TABLE_NAME"],
             timeout=(0.1, 0.1),
             retry_strategy=retry_strategy,
+            endpoint_url=mock_endpoint.url,
         )
 
     return _table_with_retry
 
 
-@mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
-def test_retry_exceed(m, table_with_retry_strategy):
+def test_retry_exceed(table_with_retry_strategy, mock_endpoint):
     strategy = retry_strategy(total=2, status_forcelist=[429])
     table = table_with_retry_strategy(strategy)
 
-    m.return_value.getresponse.side_effect = [
-        make_http_response_error(429),
-        make_http_response_error(429),
-        make_http_response_error(429),
-    ]
+    mock_endpoint.app.responses = [(429, None)] * 3
 
     with pytest.raises(requests.exceptions.RetryError):
         table.get("record")
 
-    assert len(m.return_value.request.mock_calls) == 3
 
-
-@mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
-def test_retry_status_not_allowed(m, table_with_retry_strategy, mock_response_single):
+def test_retry_status_not_allowed(
+    table_with_retry_strategy,
+    mock_endpoint,
+    mock_response_single,
+):
     strategy = retry_strategy(total=2, status_forcelist=[429, 500])
     table = table_with_retry_strategy(strategy)
 
-    response = make_response(mock_response_single, 200)
-
-    m.return_value.getresponse.side_effect = [
-        make_http_response_error(401),
-        response,
+    mock_endpoint.app.responses = [
+        (401, None),
+        (200, mock_response_single),
     ]
 
     with pytest.raises(requests.exceptions.HTTPError):
-        response = table.get("record")
-
-    assert len(m.return_value.request.mock_calls) == 1
+        table.get("record")
 
 
-@mock.patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
-def test_retry_eventual_success(m, table_with_retry_strategy, mock_response_single):
+def test_retry_eventual_success(
+    table_with_retry_strategy,
+    mock_endpoint,
+    mock_response_single,
+):
     strategy = retry_strategy(total=2, status_forcelist=[429, 500])
     table = table_with_retry_strategy(strategy)
 
-    response = make_response(mock_response_single, 200)
-
-    m.return_value.getresponse.side_effect = [
-        make_http_response_error(429),
-        make_http_response_error(500),
-        response,
+    mock_endpoint.app.responses = [
+        (429, None),
+        (500, None),
+        (200, mock_response_single),
     ]
 
-    response = table.get("record")
-    assert response == mock_response_single
-    assert len(m.return_value.request.mock_calls) == 3
-
-
-# Test Helpers
-
-
-def make_response(body: dict, status=200) -> HTTPResponse:
-    headers = HTTPMessage()
-    body_bytes = json.dumps(body).encode()
-
-    sock = FakeSocketHelper(body_bytes)
-    response = HTTPResponse(sock)  # type: ignore
-    response.chunked = False  # type: ignore
-    response.length = len(body_bytes)  # type: ignore
-    response.status = status
-    response.msg = headers
-    return response
-
-
-def make_http_response_error(status: int):
-    return mock.Mock(status=status, msg=HTTPMessage())
-
-
-class FakeSocketHelper:
-    def __init__(self, text):
-        if isinstance(text, str):
-            text = text.encode("ascii")
-        self.text = text
-        self.data = b""
-        self.file_closed = False
-
-    def makefile(self, mode, bufsize=None):
-        self.file = io.BytesIO(self.text)
-        return self.file
+    assert table.get("record") == mock_response_single


### PR DESCRIPTION
I had a sneaking suspicion that pyairtable will work _just fine_ with `urllib3 == 2.0.0`, but we can no longer mock specific urllib3 internals in `test_api_retrying.py`. This branch borrows an idea (and some code) from the excellent [pytest-httpbin](https://github.com/kevin1024/pytest-httpbin) library, running a simple WSGI application server in a parallel thread which serves a series of predefined HTTP codes. Now we don't need to care about urllib3's internals at all.

Resolves #251