### PR TITLE
Relax type annotation on batch_upsert (and other batch methods)

### DIFF
--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -260,7 +260,7 @@ class Table:
 
     def batch_create(
         self,
-        records: List[WritableFields],
+        records: Iterable[WritableFields],
         typecast: bool = False,
         return_fields_by_field_id: bool = False,
     ) -> List[RecordDict]:
@@ -282,11 +282,14 @@ class Table:
         ]
 
         Args:
-            records: List of dicts representing records to be created.
+            records: Iterable of dicts representing records to be created.
             typecast: |kwarg_typecast|
             return_fields_by_field_id: |kwarg_return_fields_by_field_id|
         """
         inserted_records = []
+
+        # If we got an iterator, exhaust it and collect it into a list.
+        records = list(records)
 
         for chunk in self.api.chunked(records):
             new_records = [{"fields": fields} for fields in chunk]
@@ -334,7 +337,7 @@ class Table:
 
     def batch_update(
         self,
-        records: List[UpdateRecordDict],
+        records: Iterable[UpdateRecordDict],
         replace: bool = False,
         typecast: bool = False,
         return_fields_by_field_id: bool = False,
@@ -353,6 +356,9 @@ class Table:
         """
         updated_records = []
         method = "put" if replace else "patch"
+
+        # If we got an iterator, exhaust it and collect it into a list.
+        records = list(records)
 
         for chunk in self.api.chunked(records):
             chunk_records = [{"id": x["id"], "fields": x["fields"]} for x in chunk]
@@ -395,6 +401,9 @@ class Table:
         Returns:
             Lists of created/updated record IDs, along with the list of all records affected.
         """
+        # If we got an iterator, exhaust it and collect it into a list.
+        records = list(records)
+
         # The API will reject a request where a record is missing any of fieldsToMergeOn,
         # but we might not reach that error until we've done several batch operations.
         # To spare implementers from having to recover from a partially applied upsert,
@@ -454,7 +463,7 @@ class Table:
             self.api.request("delete", self.record_url(record_id)),
         )
 
-    def batch_delete(self, record_ids: List[RecordId]) -> List[RecordDeletedDict]:
+    def batch_delete(self, record_ids: Iterable[RecordId]) -> List[RecordDeletedDict]:
         """
         Deletes the given records, operating in batches.
 
@@ -471,6 +480,9 @@ class Table:
             Confirmation that the records were deleted.
         """
         deleted_records = []
+
+        # If we got an iterator, exhaust it and collect it into a list.
+        record_ids = list(record_ids)
 
         for chunk in self.api.chunked(record_ids):
             result = self.api.request("delete", self.url, params={"records[]": chunk})

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -1,7 +1,7 @@
 import posixpath
 import urllib.parse
 import warnings
-from typing import Any, Iterator, List, Optional, Union, overload
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Union, overload
 
 import pyairtable.models
 from pyairtable.api.retrying import Retry
@@ -371,7 +371,7 @@ class Table:
 
     def batch_upsert(
         self,
-        records: List[UpdateRecordDict],
+        records: Iterable[Dict[str, Any]],
         key_fields: List[FieldName],
         replace: bool = False,
         typecast: bool = False,

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -55,6 +55,16 @@ if TYPE_CHECKING:
     table.update(record_id, {"Field Name": {"email": "alice@example.com"}})
     table.update(record_id, {"Field Name": ["rec1", "rec2", "rec3"]})
 
+    # Ensure batch_upsert takes both records with and without IDs
+    table.batch_upsert(
+        [
+            {"fields": {"Name": "Carol"}},
+            {"id": "recAsdf", "fields": {"Name": "Bob"}},
+            {"id": "recAsdf", "createdTime": "", "fields": {"Name": "Alice"}},
+        ],
+        key_fields=["Name"],
+    )
+
     # Test type annotations for the ORM
     class Actor(orm.Model):
         name = orm.fields.TextField("Name")


### PR DESCRIPTION
This branch addresses two issues with the type hints we rolled out in 2.0:

1. The `batch_upsert` method only accepts records _with_ an ID, not _without_ an ID. (Fixing this got complicated due to how mypy interprets lists of dicts, and I wound up simply relaxing it to `List[Dict[str, Any]]` instead of something like `List[Union[RecordDict, CreateRecordDict, UpdateRecordDict]]`.
2. All of our `batch_*` methods only accept lists, not other iterable types. That means, among other things, that generator expressions can't be passed directly into these functions. This branch fixes that.

Both changes have test coverage, but I may have missed something. Eyes welcome!