### PR TITLE
batch_save and batch_delete for ORM models

### DIFF
--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -102,7 +102,7 @@ class Model(metaclass=abc.ABCMeta):
 
     id: str = ""
     created_time: str = ""
-    _table: Table
+    _deleted: bool = False
     _fields: Dict[FieldName, Any] = {}
     _linked_cache: Dict[RecordId, SelfType] = {}
 
@@ -229,6 +229,8 @@ class Model(metaclass=abc.ABCMeta):
 
         Returns `True` if was created and `False` if it was updated
         """
+        if self._deleted:
+            raise RuntimeError(f"{self.id} was deleted")
         table = self.get_table()
         fields = self.to_record(only_writable=True)["fields"]
 
@@ -249,6 +251,7 @@ class Model(metaclass=abc.ABCMeta):
             raise ValueError("cannot be deleted because it does not have id")
         table = self.get_table()
         result = table.delete(self.id)
+        self._deleted = True
         # Is it even possible to get "deleted" False?
         return bool(result["deleted"])
 

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -54,10 +54,18 @@ You can read and modify attributes. If record already exists,
     }
 }
 
-Finally, you can use :meth:`~pyairtable.orm.model.Model.delete` to delete the record:
+You can use :meth:`~pyairtable.orm.model.Model.delete` to delete the record:
 
 >>> contact.delete()
 True
+
+You can also use :meth:`~pyairtable.orm.model.Model.batch_save` and
+:meth:`~pyairtable.orm.model.Model.batch_delete` on several records at once:
+
+>>> contacts = Contact.all()
+>>> contacts.append(Contact(first_name="Alice", email="alice@example.com"))
+>>> Contact.batch_save(contacts)
+>>> Contact.batch_delete(contacts)
 """
 import abc
 from functools import lru_cache
@@ -375,8 +383,8 @@ class Model(metaclass=abc.ABCMeta):
     @classmethod
     def batch_delete(cls, models: List[SelfType]) -> None:
         """
-        Deletes a list of model instances from Airtable.
-        Raises ValueError if given a model which has not been saved.
+        Deletes a list of model instances from Airtable. Raises ``ValueError`` if
+        given a model which has never been saved to Airtable.
         """
         if not all(model.id for model in models):
             raise ValueError("cannot delete an unsaved model")

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -361,6 +361,9 @@ class Model(metaclass=abc.ABCMeta):
         network requests as possible. Can accept a mixture of new records
         (which have not been saved yet) and existing records that have IDs.
         """
+        if not all(isinstance(model, cls) for model in models):
+            raise TypeError(set(type(model) for model in models))
+
         create_models = [model for model in models if not model.id]
         update_models = [model for model in models if model.id]
         create_records: List[Fields] = [
@@ -373,6 +376,7 @@ class Model(metaclass=abc.ABCMeta):
             for model in update_models
             if (record := model.to_record(only_writable=True))
         ]
+
         table = cls.get_table()
         table.batch_update(update_records, typecast=cls._typecast())
         created_records = table.batch_create(create_records, typecast=cls._typecast())
@@ -388,4 +392,6 @@ class Model(metaclass=abc.ABCMeta):
         """
         if not all(model.id for model in models):
             raise ValueError("cannot delete an unsaved model")
+        if not all(isinstance(model, cls) for model in models):
+            raise TypeError(set(type(model) for model in models))
         cls.get_table().batch_delete([model.id for model in models])

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -86,7 +86,7 @@ def test_model():
     assert contact.first_name == "Gui"
     assert not contact.id
 
-    # delete
+    # save
     with mock.patch.object(Table, "create") as m_save:
         m_save.return_value = {"id": "id", "createdTime": "time"}
         contact.save()
@@ -100,6 +100,10 @@ def test_model():
         contact.delete()
 
     assert m_delete.called
+
+    # cannot save a deleted record
+    with pytest.raises(RuntimeError):
+        contact.save()
 
     record = contact.to_record()
     assert record["id"] == contact.id

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -234,3 +234,78 @@ def test_undeclared_field(requests_mock, test_case):
     _, get_model_instance = test_case
     instance = get_model_instance(Address, record["id"])
     assert instance.to_record()["fields"] == {"Number": "123", "Street": "Fake St"}
+
+
+@mock.patch("pyairtable.Table.batch_create")
+@mock.patch("pyairtable.Table.batch_update")
+def test_batch_save(mock_update, mock_create):
+    """
+    Test that we can pass multiple unsaved Model instances (or dicts) to batch_save
+    and it will create or update them all in as few requests as possible.
+    """
+    addr1 = Address(number="123", street="Fake St")
+    addr2 = Address(number="456", street="Fake St")
+    addr3 = Address.from_record(
+        {
+            "id": "recExistingRecord",
+            "createdTime": datetime.utcnow().isoformat(),
+            "fields": {"Number": "789", "Street": "Fake St"},
+        }
+    )
+
+    mock_create.return_value = [
+        fake_record(id="abc", Number="123", Street="Fake St"),
+        fake_record(id="def", Number="456", Street="Fake St"),
+    ]
+
+    # Just like model.save(), Model.batch_save() will set IDs on new records.
+    Address.batch_save([addr1, addr2, addr3])
+    assert addr1.id == "rec00000000000abc"
+    assert addr2.id == "rec00000000000def"
+    assert addr3.id == "recExistingRecord"
+
+    mock_create.assert_called_once_with(
+        [
+            {"Number": "123", "Street": "Fake St"},
+            {"Number": "456", "Street": "Fake St"},
+        ],
+        typecast=True,
+    )
+    mock_update.assert_called_once_with(
+        [
+            {
+                "id": "recExistingRecord",
+                "fields": {"Number": "789", "Street": "Fake St"},
+            },
+        ],
+        typecast=True,
+    )
+
+
+@mock.patch("pyairtable.Table.batch_delete")
+def test_batch_delete(mock_delete):
+    """
+    Test that we can pass a list of models to Model.batch_delete.
+    """
+    addresses = [
+        Address.from_record(fake_record(id=n, Number=str(n), Street="Fake St"))
+        for n in range(20)
+    ]
+    Address.batch_delete(addresses)
+    mock_delete.assert_called_once_with([record.id for record in addresses])
+
+
+@mock.patch("pyairtable.Table.batch_delete")
+def test_batch_delete__unsaved_record(mock_delete):
+    """
+    Test that we get a ValueError (and make no deletions) if Model.batch_delete
+    receives any models which have not been created yet.
+    """
+    addresses = [
+        Address.from_record(fake_record(Number="1", Street="Fake St")),
+        Address(number="2", street="Fake St"),
+    ]
+    with pytest.raises(ValueError):
+        Address.batch_delete(addresses)
+
+    assert mock_delete.call_count == 0

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -286,6 +286,20 @@ def test_batch_save(mock_update, mock_create):
     )
 
 
+@mock.patch("pyairtable.Table.batch_create")
+@mock.patch("pyairtable.Table.batch_update")
+def test_batch_save__invalid_class(mock_update, mock_create):
+    """
+    Test that batch_save() raises TypeError if a model is given which is not an
+    instance of the model being called.
+    """
+    with pytest.raises(TypeError):
+        Address.batch_save([Contact()])
+
+    assert mock_update.call_count == 0
+    assert mock_create.call_count == 0
+
+
 @mock.patch("pyairtable.Table.batch_delete")
 def test_batch_delete(mock_delete):
     """
@@ -311,5 +325,17 @@ def test_batch_delete__unsaved_record(mock_delete):
     ]
     with pytest.raises(ValueError):
         Address.batch_delete(addresses)
+
+    assert mock_delete.call_count == 0
+
+
+@mock.patch("pyairtable.Table.batch_delete")
+def test_batch_delete__invalid_class(mock_delete):
+    """
+    Test that batch_delete() raises TypeError if a model is given which is not an
+    instance of the model being called.
+    """
+    with pytest.raises(TypeError):
+        Address.batch_delete([Contact.from_record(fake_record())])
 
     assert mock_delete.call_count == 0


### PR DESCRIPTION
This adds `Model.batch_save()` and `Model.batch_delete()` to the ORM, so that implementers can reduce the number of network calls required when operating on many records at once. A few quirks:

* `Model.batch_save()` will call both `Table.batch_create()` and `Table.batch_update()`, depending on the record.
* `Model.batch_delete()` will raise `ValueError` if given a record that doesn't have an ID.
* Both methods will raise `TypeError` if given a record that is not an instance of the class.