### PR TITLE
CRUD support for comments

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,6 +18,7 @@ Module: pyairtable
 
 .. autofunction:: pyairtable.retry_strategy
 
+
 Module: pyairtable.api.types
 *******************************
 
@@ -31,6 +32,12 @@ Module: pyairtable.formulas
 .. automodule:: pyairtable.formulas
     :members:
 
+
+Module: pyairtable.models
+*******************************
+
+.. autoclass:: pyairtable.models.Comment
+    :members:
 
 Module: pyairtable.orm
 *******************************

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 
 See :ref:`Migrating from 1.x to 2.0` for detailed migration notes.
 
+* Added :class:`~pyairtable.models.Comment` class; see :ref:`Commenting on Records`.
+  - `PR #282 <https://github.com/gtalarico/pyairtable/pull/282>`_.
 * :meth:`~pyairtable.Table.batch_upsert` now returns the full payload from the Airtable API.
   - `PR #281 <https://github.com/gtalarico/pyairtable/pull/281>`_.
 * :ref:`ORM` module is no longer experimental and has a stable API.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     # "autoapi.extension",
     "sphinx_autodoc_typehints",
+    "sphinxcontrib.autodoc_pydantic",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -40,6 +41,14 @@ autodoc_default_options = {
     "exclude-members": "__new__",
 }
 autodoc_member_order = "bysource"
+autoclass_content = "class"
+
+# See https://autodoc-pydantic.readthedocs.io/en/stable/users/configuration.html
+autodoc_pydantic_field_show_alias = False
+autodoc_pydantic_model_member_order = "bysource"
+autodoc_pydantic_model_show_config_summary = False
+autodoc_pydantic_model_show_field_summary = False
+autodoc_pydantic_model_show_json = False
 
 # See https://github.com/tox-dev/sphinx-autodoc-typehints#options
 typehints_defaults = "comma"

--- a/docs/source/orm.rst
+++ b/docs/source/orm.rst
@@ -324,6 +324,44 @@ there are four components:
 4. The model class, the path to the model class, or :data:`~pyairtable.orm.fields.LinkSelf`
 
 
+Comments
+----------
+
+You can use :meth:`Model.comments <pyairtable.orm.Model.comments>` and
+:meth:`Model.add_comment <pyairtable.orm.Model.add_comment>` to interact with
+comments on a particular record, just like their :class:`~pyairtable.Table` equivalents:
+
+    >>> record = YourModel.from_id("recMNxslc6jG0XedV")
+    >>> comment = record.add_comment("Hello, @[usrVMNxslc6jG0Xed]!")
+    >>> record.comments()
+    [
+        Comment(
+            id='comdVMNxslc6jG0Xe',
+            text='Hello, @[usrVMNxslc6jG0Xed]!',
+            created_time='2023-06-07T17:46:24.435891',
+            last_updated_time=None,
+            mentioned={
+                'usrVMNxslc6jG0Xed': Mentioned(
+                    display_name='Alice',
+                    email='alice@example.com',
+                    id='usrVMNxslc6jG0Xed',
+                    type='user'
+                )
+            },
+            author={
+                'id': 'usr0000pyairtable',
+                'email': 'pyairtable@example.com',
+                'name': 'Your pyairtable access token'
+            }
+        )
+    ]
+    >>> comment.text = "Never mind!"
+    >>> comment.save()
+    >>> record.comments()[0].text
+    'Never mind!'
+    >>> comment.delete()
+
+
 ORM Limitations
 ------------------
 

--- a/docs/source/tables.rst
+++ b/docs/source/tables.rst
@@ -114,6 +114,39 @@ like :meth:`~pyairtable.Table.iterate` or :meth:`~pyairtable.Table.all`.
      - |kwarg_return_fields_by_field_id|
 
 
+Return Values
+*************
+
+This library will return records as :class:`~pyairtable.api.types.RecordDict`.
+
+.. code-block:: python
+
+  >>> table.all()
+  [
+      {
+          'id': 'recwPQIfs4wKPyc9D',
+          'createdTime': '2017-03-14T22:04:31.000Z'
+          'fields': {
+              'Name': 'Alice',
+          },
+      },
+      {
+          'id': 'rechOLltN9SpPHq5o',
+          'createdTime': '2017-03-20T15:21:50.000Z'
+          'fields': {
+              'Name': 'Bob',
+          },
+      },
+      {
+          'id': 'rec5eR7IzKSAOBHCz',
+          'createdTime': '2017-08-05T21:47:52.000Z'
+          'fields': {
+              'Name': 'Carol',
+          },
+      }
+  ]
+
+
 Formulas
 ********
 
@@ -239,34 +272,40 @@ Batch delete records using a list of record ids.
    {'deleted': True, 'id': 'recwAcQdqwe21asdf'}]
 
 
-Return Values
--------------
+Commenting on Records
+---------------------
 
-This library will return records as :class:`~pyairtable.api.types.RecordDict`.
+pyAirtable allows you to access, create, and modify comments on records through
+the :class:`~pyairtable.Table` class. Both the :meth:`~pyairtable.Table.comments`
+and :meth:`~pyairtable.Table.add_comment` methods will return instances of
+:class:`~pyairtable.models.Comment`, which can be modified, saved, or deleted.
 
-.. code-block:: python
-
-  >>> table.all()
-  [
-      {
-          'id': 'recwPQIfs4wKPyc9D',
-          'createdTime': '2017-03-14T22:04:31.000Z'
-          'fields': {
-              'Name': 'Alice',
-          },
-      },
-      {
-          'id': 'rechOLltN9SpPHq5o',
-          'createdTime': '2017-03-20T15:21:50.000Z'
-          'fields': {
-              'Name': 'Bob',
-          },
-      },
-      {
-          'id': 'rec5eR7IzKSAOBHCz',
-          'createdTime': '2017-08-05T21:47:52.000Z'
-          'fields': {
-              'Name': 'Carol',
-          },
-      }
-  ]
+    >>> table = Api.table("appNxslc6jG0XedVM", "tblslc6jG0XedVMNx")
+    >>> comment = table.add_comment("recMNxslc6jG0XedV", "Hello, @[usrVMNxslc6jG0Xed]!")
+    >>> table.comments("recMNxslc6jG0XedV")
+    [
+        Comment(
+            id='comdVMNxslc6jG0Xe',
+            text='Hello, @[usrVMNxslc6jG0Xed]!',
+            created_time='2023-06-07T17:46:24.435891',
+            last_updated_time=None,
+            mentioned={
+                'usrVMNxslc6jG0Xed': Mentioned(
+                    display_name='Alice',
+                    email='alice@example.com',
+                    id='usrVMNxslc6jG0Xed',
+                    type='user'
+                )
+            },
+            author={
+                'id': 'usr0000pyairtable',
+                'email': 'pyairtable@example.com',
+                'name': 'Your pyairtable access token'
+            }
+        )
+    ]
+    >>> comment.text = "Never mind!"
+    >>> comment.save()
+    >>> table.comments("recMNxslc6jG0XedV")[0].text
+    'Never mind!'
+    >>> comment.delete()

--- a/pyairtable/metadata.py
+++ b/pyairtable/metadata.py
@@ -30,8 +30,13 @@ def get_api_bases(api: Union[Api, Base]) -> Dict[Any, Any]:
     """
     api = api.api if isinstance(api, Base) else api
     base_list_url = api.build_url("meta", "bases")
-    assert isinstance(response := api.request("get", base_list_url), dict)
-    return response
+    return {
+        "bases": [
+            base
+            for page in api.iterate_requests("get", base_list_url)
+            for base in page.get("bases", [])
+        ]
+    }
 
 
 def get_base_schema(base: Union[Base, Table]) -> Dict[Any, Any]:

--- a/pyairtable/models/__init__.py
+++ b/pyairtable/models/__init__.py
@@ -1,0 +1,5 @@
+from .comment import Comment
+
+__all__ = [
+    "Comment",
+]

--- a/pyairtable/models/_base.py
+++ b/pyairtable/models/_base.py
@@ -1,0 +1,98 @@
+from functools import partial
+from typing import Any, ClassVar, Iterable, Optional
+
+import inflection
+import pydantic
+from typing_extensions import Self as SelfType
+
+
+class AirtableModel(pydantic.BaseModel):
+    """
+    Base model for any data structures that will be loaded from the Airtable API.
+    """
+
+    class Config:
+        # Ignore field names we don't recognize, so applications don't crash
+        # if Airtable decides to add new attributes.
+        extra = "ignore"
+
+        # Convert e.g. "base_invite_links" to "baseInviteLinks" for (de)serialization
+        alias_generator = partial(inflection.camelize, uppercase_first_letter=False)
+
+        # We'll assume this in a couple different places
+        underscore_attrs_are_private = True
+
+
+class SerializableModel(AirtableModel):
+    """
+    Base model for any data structures that can be saved back to the API.
+    """
+
+    #: Subclasses can set ``__writable__`` to define specific fields to write to the API.
+    __writable__: ClassVar[Optional[Iterable[str]]] = None
+
+    #: Subclasses can set ``__readonly__`` to define certain fields that should not be written to API.
+    __readonly__: ClassVar[Optional[Iterable[str]]] = None
+
+    _api: "pyairtable.api.api.Api"
+    _url: str
+    _deleted: bool = False
+
+    @classmethod
+    def from_api(cls, api: "pyairtable.api.api.Api", url: str, obj: Any) -> SelfType:
+        """
+        Constructs an instance which is able to update itself using an
+        :class:`~pyairtable.Api`.
+
+        Args:
+            api: The connection to use for saving updates.
+            url: The URL which can receive PATCH or DELETE requests for this object.
+            obj: The JSON data structure used to construct the instance.
+                 Will be passed to `parse_obj <https://docs.pydantic.dev/latest/usage/models/#helper-functions>`_.
+        """
+        parsed = cls.parse_obj(obj)
+        parsed._api = api
+        parsed._url = url
+        return parsed
+
+    def save(self) -> None:
+        """
+        Save any changes made to the instance's writable fields.
+
+        Will raise ``RuntimeError`` if the record has been deleted.
+        """
+        if self._deleted:
+            raise RuntimeError("save() called after delete()")
+        include = set(self.__writable__) if self.__writable__ else None
+        exclude = set(self.__readonly__) if self.__readonly__ else None
+        data = self.dict(by_alias=True, include=include, exclude=exclude)
+        response = self._api.request("PATCH", self._url, json=data)
+        copyable = self.parse_obj(response)
+        self.__dict__.update(copyable.__dict__)
+
+    def delete(self) -> None:
+        """
+        Delete the record on the server and marks this instance as deleted.
+        """
+        response = self._api.request("DELETE", self._url)
+        self._deleted = bool(response["deleted"])
+
+    @property
+    def deleted(self) -> bool:
+        """
+        Indicates whether the record has been deleted since being returned from the API.
+        """
+        return self._deleted
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # Prevents implementers from changing values on readonly or non-writable fields.
+        if name in self.__class__.__fields__:
+            if self.__readonly__ and name in self.__readonly__:
+                raise AttributeError(name)
+            if self.__writable__ is not None and name not in self.__writable__:
+                raise AttributeError(name)
+
+        super().__setattr__(name, value)
+
+
+import pyairtable.api.api  # noqa

--- a/pyairtable/models/comment.py
+++ b/pyairtable/models/comment.py
@@ -1,0 +1,84 @@
+from typing import Dict, Optional
+
+from pyairtable.api.types import CollaboratorDict
+from pyairtable.models._base import AirtableModel, SerializableModel
+
+
+class Comment(SerializableModel):
+    """
+    A record comment that has been retrieved from the Airtable API.
+
+    >>> comment = table.add_comment("recMNxslc6jG0XedV", "Hello, @[usrVMNxslc6jG0Xed]!")
+    >>> table.comments("recMNxslc6jG0XedV")
+    [
+        Comment(
+            id='comdVMNxslc6jG0Xe',
+            text='Hello, @[usrVMNxslc6jG0Xed]!',
+            created_time='2023-06-07T17:46:24.435891',
+            last_updated_time=None,
+            mentioned={
+                'usrVMNxslc6jG0Xed': Mentioned(
+                    display_name='Alice',
+                    email='alice@example.com',
+                    id='usrVMNxslc6jG0Xed',
+                    type='user'
+                )
+            },
+            author={
+                'id': 'usrL2xZC5xoH4luAi',
+                'email': 'pyairtable@example.com',
+                'name': 'Your pyairtable access token'
+            }
+        )
+    ]
+    >>> comment.text = "Never mind!"
+    >>> comment.save()
+    >>> comment.delete()
+    """
+
+    __writable__ = ["text"]
+
+    #: The unique ID of the comment.
+    id: str
+
+    #: The text of the comment.
+    text: str
+
+    #: The ISO 8601 timestamp of when the comment was created.
+    created_time: str
+
+    #: The ISO 8601 timestamp of when the comment was last edited.
+    last_updated_time: Optional[str]
+
+    #: The account which created the comment.
+    author: CollaboratorDict
+
+    #: Users or groups that were mentioned in the text.
+    mentioned: Optional[Dict[str, "Comment.Mentioned"]]
+
+    class Mentioned(AirtableModel):
+        """
+        A user or group that was mentioned within a comment.
+        Stored as a ``dict`` that is keyed by ID.
+
+        >>> comment = table.add_comment(record_id, "Hello, @[usrVMNxslc6jG0Xed]!")
+        >>> comment.mentioned
+        {
+            "usrVMNxslc6jG0Xed": Mentioned(
+                display_name='Alice',
+                email='alice@example.com',
+                id='usrVMNxslc6jG0Xed',
+                type='user'
+            )
+        }
+
+        See `User mentioned <https://airtable.com/developers/web/api/model/user-mentioned>`_ for more details.
+        """
+
+        id: str
+        type: str
+        display_name: str
+        email: Optional[str] = None
+
+
+Comment.update_forward_refs()

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -14,6 +14,7 @@ from pyairtable.api.types import (
     WritableFields,
 )
 from pyairtable.formulas import OR, STR_VALUE
+from pyairtable.models import Comment
 from pyairtable.orm.fields import AnyField, Field
 
 
@@ -364,3 +365,17 @@ class Model:
         if not all(isinstance(model, cls) for model in models):
             raise TypeError(set(type(model) for model in models))
         cls.get_table().batch_delete([model.id for model in models])
+
+    def comments(self) -> List[Comment]:
+        """
+        Return a list of comments on this record.
+        See :meth:`Table.comments <pyairtable.Table.comments>`.
+        """
+        return self.get_table().comments(self.id)
+
+    def add_comment(self, text: str) -> Comment:
+        """
+        Add a comment to this record.
+        See :meth:`Table.add_comment <pyairtable.Table.add_comment>`.
+        """
+        return self.get_table().add_comment(self.id, text)

--- a/pyairtable/testing.py
+++ b/pyairtable/testing.py
@@ -67,7 +67,7 @@ def fake_record(
 
 def fake_user(value: Any = None) -> CollaboratorDict:
     id = fake_id("usr", value)
-    return {"id": id, "email": f"{value or id}@example.com"}
+    return {"id": id, "email": f"{value or id}@example.com", "name": "Fake User"}
 
 
 def fake_attachment() -> AttachmentDict:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ sphinx-autoapi
 sphinxext-opengraph
 revitron-sphinx-theme @ git+https://github.com/gtalarico/revitron-sphinx-theme.git@40f4b09fa5c199e3844153ef973a1155a56981dd
 sphinx-autodoc-typehints
+autodoc-pydantic
 
 # Packaging
 wheel==0.38.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
+    inflection
     pydantic ~= 1.10
     requests >= 2.22.0
     typing_extensions

--- a/tests/test_models_comment.py
+++ b/tests/test_models_comment.py
@@ -1,0 +1,138 @@
+import datetime
+
+import pytest
+
+from pyairtable.models import Comment
+from pyairtable.testing import fake_id, fake_user
+
+RECORD_ID = "recHasSomeComments"
+NOW = datetime.datetime.now().isoformat()
+
+
+@pytest.fixture
+def comment_json():
+    author = fake_user("author")
+    mentioned = fake_user("mentioned")
+    return {
+        "author": author,
+        "createdTime": NOW,
+        "id": fake_id("com"),
+        "lastUpdatedTime": None,
+        "text": f"Hello, @[{mentioned['id']}]!",
+        "mentioned": {
+            mentioned["id"]: {
+                "displayName": mentioned["name"],
+                "id": mentioned["id"],
+                "email": mentioned["email"],
+                "type": "user",
+            }
+        },
+    }
+
+
+@pytest.fixture
+def comment(comment_json, table):
+    url = table.record_url(RECORD_ID, "comments", comment_json["id"])
+    return Comment.from_api(table.api, url, comment_json)
+
+
+@pytest.fixture
+def comments_url(base, table):
+    return f"https://api.airtable.com/v0/{base.id}/{table.name}/{RECORD_ID}/comments"
+
+
+def test_parse(comment_json):
+    Comment.parse_obj(comment_json)
+
+
+@pytest.mark.parametrize(
+    "attr,value",
+    [
+        ("id", fake_id("rec", "FAKE")),
+        ("created_time", "2023-06-07T17:35:17"),
+        ("last_updated_time", "2023-06-07T17:35:17"),
+        ("mentioned", {}),
+        ("author", {}),
+    ],
+)
+def test_readonly_attributes(comment, attr, value):
+    """
+    Test that we cannot modify any attributes on a Comment besides ``text``.
+    """
+    with pytest.raises(AttributeError):
+        setattr(comment, attr, value)
+
+
+def test_save(comment, requests_mock):
+    """
+    Test that Comment.save() writes the correct payload to the API
+    and that it updates the instance with the values in the API response.
+    """
+    new_text = "This was changed!"
+    mentions = {}
+    modified = dict(comment.dict(by_alias=True), mentioned=mentions, text=new_text)
+    m = requests_mock.patch(comment._url, json=modified)
+
+    comment.text = "Whatever"
+    comment.save()
+    assert m.call_count == 1
+
+    # Ensure we wrote the changed text to the API...
+    assert m.request_history[0].json()["text"] == "Whatever"
+
+    # ...but our model loaded whatever values the API sent back.
+    assert comment.text == new_text
+    assert not comment.mentioned
+
+
+def test_delete(comment, requests_mock):
+    """
+    Test that Comment.delete() writes the correct payload to the API
+    and prevents the record from being saved in the future.
+    """
+    m = requests_mock.delete(comment._url, json={"id": comment.id, "deleted": True})
+    comment.delete()
+    assert m.call_count == 1
+    assert comment.deleted is True
+
+    # Once we have deleted a comment, we shouldn't be allowed to save it.
+    with pytest.raises(RuntimeError):
+        comment.save()
+
+
+# TODO: test_table_comments should probably be in test_api_table.py
+def test_table_comments(table, comments_url, comment_json, requests_mock):
+    """
+    Test that Table.comments() returns a list of comments and that
+    it requests all pages at once.
+    """
+    comment1 = {**comment_json, "id": "comFake1"}
+    comment2 = {**comment_json, "id": "comFake2"}
+    comment3 = {**comment_json, "id": "comFake3"}
+
+    m = requests_mock.get(
+        comments_url,
+        [
+            {"json": {"comments": [comment1], "offset": "offset1"}},
+            {"json": {"comments": [comment2, comment3], "offset": None}},
+        ],
+    )
+
+    comments = table.comments(RECORD_ID)
+    assert m.call_count == 2
+    assert len(comments) == 3
+    assert [c.id for c in comments] == ["comFake1", "comFake2", "comFake3"]
+    assert fake_user("mentioned")["id"] in comments[0].mentioned
+
+
+# TODO: test_table_comment should probably be in test_api_table.py
+def test_table_add_comment(table, comment_json, comments_url, requests_mock):
+    def _callback(request, context):
+        return {**comment_json, **request.json()}
+
+    m = requests_mock.post(comments_url, json=_callback)
+
+    text = "I'd like to weigh in here."
+    comment = table.add_comment(RECORD_ID, text)
+    assert m.call_count == 1
+    assert comment.text == text


### PR DESCRIPTION
This branch closes #238 by adding a few new methods and one new class:
* `Api.iterate_requests(...)` is a generic "retrieve all pages" method suitable for various API endpoints.
* `Table.comments(record_id)` and `Model.comments()` will retrieve all comments for the given record.
* `Table.add_comment(record_id, text)` and `Model.add_comment(text)` will add a comment to the given record.
* `Comment.text = text; Comment.save()` will modify an existing comment.
* `Comment.delete()` will delete it.

This branch also fixes #230 by adding support for multiple pages to the "get bases" metadata API. This was an easy side effect of implementing `Api.iterate_requests()`, which we needed for comments anyways.

Lastly, this branch sets up some base classes (`AirtableModel` and `SerializableModel`) that will be useful for other Airtable-supplied metadata in the future, such as webhooks.