### PR TITLE
Fix bug that ignored `lazy=True` on ORM LinkField

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,12 @@ release-test:
 bump:
 	@bash -c "./scripts/bump.sh"
 
-.PHONY: test test-e2e tox coverage lint format docs clean
+.PHONY: test test-e2e coverage lint format docs clean
 test:
-	tox -e py
+	tox -- -m 'not integration'
 
 test-e2e:
-	tox -e py -- ""
-
-tox: test
+	tox
 
 coverage:
 	tox -e coverage

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ Anyone who uses this library is welcome to [submit a pull request](https://githu
 2. New functionality is accompanied by clear, descriptive unit tests.
 3. You can run `make test && make docs` successfully.
 
-If you have an enterprise API key that can run end-to-end tests, please also run `env AIRTABLE_API_KEY=... make test-e2e`.
-
 If you want to discuss an idea you're working on but haven't yet finished all of the above, please [open a draft pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests). That will be a clear signal that you're not asking to merge your code (yet) and are just looking for discussion or feedback.
 
 Thanks in advance for sharing your ideas!

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -552,7 +552,8 @@ class LinkField(_ListField[RecordId, T_Linked]):
             new_records = {
                 record.id: record
                 for record in self.linked_model.from_ids(
-                    cast(List[RecordId], new_record_ids)
+                    cast(List[RecordId], new_record_ids),
+                    fetch=(not self._lazy),
                 )
             }
         # If the list contains record IDs, replace the contents with instances.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,7 +30,7 @@ def api_key():
     try:
         return os.environ["AIRTABLE_API_KEY"]
     except KeyError:
-        pytest.skip("integration test requires AIRTABLE_API_KEY env variable")
+        pytest.skip("integration test requires AIRTABLE_API_KEY")
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands = mypy --strict pyairtable tests/test_typing.py
 passenv = AIRTABLE_API_KEY
 addopts = -v
 testpaths = tests
-commands = python -m pytest {posargs:-m 'not integration'}
+commands = python -m pytest {posargs}
 deps =
     -r requirements-test.txt
     requestsmin: requests==2.22.0  # Keep in sync with setup.cfg


### PR DESCRIPTION
This was a regression from some refactoring I did on LinkField a while back. I only just noticed it now. 

GitHub Actions isn't configured to run integration tests, so I must've simply been neglecting to run them myself. As part of this branch I'm making it just a bit easier to run integration tests (and therefore harder for me to forget) in my local env.

