### PR TITLE
Fix docs bug that treated all `Dict[str,Any]` as `Fields`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,8 +70,11 @@ def typehints_formatter(annotation, config):
         if isinstance(value, type) and issubclass(value, dict):  # TypedDict
             return f":data:`~pyairtable.api.types.{name}`"
         # At this point there's no way to determine whether an annotation
-        # which was evaluated to Dict[str, Any] is Fields or something unrelated.
-        # TODO: get all TypeAlias annotations properly reflected in docs.
+        # which was evaluated to Dict[str, Any] is Fields or something unrelated,
+        # so we limit this formatter to just type aliases which we *know* are unique.
+        # TODO: get *all* type alias annotations properly reflected in docs.
+        if name in ("WritableFieldValue", "WritableField"):
+            return f":data:`~pyairtable.api.types.{name}`"
 
     if annotation == typing.Literal[pyairtable.orm.fields._LinkFieldOptions.LinkSelf]:
         return ":data:`~pyairtable.orm.fields.LinkSelf`"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,8 +69,9 @@ def typehints_formatter(annotation, config):
             continue
         if isinstance(value, type) and issubclass(value, dict):  # TypedDict
             return f":data:`~pyairtable.api.types.{name}`"
-        if isinstance(value, typing._GenericAlias):  # Union, Dict, etc.
-            return f":data:`~pyairtable.api.types.{name}`"
+        # At this point there's no way to determine whether an annotation
+        # which was evaluated to Dict[str, Any] is Fields or something unrelated.
+        # TODO: get all TypeAlias annotations properly reflected in docs.
 
     if annotation == typing.Literal[pyairtable.orm.fields._LinkFieldOptions.LinkSelf]:
         return ":data:`~pyairtable.orm.fields.LinkSelf`"

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -7,12 +7,12 @@ import pyairtable.models
 from pyairtable.api.retrying import Retry
 from pyairtable.api.types import (
     FieldName,
-    Fields,
     RecordDeletedDict,
     RecordDict,
     RecordId,
     UpdateRecordDict,
     UpsertResultDict,
+    WritableFields,
     assert_typed_dict,
     assert_typed_dicts,
 )
@@ -231,7 +231,7 @@ class Table:
 
     def create(
         self,
-        fields: Fields,
+        fields: WritableFields,
         typecast: bool = False,
         return_fields_by_field_id: bool = False,
     ) -> RecordDict:
@@ -260,7 +260,7 @@ class Table:
 
     def batch_create(
         self,
-        records: List[Fields],
+        records: List[WritableFields],
         typecast: bool = False,
         return_fields_by_field_id: bool = False,
     ) -> List[RecordDict]:
@@ -306,7 +306,7 @@ class Table:
     def update(
         self,
         record_id: RecordId,
-        fields: Fields,
+        fields: WritableFields,
         replace: bool = False,
         typecast: bool = False,
     ) -> RecordDict:

--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -214,6 +214,16 @@ class RecordDict(TypedDict):
 class CreateRecordDict(TypedDict):
     """
     A ``dict`` representing the payload passed to the Airtable API to create a record.
+
+    Field values must each be a :data:`~pyairtable.api.types.WritableFieldValue`.
+
+    Usage:
+        >>> table.create({
+        ...     "fields": {
+        ...         "Field Name": "Field Value",
+        ...         "Other Field": ["Value 1", "Value 2"]
+        ...     }
+        ... })
     """
 
     fields: WritableFields
@@ -223,12 +233,23 @@ class UpdateRecordDict(TypedDict):
     """
     A ``dict`` representing the payload passed to the Airtable API to update a record.
 
+    Field values must each be a :data:`~pyairtable.api.types.WritableFieldValue`.
+
     Usage:
-        >>> update_records = [
-        ...     {"id": "recAdw9EjV90xbW", "fields": {"Email": "alice@example.com"}},
-        ...     {"id": "recAdw9EjV90xbX", "fields": {"Email": "bob@example.com"}},
-        ... ]
-        >>> table.batch_update(update_records)
+        >>> table.batch_update([
+        ...     {
+        ...         "id": "recAdw9EjV90xbW",
+        ...         "fields": {
+        ...             "Email": "alice@example.com"
+        ...         }
+        ...     },
+        ...     {
+        ...         "id": "recAdw9EjV90xbX",
+        ...         "fields": {
+        ...             "Email": "bob@example.com"
+        ...         }
+        ...     }
+        ... ])
     """
 
     id: RecordId

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ sphinx-autoapi
 sphinxext-opengraph
 revitron-sphinx-theme @ git+https://github.com/gtalarico/revitron-sphinx-theme.git@40f4b09fa5c199e3844153ef973a1155a56981dd
 sphinx-autodoc-typehints
-autodoc-pydantic
+autodoc-pydantic<2
 
 # Packaging
 wheel==0.38.1


### PR DESCRIPTION
Unfortunately in https://github.com/gtalarico/pyairtable/commit/8009cedbb7d7524e81ab6c46f0667f66f73333c8 it seems I inadvertently broke a part of the custom type hints formatter in `conf.py`, which relied on type aliases generally being unique. This caused it to display any `Dict[str, Any]` as a link to the `Fields` alias, which is subtly confusing.

For now I don't have a great workaround. The plugin we're using to render type annotations in method parameters doesn't support the autodoc_type_aliases option (see https://github.com/tox-dev/sphinx-autodoc-typehints/issues/284). Instead I'm just going to limit our use of it to a couple specific type aliases which we know  are unique.

I also found a couple spots where we were using `Fields` instead of `WritableFields`. This means we're _technically_ changing the API, but I doubt it's in a way that will impact anyone's project. I think we can release this as 2.1.1 at some point (instead of waiting for 2.2).