### PR TITLE
Return full payload from batch_upsert

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 
 See :ref:`Migrating from 1.x to 2.0` for detailed migration notes.
 
+* :meth:`~pyairtable.Table.batch_upsert` now returns the full payload from the Airtable API.
+  - `PR #281 <https://github.com/gtalarico/pyairtable/pull/281>`_.
 * :ref:`ORM` module is no longer experimental and has a stable API.
   - `PR #277 <https://github.com/gtalarico/pyairtable/pull/277>`_.
 * Added :meth:`Model.batch_save <pyairtable.orm.Model.batch_save>`

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -72,6 +72,13 @@ Changes to types
 * All functions and methods in this library have full type annotations that will pass ``mypy --strict``.
   See the :ref:`types <Module: pyairtable.api.types>` module for more information on the types this library accepts and returns.
 
+batch_upsert has a different return type
+--------------------------------------------
+
+* :meth:`~pyairtable.Table.batch_upsert` now returns the full payload from the Airtable API,
+  as opposed to just the list of records (with no indication of which were created or updated).
+  See :class:`~pyairtable.api.types.UpsertResultDict` for more details.
+
 
 Migrating from 0.x to 1.0
 ============================

--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -247,6 +247,27 @@ class RecordDeletedDict(TypedDict):
     deleted: bool
 
 
+class UpsertResultDict(TypedDict):
+    """
+    A ``dict`` representing the payload returned by the Airtable API after an upsert.
+    For more details on this data structure, see the
+    `Update multiple records <https://airtable.com/developers/web/api/update-multiple-records>`__
+    API documentation.
+
+    Usage:
+        >>> table.batch_upsert(records, key_fields=["Name"])
+        {
+            'createdRecords': [...],
+            'updatedRecords': [...],
+            'records': [...]
+        }
+    """
+
+    createdRecords: List[RecordId]
+    updatedRecords: List[RecordId]
+    records: List[RecordDict]
+
+
 class UserAndScopesDict(TypedDict, total=False):
     """
     A ``dict`` representing the `Get user ID & scopes <https://airtable.com/developers/web/api/get-user-id-scopes>`_ endpoint.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,11 +73,6 @@ def mock_response_single(mock_records):
 
 
 @pytest.fixture
-def mock_response_batch(mock_records):
-    return {"records": mock_records * 2}
-
-
-@pytest.fixture
 def mock_response_list(mock_records):
     return [
         {"records": mock_records[0:2], "offset": "recuOeLpF6TQpArJi"},

--- a/tests/integration/test_integration_api.py
+++ b/tests/integration/test_integration_api.py
@@ -176,7 +176,7 @@ def test_batch_upsert(table: Table, cols):
     )
 
     # Test batch_upsert where replace=False
-    results = table.batch_upsert(
+    result = table.batch_upsert(
         [
             {"id": one["id"], "fields": {cols.NUM: 3}},  # use id
             {"fields": {cols.TEXT: "Two", cols.NUM: 4}},  # use key_fields
@@ -184,15 +184,17 @@ def test_batch_upsert(table: Table, cols):
         ],
         key_fields=[cols.TEXT],
     )
-    assert len(results) == 3
-    assert results[0]["id"] == one["id"]
-    assert results[0]["fields"] == {cols.TEXT: "One", cols.NUM: 3}
-    assert results[1]["id"] == two["id"]
-    assert results[1]["fields"] == {cols.TEXT: "Two", cols.NUM: 4}
-    assert results[2]["fields"] == {cols.TEXT: "Three", cols.NUM: 5}
+    assert set(result["updatedRecords"]) == {one["id"], two["id"]}
+    assert len(result["createdRecords"]) == 1
+    assert len(result["records"]) == 3
+    assert result["records"][0]["id"] == one["id"]
+    assert result["records"][0]["fields"] == {cols.TEXT: "One", cols.NUM: 3}
+    assert result["records"][1]["id"] == two["id"]
+    assert result["records"][1]["fields"] == {cols.TEXT: "Two", cols.NUM: 4}
+    assert result["records"][2]["fields"] == {cols.TEXT: "Three", cols.NUM: 5}
 
     # Test batch_upsert where replace=True
-    results = table.batch_upsert(
+    result = table.batch_upsert(
         [
             {"id": one["id"], "fields": {cols.NUM: 3}},  # removes cols.TEXT
             {"fields": {cols.TEXT: "Two"}},  # removes cols.NUM
@@ -202,21 +204,21 @@ def test_batch_upsert(table: Table, cols):
         key_fields=[cols.TEXT],
         replace=True,
     )
-    assert len(results) == 4
-    assert results[0]["id"] == one["id"]
-    assert results[0]["fields"] == {cols.NUM: 3}
-    assert results[1]["id"] == two["id"]
-    assert results[1]["fields"] == {cols.TEXT: "Two"}
-    assert results[2]["fields"] == {cols.TEXT: "Three", cols.NUM: 6}
-    assert results[3]["fields"] == {cols.NUM: 7}
+    assert len(result["records"]) == 4
+    assert result["records"][0]["id"] == one["id"]
+    assert result["records"][0]["fields"] == {cols.NUM: 3}
+    assert result["records"][1]["id"] == two["id"]
+    assert result["records"][1]["fields"] == {cols.TEXT: "Two"}
+    assert result["records"][2]["fields"] == {cols.TEXT: "Three", cols.NUM: 6}
+    assert result["records"][3]["fields"] == {cols.NUM: 7}
 
     # Test that batch_upsert passes along return_fields_by_field_id
-    results = table.batch_upsert(
+    result = table.batch_upsert(
         [{"fields": {cols.TEXT: "Two", cols.NUM: 8}}],
         key_fields=[cols.TEXT],
         return_fields_by_field_id=True,
     )
-    assert results == [
+    assert result["records"] == [
         {
             "id": two["id"],
             "createdTime": two["createdTime"],

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     assert_type(table.delete(record_id), T.RecordDeletedDict)
     assert_type(table.batch_create([]), List[T.RecordDict])
     assert_type(table.batch_update([]), List[T.RecordDict])
-    assert_type(table.batch_upsert([], []), List[T.RecordDict])
+    assert_type(table.batch_upsert([], []), T.UpsertResultDict)
     assert_type(table.batch_delete([]), List[T.RecordDeletedDict])
 
     # Ensure we can set all kinds of field values


### PR DESCRIPTION
* Changes the return signature of `batch_upsert` from a list of records to a dict
* Iterates over multiple pages of inputs and combines them all into a single response
* Fixes #280 – FYI @awb715 
