### PR TITLE
Allow ORM Meta options to be lookups at runtime (not import time)

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,8 @@ See :ref:`Migrating from 1.x to 2.0` for detailed migration notes.
   - `PR #273 <https://github.com/gtalarico/pyairtable/pull/273>`_.
 * pyAirtable will automatically retry requests when throttled by Airtable's QPS.
   - `PR #272 <https://github.com/gtalarico/pyairtable/pull/272>`_.
+* ORM Meta attributes can now be defined as callables.
+  - `PR #268 <https://github.com/gtalarico/pyairtable/pull/268>`_.
 * Removed ``ApiAbstract``.
   - `PR #267 <https://github.com/gtalarico/pyairtable/pull/267>`_.
 * Implemented strict type annotations on all functions and methods.

--- a/tests/test_orm_model.py
+++ b/tests/test_orm_model.py
@@ -1,3 +1,4 @@
+from functools import partial
 from unittest import mock
 
 import pytest
@@ -118,3 +119,29 @@ def test_from_ids(mock_all):
     with pytest.raises(KeyError):
         FakeModel.from_ids(fake_ids + ["recDefinitelyNotValid"])
     mock_all.assert_called_once()
+
+
+def test_dynamic_model_meta():
+    """
+    Test that we can provide callables in our Meta class to provide
+    the access token, base ID, and table name at runtime.
+    """
+    data = {
+        "api_key": "FakeApiKey",
+        "base_id": "appFakeBaseId",
+        "table_name": "tblFakeTableName",
+    }
+
+    class Fake(Model):
+        class Meta:
+            api_key = lambda: data["api_key"]  # noqa
+            base_id = partial(data.get, "base_id")
+
+            @staticmethod
+            def table_name():
+                return data["table_name"]
+
+    f = Fake()
+    assert f._get_meta("api_key") == data["api_key"]
+    assert f._get_meta("base_id") == data["base_id"]
+    assert f._get_meta("table_name") == data["table_name"]


### PR DESCRIPTION
This allows the `Meta` class inside each ORM model to provide a callable that will be executed whenever the ORM requests one of its meta properties. The use case we have is to be able to provide API keys via global configuration singletons or environment variables which might not be loaded at import time but will be present at runtime.

Resolves #192 