### PR TITLE
Use a default retry strategy and remove `time.sleep`

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -34,14 +34,23 @@ Retrying
 `urllib3.util.Retry <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry>`_.
 
 As of 2.0.0, the default behavior is to retry requests up to five times if the Airtable API responds with
-a 429 status code (indicating you've exceeded their per-base QPS limit) or a potentially transient server error.
+a 429 status code, indicating you've exceeded their per-base QPS limit.
 
-To adjust the default behavior, you can use the :func:`~pyairtable.retry_strategy` function:
+To adjust the default behavior, you can use the :func:`~pyairtable.retry_strategy` function.
+For example, to increase the total number of retries:
 
 .. code-block:: python
 
   from pyairtable import Api, retry_strategy
   api = Api('auth_token', retry_strategy=retry_strategy(total=10))
+
+Or to retry certain types of server errors in addition to rate limiting errors:
+
+.. code-block:: python
+
+  from pyairtable import Api, retry_strategy
+  retry = retry_strategy(status_forcelist=(429, 500, 502, 503, 504))
+  api = Api('auth_token', retry_strategy=retry)
 
 You can also disable retries entirely:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,22 +30,25 @@ Retrying
 
 .. versionadded:: 1.4.0
 
-You may provide an instance of ``urllib3.util.Retry`` to configure retrying behaviour,
-or you can use :func:`~pyairtable.retry_strategy` to quickly generate a
-``Retry`` instance with reasonable defaults (which you can adjust).
+:class:`~pyairtable.api.Api` accepts a ``retry_strategy=`` parameter that receives an instance of
+`urllib3.util.Retry <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry>`_.
 
-.. note:: for backwards-compatibility, the default behavior is to not retry (`retry_strategy=None`).
-  This may change in future releases.
+As of 2.0.0, the default behavior is to retry requests up to five times if the Airtable API responds with
+a 429 status code (indicating you've exceeded their per-base QPS limit) or a potentially transient server error.
 
-Out of the box, :func:`~pyairtable.retry_strategy` will retry a request several times
-if it receives a 429 (which indicates you've exceeded Airtable's limit of 5 QPS per base) or
-if it receives a potentially transient server-side error (500, 502, 503, or 504).
+To adjust the default behavior, you can use the :func:`~pyairtable.retry_strategy` function:
 
 .. code-block:: python
 
   from pyairtable import Api, retry_strategy
-  api = Api('auth_token', retry_strategy=retry_strategy())
+  api = Api('auth_token', retry_strategy=retry_strategy(total=10))
 
+You can also disable retries entirely:
+
+.. code-block:: python
+
+  from pyairtable import Api
+  api = Api('auth_token', retry_strategy=None)
 
 .. autofunction:: pyairtable.retry_strategy
 

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -51,6 +51,15 @@ See below for supported and unsupported patterns:
     # to avoid situations where self.api and self.base don't align.
     >>> table = Table(api, base_id, table_name)  # [Api, Base, str]
 
+Changes to Api
+--------------
+
+* By default, the library will retry requests up to five times if it receives
+  a 429 status code from Airtable (indicating the base has exceeded the
+  maximum QPS enforced by Airtable) or a 500/502/503/504 status code
+  (which is a potentially transient error).
+
+
 Changes to the ORM
 ------------------
 

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -51,8 +51,8 @@ See below for supported and unsupported patterns:
     # to avoid situations where self.api and self.base don't align.
     >>> table = Table(api, base_id, table_name)  # [Api, Base, str]
 
-Changes to Api
---------------
+Retry by Default
+----------------
 
 * By default, the library will retry requests up to five times if it receives
   a 429 status code from Airtable, indicating the base has exceeded its QPS limit.

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -55,9 +55,7 @@ Changes to Api
 --------------
 
 * By default, the library will retry requests up to five times if it receives
-  a 429 status code from Airtable (indicating the base has exceeded the
-  maximum QPS enforced by Airtable) or a 500/502/503/504 status code
-  (which is a potentially transient error).
+  a 429 status code from Airtable, indicating the base has exceeded its QPS limit.
 
 
 Changes to the ORM

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -44,8 +44,6 @@ class Api:
         endpoint_url: str = "https://api.airtable.com",
     ):
         """
-
-
         Args:
             api_key: An Airtable API key or personal access token.
             timeout: A tuple indicating a connect and read timeout.

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,5 +1,4 @@
 import posixpath
-import time
 from functools import lru_cache
 from typing import Any, Dict, Iterator, Optional, Sequence, Tuple, TypeVar, Union
 
@@ -191,11 +190,3 @@ class Api:
         to the maximum number of records per request allowed by the API.
         """
         return chunked(iterable, self.MAX_RECORDS_PER_REQUEST)
-
-    def wait(self) -> None:
-        """
-        Sleep for 1/N seconds, where N is the maximum RPS allowed by the Airtable API.
-
-        :meta private: because we expect to remove this soon.
-        """
-        time.sleep(self.API_LIMIT)

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,7 +1,7 @@
 import posixpath
 import time
 from functools import lru_cache
-from typing import Any, Dict, Iterator, Optional, Sequence, Tuple, TypeVar
+from typing import Any, Dict, Iterator, Optional, Sequence, Tuple, TypeVar, Union
 
 import requests
 from requests.sessions import Session
@@ -9,10 +9,9 @@ from typing_extensions import TypeAlias
 
 import pyairtable.api.base
 import pyairtable.api.table
+from pyairtable.api import retrying
 from pyairtable.api.params import options_to_json_and_params, options_to_params
 from pyairtable.utils import chunked
-
-from .retrying import Retry, _RetryingSession
 
 T = TypeVar("T")
 TimeoutTuple: TypeAlias = Tuple[int, int]
@@ -42,10 +41,12 @@ class Api:
         api_key: str,
         *,
         timeout: Optional[TimeoutTuple] = None,
-        retry_strategy: Optional[Retry] = None,
+        retry_strategy: Optional[Union[bool, retrying.Retry]] = True,
         endpoint_url: str = "https://api.airtable.com",
     ):
         """
+
+
         Args:
             api_key: An Airtable API key or personal access token.
             timeout: A tuple indicating a connect and read timeout.
@@ -53,16 +54,19 @@ class Api:
                 the connection to be established  and 5 seconds for a
                 server read timeout. Default is ``None`` (no timeout).
             retry_strategy: An instance of
-                `urllib3.util.Retry <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry>`__.
-                You can use :func:`~pyairtable.retry_strategy` to build one with reasonable
-                defaults, or provide your own custom instance of ``Retry``.
+                `urllib3.util.Retry <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry>`_.
+                If ``None`` or ``False``, requests will not be retried.
+                If ``True``, the default strategy will be applied
+                (see :func:`~pyairtable.retry_strategy` for details).
             endpoint_url: The API endpoint to use. Override this if you are using
                 a debugging or caching proxy.
         """
+        if retry_strategy is True:
+            retry_strategy = retrying.retry_strategy()
         if not retry_strategy:
             self.session = Session()
         else:
-            self.session = _RetryingSession(retry_strategy)
+            self.session = retrying._RetryingSession(retry_strategy)
 
         self.endpoint_url = endpoint_url
         self.timeout = timeout

--- a/pyairtable/api/retrying.py
+++ b/pyairtable/api/retrying.py
@@ -4,7 +4,7 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-DEFAULT_RETRIABLE_STATUS_CODES = (429, 500, 502, 503, 504)
+DEFAULT_RETRIABLE_STATUS_CODES = (429,)
 DEFAULT_BACKOFF_FACTOR = 0.1  # retry after 0.1, 0.2, 0.4, 0.8, 1.6 seconds
 DEFAULT_MAX_RETRIES = 5
 

--- a/pyairtable/api/retrying.py
+++ b/pyairtable/api/retrying.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple, Union
+from typing import Any, Collection, Optional, Tuple, Union
 
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -14,6 +14,7 @@ def retry_strategy(
     status_forcelist: Tuple[int, ...] = DEFAULT_RETRIABLE_STATUS_CODES,
     backoff_factor: Union[int, float] = DEFAULT_BACKOFF_FACTOR,
     total: int = DEFAULT_MAX_RETRIES,
+    allowed_methods: Optional[Collection[str]] = None,
     **kwargs: Any,
 ) -> Retry:
     """
@@ -24,6 +25,8 @@ def retry_strategy(
 
     Args:
         status_forcelist: Status codes which should be retried.
+        allowed_methods: HTTP methods which can be retried.
+            If ``None``, then all HTTP methods will be retried.
         backoff_factor:
             A backoff factor to apply between attempts after the second try.
             Sleep time between each request will be calculated as
@@ -37,6 +40,7 @@ def retry_strategy(
         total=total,
         backoff_factor=backoff_factor,
         status_forcelist=status_forcelist,
+        allowed_methods=allowed_methods,
         **kwargs,
     )
 

--- a/pyairtable/api/retrying.py
+++ b/pyairtable/api/retrying.py
@@ -5,7 +5,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 DEFAULT_RETRIABLE_STATUS_CODES = (429, 500, 502, 503, 504)
-DEFAULT_BACKOFF_FACTOR = 0.3
+DEFAULT_BACKOFF_FACTOR = 0.1  # retry after 0.1, 0.2, 0.4, 0.8, 1.6 seconds
 DEFAULT_MAX_RETRIES = 5
 
 
@@ -17,8 +17,8 @@ def retry_strategy(
     **kwargs: Any,
 ) -> Retry:
     """
-    Creates a ``Retry`` instance with optional default values.
-    See `urllib3.util.Retry`_ for more details.
+    Creates a `Retry <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry>`_
+    instance with adjustable default values.
 
     .. versionadded:: 1.4.0
 
@@ -31,7 +31,7 @@ def retry_strategy(
         total:
             Maximum number of retries. Note that ``0`` means no retries,
             whereas ``1`` will execute a total of two requests (original + 1 retry).
-        **kwargs: Any valid parameter to `urllib3.util.Retry <https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry>`_.
+        **kwargs: Accepts any valid parameter to `Retry`_.
     """
     return Retry(
         total=total,

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -179,7 +179,6 @@ class Table:
             offset = data.get("offset")
             if not offset:
                 break
-            self.api.wait()
 
     def all(self, **options: Any) -> List[RecordDict]:
         """
@@ -298,7 +297,6 @@ class Table:
                 },
             )
             inserted_records += assert_typed_dicts(RecordDict, response["records"])
-            self.api.wait()
 
         return inserted_records
 
@@ -365,7 +363,6 @@ class Table:
                 },
             )
             updated_records += assert_typed_dicts(RecordDict, response["records"])
-            self.api.wait()
 
         return updated_records
 
@@ -424,7 +421,6 @@ class Table:
                 },
             )
             updated_records += assert_typed_dicts(RecordDict, response["records"])
-            self.api.wait()
 
         return updated_records
 
@@ -467,6 +463,5 @@ class Table:
         for chunk in self.api.chunked(record_ids):
             result = self.api.request("delete", self.url, params={"records[]": chunk})
             deleted_records += assert_typed_dicts(RecordDeletedDict, result["records"])
-            self.api.wait()
 
         return deleted_records

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     pydantic
     requests >= 2.22.0
     typing_extensions
+    urllib3 >= 1.26
 
 [aliases]
 test=pytest

--- a/tests/integration/test_high_volume.py
+++ b/tests/integration/test_high_volume.py
@@ -1,0 +1,43 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.fixture
+def table_name():
+    return "EVERYTHING"
+
+
+@pytest.mark.parametrize(
+    "thread_count,records_per_thread",
+    [
+        # (1, 500),
+        # (5, 100),
+        (25, 20),
+    ],
+)
+def test_high_volume_operations(table, thread_count, records_per_thread):
+    """
+    Test that we can perform hundreds of batch operations and our
+    default retry strategy will catch any 429s (rate limiting).
+
+    If retry_strategy=None, this test will fail.
+    """
+
+    def bulk_create(thread_number, record_count):
+        created = table.batch_create(
+            [
+                {"Name": f"thread={thread_number} record={n}"}
+                for n in range(record_count)
+            ]
+        )
+        table.batch_delete([record["id"] for record in created])
+
+    with ThreadPoolExecutor(max_workers=thread_count) as executor:
+        futures = [
+            executor.submit(bulk_create, thread_number, records_per_thread)
+            for thread_number in range(thread_count)
+        ]
+        all(future.result() for future in as_completed(futures))


### PR DESCRIPTION
This implements a default retry strategy which will retry 429 (too many requests) up to five times before giving up. This seems like a sensible default, and it is similar to the behavior of the official Airtable.js library. The brief testing I've done suggests that removing `time.sleep` and replacing with retries does speed up large batch operations. 

Given this code...
```python
import os
import time
from threading import Thread
from pyairtable import Api


def main():
    for case in [(1, 500), (5, 100), (25, 20)]:
        timer(*case)


def timer(threads, records):
    start_time = time.time()
    started = []
    for thread_number in range(threads):
        t = Thread(target=bulk_create, args=[thread_number, records])
        t.start()
        started.append(t)

    all(t.join() for t in started)
    duration = time.time() - start_time
    print(threads, "thread(s),", records, "records:", f"{duration:.2f}s")


def bulk_create(prefix, count):
    api = Api(os.environ["AIRTABLE_API_KEY"])
    table = api.table("appaPqizdsNHDvlEm", "TEST_TABLE")
    records = [{"text": f"bulk {prefix} #{n}"} for n in range(1, count)]
    created = table.batch_create(records)
    table.batch_delete([record["id"] for record in created])


if __name__ == "__main__":
    main()
```

...I got this output:
```
% git checkout main
% python3 tmp/bulk.py
1 thread(s), 500 records: 53.67s
5 thread(s), 100 records: 12.96s
Exception in thread Thread-14:
...
requests.exceptions.HTTPError: 429 Client Error: Too Many Requests

% git checkout default_retry
% python3 tmp/bulk.py
1 thread(s), 500 records: 32.18s
5 thread(s), 100 records: 10.19s
25 thread(s), 20 records: 10.02s
```

I'd considered retrying 500s by default, but I think that is probably inadvisable given a 500 might indicate a request was _partially_ fulfilled. It should be left to the implementer to decide whether to retry an operation in that situation or not.

This does not add any new tests. I considered adding something like the above as an integration test, but it would add several seconds to each test run and I'm not clear on what sort of regressions we'd actually be guarding against.

This branch closes #218 