### PR TITLE
`types.Fields` should allow field values to be `None`

### DIFF
--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -153,7 +153,7 @@ FieldValue: TypeAlias = Union[
 
 
 #: A mapping of field names to values.
-Fields: TypeAlias = Dict[FieldName, FieldValue]
+Fields: TypeAlias = Dict[FieldName, Optional[FieldValue]]
 
 
 class RecordDict(TypedDict):

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -60,3 +60,11 @@ if TYPE_CHECKING:
     assert_type(table.batch_update([]), List[T.RecordDict])
     assert_type(table.batch_upsert([], []), List[T.RecordDict])
     assert_type(table.batch_delete([]), List[T.RecordDeletedDict])
+
+    # Ensure we can set all kinds of field values
+    table.update(record_id, {"Field Name": "name"})
+    table.update(record_id, {"Field Name": 1})
+    table.update(record_id, {"Field Name": 1.0})
+    table.update(record_id, {"Field Name": True})
+    table.update(record_id, {"Field Name": None})
+    table.update(record_id, {"Field Name": {"id": "usrXXX"}})


### PR DESCRIPTION
This was an oversight on my part during #263. When passing a `Fields`-typed dict to `create()` or `update()`, sometimes we need to be able to set a field's value to `None`, but that doesn't work unless we make the field value optional. I added a line to test_typing.py to prevent regressions.