### PR TITLE
Implement `api.whoami()`

### DIFF
--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -10,6 +10,7 @@ import pyairtable.api.base
 import pyairtable.api.table
 from pyairtable.api import retrying
 from pyairtable.api.params import options_to_json_and_params, options_to_params
+from pyairtable.api.types import UserAndScopesDict, assert_typed_dict
 from pyairtable.utils import chunked
 
 T = TypeVar("T")
@@ -188,3 +189,11 @@ class Api:
         to the maximum number of records per request allowed by the API.
         """
         return chunked(iterable, self.MAX_RECORDS_PER_REQUEST)
+
+    def whoami(self) -> UserAndScopesDict:
+        """
+        Return the current user ID and (if connected via OAuth) the list of scopes.
+        See `Get user ID & scopes <https://airtable.com/developers/web/api/get-user-id-scopes>`_ for more information.
+        """
+        data = self.request("GET", self.build_url("meta/whoami"))
+        return assert_typed_dict(UserAndScopesDict, data)

--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -259,6 +259,19 @@ class RecordDeletedDict(TypedDict):
     deleted: bool
 
 
+class UserAndScopesDict(TypedDict, total=False):
+    """
+    A ``dict`` representing the `Get user ID & scopes <https://airtable.com/developers/web/api/get-user-id-scopes>`_ endpoint.
+
+    Usage:
+        >>> api.whoami()
+        {'id': 'usrX9e810wHn3mMLz'}
+    """
+
+    id: Required[str]
+    scopes: List[str]
+
+
 @lru_cache
 def _create_model_from_typeddict(cls: Type[T]) -> Type[pydantic.BaseModel]:
     """

--- a/tests/test_api_api.py
+++ b/tests/test_api_api.py
@@ -42,3 +42,18 @@ def test_update_api_key(api):
     """
     api.api_key = "123"
     assert "123" in api.session.headers["Authorization"]
+
+
+def test_whoami(api, requests_mock):
+    """
+    Test the /whoami endpoint gets passed straight through.
+    """
+    payload = {
+        "id": "usrFakeTestingUser",
+        "scopes": [
+            "data.records:read",
+            "data.records:write",
+        ],
+    }
+    requests_mock.get("https://api.airtable.com/v0/meta/whoami", json=payload)
+    assert api.whoami() == payload

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     assert_type(api.build_url("foo", "bar"), str)
     assert_type(api.base(base_id), pyairtable.Base)
     assert_type(api.table(base_id, table_name), pyairtable.Table)
+    assert_type(api.whoami(), T.UserAndScopesDict)
 
     # Ensure the type signatures for pyairtable.Base don't change.
     base = pyairtable.Base(api, base_id)


### PR DESCRIPTION
This is a pretty simple endpoint and doesn't really need any embellishment.