### PR TITLE
For discussion: run pytest against docstrings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
-include *.py
-include *.rst
-include tox.ini
+include pyairtable/**/*.py
+exclude pyairtable/**/conftest.py
 include LICENSE
 include README.md

--- a/docs/source/conftest.py
+++ b/docs/source/conftest.py
@@ -1,0 +1,1 @@
+../../pyairtable/conftest.py

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -49,11 +49,19 @@ See below for supported and unsupported patterns:
 
     # The following will raise a TypeError for mixing str & instances:
     >>> table = Table(api_key, base, table_name)  # [str, Base, str]
+    Traceback (most recent call last):
+    TypeError: Table() expects either (str, str, str) or (None, Base, str); got ...
+
+    # The following will raise a TypeError for mixing str & instances:
     >>> table = Table(api, base_id, table_name)  # [Api, str, str]
+    Traceback (most recent call last):
+    TypeError: Table() expects either (str, str, str) or (None, Base, str); got ...
 
     # The following will raise a TypeError. We do this proactively
     # to avoid situations where self.api and self.base don't align.
     >>> table = Table(api, base_id, table_name)  # [Api, Base, str]
+    Traceback (most recent call last):
+    TypeError: Table() expects either (str, str, str) or (None, Base, str); got ...
 
 You may need to change how your code looks up some pieces of connection metadata; for example:
 

--- a/docs/source/tables.rst
+++ b/docs/source/tables.rst
@@ -62,8 +62,8 @@ Iterate over a set of records of size ``page_size``, up until ``max_records`` or
   >>> for records in table.iterate(page_size=100, max_records=1000):
   ...     print(records)
   ...
-  [{'id': 'rec123asa23', 'fields': {'Last Name': 'Alfred', 'Age': 84}, ...}, ...]
-  [{'id': 'rec123asa23', 'fields': {'Last Name': 'Jameson', 'Age': 42}, ...}, ...]
+  [{'id': 'rec000000123asa23', 'fields': {'Last Name': 'Alfred', 'Age': 84}, ...}, ...]
+  [{'id': 'rec000000123asa23', 'fields': {'Last Name': 'Jameson', 'Age': 42}, ...}, ...]
 
 :meth:`~pyairtable.Table.all`
 
@@ -74,7 +74,7 @@ multiple requests.
 .. code-block:: python
 
   >>> table.all(sort=["Name", "-Age"])
-  [{'id': 'rec123asa23', 'fields': {'Last Name': 'Alfred', 'Age': 84}, ...}, ...]
+  [{'id': 'rec000000123asa23', 'fields': {'Last Name': 'Alfred', 'Age': 84}, ...}, ...]
 
 
 Parameters
@@ -198,7 +198,7 @@ Creates a single record from a dictionary representing the table's fields.
 .. code-block:: python
 
   >>> table.create({'Name': 'John'})
-  {'id': 'rec123asa23', 'fields': {'Name': 'John', ...}}
+  {'id': 'rec000000123asa23', 'fields': {'Name': 'John', ...}}
 
 
 :meth:`~pyairtable.Table.batch_create`
@@ -208,7 +208,7 @@ Create multiple records from a list of :class:`~pyairtable.api.types.WritableFie
 .. code-block:: python
 
   >>> table.batch_create([{'Name': 'John'}, ...])
-  [{'id': 'rec123asa23', 'fields': {'Name': 'John'}}, ...]
+  [{'id': 'rec000000123asa23', 'fields': {'Name': 'John'}}, ...]
 
 
 Updating Records

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -454,8 +454,8 @@ class Table:
         """
         Deletes the given record.
 
-        >>> table.delete('recAdw9EjV90xbW')
-        {'id': 'recAdw9EjV90xbW', 'deleted': True}
+        >>> table.delete('recAdw9EjV90xbcdW')
+        {'id': 'recAdw9EjV90xbcdW', 'deleted': True}
 
         Args:
             record_id: |arg_record_id|
@@ -472,10 +472,10 @@ class Table:
         """
         Deletes the given records, operating in batches.
 
-        >>> table.batch_delete(['recAdw9EjV90xbW', 'recAdw9EjV90xbX'])
+        >>> table.batch_delete(['recAdw9EjV90xbcdW', 'recAdw9EjV90xbcdX'])
         [
-            {'id': 'recAdw9EjV90xbW', 'deleted': True},
-            {'id': 'recAdw9EjV90xbX', 'deleted': True}
+            {'id': 'recAdw9EjV90xbcdW', 'deleted': True},
+            {'id': 'recAdw9EjV90xbcdX', 'deleted': True}
         ]
 
         Args:
@@ -497,12 +497,12 @@ class Table:
         Returns a list of comments on the given record.
 
         Usage:
-            >>> table.comments("recMNxslc6jG0XedV")
+            >>> table.comments("recThatHasComment")
             [
                 Comment(
-                    id='comdVMNxslc6jG0Xe',
+                    id='com...',
                     text='Hello, @[usrVMNxslc6jG0Xed]!',
-                    created_time='2023-06-07T17:46:24.435891',
+                    created_time='...',
                     last_updated_time=None,
                     mentioned={
                         'usrVMNxslc6jG0Xed': Mentioned(
@@ -544,7 +544,6 @@ class Table:
         See `Create comment <https://airtable.com/developers/web/api/create-comment>`_ for details.
 
         Usage:
-            >>> table = api.table("appNxslc6jG0XedVM", "tblslc6jG0XedVMNx")
             >>> comment = table.add_comment("recMNxslc6jG0XedV", "Hello, @[usrVMNxslc6jG0Xed]!")
             >>> comment.text = "Never mind!"
             >>> comment.save()

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -23,7 +23,7 @@ class Table:
     Represents an Airtable table.
 
     Usage:
-        >>> api = Api(access_token)
+        >>> api = Api("your_personal_access_token")
         >>> table = api.table("base_id", "table_name")
         >>> records = table.all()
     """
@@ -70,13 +70,15 @@ class Table:
 
         This approach is deprecated, and will likely be removed in the future.
 
-            >>> Table("api_key", "base_id", "table_name", timeout=(1, 1))
+            >>> Table("api_key", "appBase", "tblName", timeout=(1, 1))
+            <Table base_id='appBase' table_name='tblName'>
 
         New style constructor has an odd signature to preserve backwards-compatibility
         with the old style (above), requiring ``None`` as the first argument, followed by
         an instance of :class:`Base`, followed by the table name.
 
-            >>> Table(None, base, "table_name")
+            >>> Table(None, Base(api, 'appBase'), "tblName")
+            <Table base_id='appBase' table_name='tblName'>
 
         These signatures may change in the future. Developers using this library are
         encouraged to not construct Table instances directly, and instead fetch tables
@@ -131,7 +133,11 @@ class Table:
         Retrieves a record by its ID.
 
         >>> table.get('recwPQIfs4wKPyc9D')
-        {'id': 'recwPQIfs4wKPyc9D', 'fields': {'First Name': 'John', 'Age': 21}}
+        {
+            'id': 'recwPQIfs4wKPyc9D',
+            'createdTime': '...',
+            'fields': {'First Name': 'John', 'Age': 20}
+        }
 
         Args:
             record_id: |arg_record_id|
@@ -152,11 +158,7 @@ class Table:
 
         >>> it = table.iterate()
         >>> next(it)
-        [{"id": ...}, {"id": ...}, {"id": ...}, ...]
-        >>> next(it)
-        [{"id": ...}, {"id": ...}, {"id": ...}, ...]
-        >>> next(it)
-        [{"id": ...}]
+        [{'id': ...}, {'id': ...}, {'id': ...}, ...]
         >>> next(it)
         Traceback (most recent call last):
         StopIteration
@@ -185,11 +187,8 @@ class Table:
         """
         Retrieves all matching records in a single list.
 
-        >>> table = api.table('base_id', 'table_name')
-        >>> table.all(view='MyView', fields=['ColA', '-ColB'])
-        [{'fields': ...}, ...]
-        >>> table.all(max_records=50)
-        [{'fields': ...}, ...]
+        >>> records = table.all(view='MyView', fields=['ColA', '-ColB'])
+        >>> records = table.all(max_records=50)
 
         Keyword Args:
             view: |kwarg_view|
@@ -241,6 +240,13 @@ class Table:
         >>> record = {'Name': 'John'}
         >>> table = api.table('base_id', 'table_name')
         >>> table.create(record)
+        {
+            'id': 'rec...',
+            'createdTime': '...',
+            'fields': {
+                'Name': 'John'
+            }
+        }
 
         Args:
             fields: Fields to insert. Must be a dict with field names or IDs as keys.
@@ -270,13 +276,13 @@ class Table:
         >>> table.batch_create([{'Name': 'John'}, {'Name': 'Marc'}])
         [
             {
-                'id': 'recW9e0c9w0er9gug',
-                'createdTime': '2017-03-14T22:04:31.000Z',
+                'id': 'rec...',
+                'createdTime': '...',
                 'fields': {'Name': 'John'}
             },
             {
-                'id': 'recW9e0c9w0er9guh',
-                'createdTime': '2017-03-14T22:04:31.000Z',
+                'id': 'rec...',
+                'createdTime': '...',
                 'fields': {'Name': 'Marc'}
             }
         ]
@@ -314,9 +320,17 @@ class Table:
         Updates a particular record ID with the given fields.
 
         >>> table.update('recwPQIfs4wKPyc9D', {"Age": 21})
-        {'id': 'recwPQIfs4wKPyc9D', 'fields': {'First Name': 'John', 'Age': 21}}
+        {
+            'id': 'recwPQIfs4wKPyc9D',
+            'createdTime': '...',
+            'fields': {'First Name': 'John', 'Age': 21}
+        }
         >>> table.update('recwPQIfs4wKPyc9D', {"Age": 22}, replace=True)
-        {'id': 'recwPQIfs4wKPyc9D', 'fields': {'Age': 22}}
+        {
+            'id': 'recwPQIfs4wKPyc9D',
+            'createdTime': '...',
+            'fields': {'Age': 22}
+        }
 
         Args:
             record_id: |arg_record_id|
@@ -440,8 +454,8 @@ class Table:
         """
         Deletes the given record.
 
-        >>> table.delete('recwPQIfs4wKPyc9D')
-        {'id': 'recwPQIfs4wKPyc9D', 'deleted': True}
+        >>> table.delete('recAdw9EjV90xbW')
+        {'id': 'recAdw9EjV90xbW', 'deleted': True}
 
         Args:
             record_id: |arg_record_id|
@@ -458,10 +472,10 @@ class Table:
         """
         Deletes the given records, operating in batches.
 
-        >>> table.batch_delete(['recwPQIfs4wKPyc9D', 'recwDxIfs3wDPyc3F'])
+        >>> table.batch_delete(['recAdw9EjV90xbW', 'recAdw9EjV90xbX'])
         [
-            {'id': 'recwPQIfs4wKPyc9D', 'deleted': True},
-            {'id': 'recwDxIfs3wDPyc3F', 'deleted': True}
+            {'id': 'recAdw9EjV90xbW', 'deleted': True},
+            {'id': 'recAdw9EjV90xbX', 'deleted': True}
         ]
 
         Args:
@@ -483,7 +497,6 @@ class Table:
         Returns a list of comments on the given record.
 
         Usage:
-            >>> table = Api.table("appNxslc6jG0XedVM", "tblslc6jG0XedVMNx")
             >>> table.comments("recMNxslc6jG0XedV")
             [
                 Comment(
@@ -531,7 +544,7 @@ class Table:
         See `Create comment <https://airtable.com/developers/web/api/create-comment>`_ for details.
 
         Usage:
-            >>> table = Api.table("appNxslc6jG0XedVM", "tblslc6jG0XedVMNx")
+            >>> table = api.table("appNxslc6jG0XedVM", "tblslc6jG0XedVMNx")
             >>> comment = table.add_comment("recMNxslc6jG0XedV", "Hello, @[usrVMNxslc6jG0Xed]!")
             >>> comment.text = "Never mind!"
             >>> comment.save()

--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -56,13 +56,22 @@ class CreateAttachmentDict(TypedDict, total=False):
     """
     A ``dict`` representing a new attachment to be written to the Airtable API.
 
+    >>> record = table.get("recW8eG2x0ew1Af")
     >>> new_attachment = {
     ...     "url": "https://example.com/image.jpg",
     ...     "filename": "something_else.jpg",
     ... }
     >>> existing = record["fields"].setdefault("Attachments", [])
     >>> existing.append(new_attachment)
-    >>> table.update(existing["id"], existing["fields"])
+    >>> table.update(record["id"], record["fields"])
+    {
+        'id': 'recW8eG2x0ew1Af',
+        'createdTime': '...',
+        'fields': {
+            'Attachments': [...],
+            ...
+        }
+    }
     """
 
     url: Required[str]
@@ -139,14 +148,13 @@ class CollaboratorEmailDict(TypedDict):
     Often used when writing to the API, because the email of a collaborator
     may be more easily accessible than their Airtable user ID.
 
-    >>> table = Table("access_token", "base_id", "api_key")
-    >>> record = table.update("recW8eG2x0ew1Af", {
+    >>> record = table.update("recW8eG2x0ew1Ac", {
     ...     "Collaborator": {"email": "alice@example.com"}
     ... })
     >>> record
     {
-        'id': 'recW8eG2x0ew1Af',
-        'createdTime': 2023-06-07T17:35:17Z',
+        'id': 'recW8eG2x0ew1Ac',
+        'createdTime': '...',
         'fields': {
             'Collaborator': {
                 'id': 'usrAdw9EjV90xbW',
@@ -198,11 +206,13 @@ class RecordDict(TypedDict):
     See `List records <https://airtable.com/developers/web/api/list-records>`__.
 
     Usage:
-        >>> table.first(formula="Name = 'Alice'")
+        >>> table.first()
         {
-            'id': 'recAdw9EjV90xbW',
-            'createdTime': '2023-05-22T21:24:15.333134Z',
-            'fields': {'Name': 'Alice', 'Department': 'Engineering'}
+            'id': 'recW8eG2x0ew1Af',
+            'createdTime': '...',
+            'fields': {
+                ...
+            }
         }
     """
 
@@ -218,7 +228,7 @@ class CreateRecordDict(TypedDict):
     Field values must each be a :data:`~pyairtable.api.types.WritableFieldValue`.
 
     Usage:
-        >>> table.create({
+        >>> record = table.create({
         ...     "fields": {
         ...         "Field Name": "Field Value",
         ...         "Other Field": ["Value 1", "Value 2"]
@@ -236,7 +246,7 @@ class UpdateRecordDict(TypedDict):
     Field values must each be a :data:`~pyairtable.api.types.WritableFieldValue`.
 
     Usage:
-        >>> table.batch_update([
+        >>> records = table.batch_update([
         ...     {
         ...         "id": "recAdw9EjV90xbW",
         ...         "fields": {
@@ -261,8 +271,8 @@ class RecordDeletedDict(TypedDict):
     A ``dict`` representing the payload returned by the Airtable API to confirm a deletion.
 
     Usage:
-        >>> table.delete("recAdw9EjV90xbZ")
-        {'id': 'recAdw9EjV90xbZ', 'deleted': True}
+        >>> table.delete("recW8eG2x0ew1Af")
+        {'id': 'recW8eG2x0ew1Af', 'deleted': True}
     """
 
     id: RecordId
@@ -277,7 +287,7 @@ class UpsertResultDict(TypedDict):
     API documentation.
 
     Usage:
-        >>> table.batch_upsert(records, key_fields=["Name"])
+        >>> table.batch_upsert(upserts, key_fields=["Name"])
         {
             'createdRecords': [...],
             'updatedRecords': [...],
@@ -340,7 +350,7 @@ def assert_typed_dict(cls: Type[T], obj: Any) -> T:
 
         >>> assert_typed_dict(RecordDict, {"foo": "bar"})
         Traceback (most recent call last):
-        pydantic.error_wrappers.ValidationError: 3 validation errors for RecordDict
+        pydantic.v1.error_wrappers.ValidationError: 3 validation errors for RecordDict
         id
           field required (type=value_error.missing)
         createdTime

--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -12,7 +12,7 @@ from pyairtable._compat import pydantic
 T = TypeVar("T")
 
 #: An alias for ``str`` used internally for disambiguation.
-#: Record IDs for Airtable look like ``"recAdw9EjV90xbZ"``.
+#: Record IDs for Airtable look like ``"rec00Adw9EjV90xbZ"``.
 RecordId: TypeAlias = str
 
 #: An alias for ``str`` used internally for disambiguation.
@@ -29,7 +29,7 @@ class AttachmentDict(TypedDict, total=False):
     """
     A ``dict`` representing an attachment stored in an Attachments field.
 
-    >>> record = table.get('recW8eG2x0ew1Af')
+    >>> record = table.get('rec00W8eG2x0ew1Af')
     >>> record['fields']['Attachments']
     [
         {
@@ -56,7 +56,7 @@ class CreateAttachmentDict(TypedDict, total=False):
     """
     A ``dict`` representing a new attachment to be written to the Airtable API.
 
-    >>> record = table.get("recW8eG2x0ew1Af")
+    >>> record = table.get("rec00W8eG2x0ew1Af")
     >>> new_attachment = {
     ...     "url": "https://example.com/image.jpg",
     ...     "filename": "something_else.jpg",
@@ -65,7 +65,7 @@ class CreateAttachmentDict(TypedDict, total=False):
     >>> existing.append(new_attachment)
     >>> table.update(record["id"], record["fields"])
     {
-        'id': 'recW8eG2x0ew1Af',
+        'id': 'rec00W8eG2x0ew1Af',
         'createdTime': '...',
         'fields': {
             'Attachments': [...],
@@ -82,7 +82,7 @@ class BarcodeDict(TypedDict, total=False):
     """
     A ``dict`` representing the value stored in a Barcode field.
 
-    >>> record = table.get('recW8eG2x0ew1Af')
+    >>> record = table.get('rec00W8eG2x0ew1Af')
     >>> record['fields']['Barcode']
     {'type': 'upce', 'text': '01234567'}
 
@@ -97,7 +97,7 @@ class ButtonDict(TypedDict):
     """
     A ``dict`` representing the value stored in a Button field.
 
-    >>> record = table.get('recW8eG2x0ew1Af')
+    >>> record = table.get('rec00W8eG2x0ew1Af')
     >>> record['fields']['Click Me']
     {'label': 'Click Me', 'url': 'http://example.com'}
 
@@ -112,7 +112,7 @@ class CollaboratorDict(TypedDict, total=False):
     """
     A dict representing the value stored in a User field returned from the API.
 
-    >>> record = table.get('recW8eG2x0ew1Af')
+    >>> record = table.get('rec00W8eG2x0ew1Af')
     >>> record['fields']['Created By']
     {
         'id': 'usrAdw9EjV90xbW',
@@ -148,12 +148,12 @@ class CollaboratorEmailDict(TypedDict):
     Often used when writing to the API, because the email of a collaborator
     may be more easily accessible than their Airtable user ID.
 
-    >>> record = table.update("recW8eG2x0ew1Ac", {
+    >>> record = table.update("rec00W8eG2x0ew1Ac", {
     ...     "Collaborator": {"email": "alice@example.com"}
     ... })
     >>> record
     {
-        'id': 'recW8eG2x0ew1Ac',
+        'id': 'rec00W8eG2x0ew1Ac',
         'createdTime': '...',
         'fields': {
             'Collaborator': {
@@ -208,7 +208,7 @@ class RecordDict(TypedDict):
     Usage:
         >>> table.first()
         {
-            'id': 'recW8eG2x0ew1Af',
+            'id': 'rec00W8eG2x0ew1Af',
             'createdTime': '...',
             'fields': {
                 ...
@@ -248,13 +248,13 @@ class UpdateRecordDict(TypedDict):
     Usage:
         >>> records = table.batch_update([
         ...     {
-        ...         "id": "recAdw9EjV90xbW",
+        ...         "id": "recAdw9EjV90xbcdW",
         ...         "fields": {
         ...             "Email": "alice@example.com"
         ...         }
         ...     },
         ...     {
-        ...         "id": "recAdw9EjV90xbX",
+        ...         "id": "recAdw9EjV90xbcdX",
         ...         "fields": {
         ...             "Email": "bob@example.com"
         ...         }
@@ -271,8 +271,8 @@ class RecordDeletedDict(TypedDict):
     A ``dict`` representing the payload returned by the Airtable API to confirm a deletion.
 
     Usage:
-        >>> table.delete("recW8eG2x0ew1Af")
-        {'id': 'recW8eG2x0ew1Af', 'deleted': True}
+        >>> table.delete("rec00W8eG2x0ew1Af")
+        {'id': 'rec00W8eG2x0ew1Af', 'deleted': True}
     """
 
     id: RecordId
@@ -337,13 +337,13 @@ def assert_typed_dict(cls: Type[T], obj: Any) -> T:
         >>> assert_typed_dict(
         ...     RecordDict,
         ...     {
-        ...         "id": "recAdw9EjV90xbZ",
+        ...         "id": "rec00Adw9EjV90xbZ",
         ...         "createdTime": "2023-05-22T21:24:15.333134Z",
         ...         "fields": {},
         ...     }
         ... )
         {
-            'id': 'recAdw9EjV90xbZ',
+            'id': 'rec00Adw9EjV90xbZ',
             'createdTime': '2023-05-22T21:24:15.333134Z',
             'fields': {}
         }

--- a/pyairtable/conftest.py
+++ b/pyairtable/conftest.py
@@ -1,0 +1,108 @@
+"""
+Configuration for pyairtable doctests
+"""
+
+# mypy: ignore-errors
+
+import datetime
+import pprint
+import re
+from importlib import import_module
+from typing import Any
+from unittest import mock
+
+import pytest
+
+import pyairtable
+from pyairtable.testing import fake_airtable, fake_id
+
+
+@pytest.fixture(autouse=True)
+def annotate_doctest_namespace(doctest_namespace, monkeypatch, requests_mock):
+    """
+    Ensures our doctests do not need to import common methods/classes
+    or reference objects that our documentation assumes the user has
+    already created.
+    """
+    doctest_namespace["api"] = api = pyairtable.Api("FAKE API KEY")
+    doctest_namespace["base"] = api.base(base := fake_id("app"))
+    doctest_namespace["table"] = api.table(base, table := fake_id("tbl"))
+    doctest_namespace["pprint"] = pprint.pprint
+
+    for objpath in (
+        "pyairtable",
+        "pyairtable.Api",
+        "pyairtable.Base",
+        "pyairtable.Table",
+    ):
+        modpath, _, name = objpath.rpartition(".")
+        if modpath:
+            obj = getattr(import_module(modpath), name)
+        else:
+            obj = import_module(name)
+        doctest_namespace[name] = obj
+
+    with fake_airtable() as fake:
+        doctest_namespace["fake_airtable"] = fake
+        now = datetime.datetime.utcnow().isoformat()
+        fake.add_records(
+            base,
+            table,
+            [
+                {
+                    "id": "recW8eG2x0ew1Af",
+                    "createdTime": now,
+                    "fields": {
+                        "Attachments": [
+                            {
+                                "id": "attW8eG2x0ew1Af",
+                                "url": "https://example.com/hello.jpg",
+                                "filename": "hello.jpg",
+                            }
+                        ],
+                        "Barcode": {"type": "upce", "text": "01234567"},
+                        "Click Me": {"label": "Click Me", "url": "http://example.com"},
+                        "Created By": {
+                            "id": "usrAdw9EjV90xbW",
+                            "email": "alice@example.com",
+                            "name": "Alice Arnold",
+                        },
+                        "Collaborators": [
+                            {
+                                "id": "usrAdw9EjV90xbW",
+                                "email": "alice@example.com",
+                                "name": "Alice Arnold",
+                            },
+                            {
+                                "id": "usrAdw9EjV90xbX",
+                                "email": "bob@example.com",
+                                "name": "Bob Barker",
+                            },
+                        ],
+                    },
+                }
+            ],
+        )
+        yield
+
+
+@pytest.fixture(autouse=True)
+def custom_doctest_output_checker():
+    """
+    Allows us to put extra leading/trailing whitespace around nested objects
+    (for the sake of readability in the documentation) without disrupting
+    how doctest will compare expected vs actual output during test runs.
+    """
+    import _pytest.doctest
+
+    old_check_output = _pytest.doctest.CHECKER_CLASS.check_output
+
+    def check_output(self, want: str, got: str, optionflags: Any) -> bool:
+        if want == got:
+            return True
+        want = re.sub(r"([\[\{\(])\s+", r"\1", want)
+        want = re.sub(r"\s+([\]\}\)])", r"\1", want)
+        return old_check_output(self, want, got, optionflags)
+
+    with mock.patch("_pytest.doctest.CHECKER_CLASS.check_output", check_output):
+        yield

--- a/pyairtable/conftest.py
+++ b/pyairtable/conftest.py
@@ -35,9 +35,12 @@ def annotate_doctest_namespace(
     or reference objects that our documentation assumes the user has
     already created.
     """
-    doctest_namespace["api"] = api = pyairtable.Api("patFakeForDoctest")
-    doctest_namespace["base"] = base = api.base("appFakeForDoctest")
-    doctest_namespace["table"] = table = base.table("tblFakeForDoctest")
+    doctest_namespace["api_key"] = api_key = "patFakeForDoctest"
+    doctest_namespace["base_id"] = base_id = "appFakeForDoctest"
+    doctest_namespace["table_name"] = table_name = "tblFakeForDoctest"
+    doctest_namespace["api"] = api = pyairtable.Api(api_key)
+    doctest_namespace["base"] = base = api.base(base_id)
+    doctest_namespace["table"] = table = base.table(table_name)
     doctest_namespace["fake_airtable"] = fake_airtable
     table.add_comment("recThatHasComment", "Hello, @[usrVMNxslc6jG0Xed]!")
 

--- a/pyairtable/conftest.py
+++ b/pyairtable/conftest.py
@@ -7,24 +7,28 @@ Configuration for pyairtable doctests
 import datetime
 import re
 from importlib import import_module
-from typing import Any
+from typing import Any, Dict
 from unittest import mock
 
 import pytest
 
 import pyairtable
+import pyairtable.models.collaborator
+import pyairtable.models.comment
 import pyairtable.testing
-from pyairtable.testing import fake_id
+from pyairtable.testing import FakeAirtable, fake_id
 
 
 @pytest.fixture()
 def fake_airtable(requests_mock):
-    with pyairtable.testing.fake_airtable() as fake:
+    with FakeAirtable() as fake:
         yield fake
 
 
 @pytest.fixture(autouse=True)
-def annotate_doctest_namespace(doctest_namespace, fake_airtable):
+def annotate_doctest_namespace(
+    doctest_namespace: Dict[str, Any], fake_airtable: FakeAirtable
+):
     """
     Ensures our doctests do not need to import common methods/classes
     or reference objects that our documentation assumes the user has
@@ -85,6 +89,11 @@ def annotate_doctest_namespace(doctest_namespace, fake_airtable):
                     ],
                 },
             },
+            {
+                "id": "recwPQIfs4wKPyc9D",
+                "createdTime": now,
+                "fields": {"First Name": "John", "Age": 20},
+            },
         ],
     )
     fake_airtable.add_records(
@@ -107,6 +116,27 @@ def annotate_doctest_namespace(doctest_namespace, fake_airtable):
         ],
         immutable=True,
     )
+    fake_airtable._comments["recMNxslc6jG0XedV"] = [
+        pyairtable.models.comment.Comment(
+            id="comdVMNxslc6jG0Xe",
+            text="Hello, @[usrVMNxslc6jG0Xed]!",
+            created_time="2023-06-07T17:46:24.435891",
+            last_updated_time=None,
+            mentioned={
+                "usrVMNxslc6jG0Xed": pyairtable.models.comment.Comment.Mentioned(
+                    display_name="Alice",
+                    email="alice@example.com",
+                    id="usrVMNxslc6jG0Xed",
+                    type="user",
+                )
+            },
+            author=pyairtable.models.collaborator.Collaborator(
+                id="usr0000pyairtable",
+                email="pyairtable@example.com",
+                name="Your pyairtable access token",
+            ),
+        )
+    ]
     doctest_namespace["upserts"] = [
         {"id": "recAdw9EjV90xbX", "fields": {"Name": "Record X"}},
         {"fields": {"Name": "Record Y"}},

--- a/pyairtable/conftest.py
+++ b/pyairtable/conftest.py
@@ -60,7 +60,7 @@ def annotate_doctest_namespace(
         table,
         [
             {
-                "id": "recW8eG2x0ew1Af",
+                "id": "rec00W8eG2x0ew1Af",
                 "createdTime": now,
                 "fields": {
                     "Attachments": [
@@ -106,7 +106,7 @@ def annotate_doctest_namespace(
             {"id": "recAdw9EjV90xbcdW", "createdTime": now, "fields": {}},
             {"id": "recAdw9EjV90xbcdX", "createdTime": now, "fields": {}},
             {
-                "id": "recW8eG2x0ew1Ac",
+                "id": "rec00W8eG2x0ew1Ac",
                 "createdTime": now,
                 "fields": {
                     "Collaborator": {

--- a/pyairtable/conftest.py
+++ b/pyairtable/conftest.py
@@ -2,6 +2,8 @@
 Configuration for pyairtable doctests
 """
 
+# This file is part of the test suite, not the library,
+# so we don't type-check it. Annotations are for IDEs.
 # mypy: ignore-errors
 
 import datetime
@@ -15,8 +17,7 @@ import pytest
 import pyairtable
 import pyairtable.models.collaborator
 import pyairtable.models.comment
-import pyairtable.testing
-from pyairtable.testing import FakeAirtable, fake_id
+from pyairtable.testing import FakeAirtable
 
 
 @pytest.fixture()
@@ -34,9 +35,11 @@ def annotate_doctest_namespace(
     or reference objects that our documentation assumes the user has
     already created.
     """
-    doctest_namespace["api"] = api = pyairtable.Api("patX9e810wHn3mMLz")
-    doctest_namespace["base"] = api.base(base := fake_id("app"))
-    doctest_namespace["table"] = api.table(base, table := fake_id("tbl"))
+    doctest_namespace["api"] = api = pyairtable.Api("patFakeForDoctest")
+    doctest_namespace["base"] = base = api.base("appFakeForDoctest")
+    doctest_namespace["table"] = table = base.table("tblFakeForDoctest")
+    doctest_namespace["fake_airtable"] = fake_airtable
+    table.add_comment("recThatHasComment", "Hello, @[usrVMNxslc6jG0Xed]!")
 
     for objpath in (
         "pyairtable",
@@ -51,7 +54,6 @@ def annotate_doctest_namespace(
             obj = import_module(name)
         doctest_namespace[name] = obj
 
-    doctest_namespace["fake_airtable"] = fake_airtable
     now = datetime.datetime.utcnow().isoformat()
     fake_airtable.add_records(
         base,
@@ -94,14 +96,15 @@ def annotate_doctest_namespace(
                 "createdTime": now,
                 "fields": {"First Name": "John", "Age": 20},
             },
+            {"id": "recMNxslc6jG0XedV", "createdTime": now, "fields": {}},
         ],
     )
     fake_airtable.add_records(
         base,
         table,
         [
-            {"id": "recAdw9EjV90xbW", "createdTime": now, "fields": {}},
-            {"id": "recAdw9EjV90xbX", "createdTime": now, "fields": {}},
+            {"id": "recAdw9EjV90xbcdW", "createdTime": now, "fields": {}},
+            {"id": "recAdw9EjV90xbcdX", "createdTime": now, "fields": {}},
             {
                 "id": "recW8eG2x0ew1Ac",
                 "createdTime": now,
@@ -116,29 +119,8 @@ def annotate_doctest_namespace(
         ],
         immutable=True,
     )
-    fake_airtable._comments["recMNxslc6jG0XedV"] = [
-        pyairtable.models.comment.Comment(
-            id="comdVMNxslc6jG0Xe",
-            text="Hello, @[usrVMNxslc6jG0Xed]!",
-            created_time="2023-06-07T17:46:24.435891",
-            last_updated_time=None,
-            mentioned={
-                "usrVMNxslc6jG0Xed": pyairtable.models.comment.Comment.Mentioned(
-                    display_name="Alice",
-                    email="alice@example.com",
-                    id="usrVMNxslc6jG0Xed",
-                    type="user",
-                )
-            },
-            author=pyairtable.models.collaborator.Collaborator(
-                id="usr0000pyairtable",
-                email="pyairtable@example.com",
-                name="Your pyairtable access token",
-            ),
-        )
-    ]
     doctest_namespace["upserts"] = [
-        {"id": "recAdw9EjV90xbX", "fields": {"Name": "Record X"}},
+        {"id": "recAdw9EjV90xbcdX", "fields": {"Name": "Record X"}},
         {"fields": {"Name": "Record Y"}},
     ]
 

--- a/pyairtable/models/_base.py
+++ b/pyairtable/models/_base.py
@@ -138,13 +138,13 @@ def update_forward_refs(
     at the time the attribute is created, we need to tell pydantic to
     update forward references after all the referenced models exist.
 
-    Only intended for use within pyAirtable, like:
+    Only intended for use within pyAirtable, as in:
 
         >>> from pyairtable.models._base import AirtableModel, update_forward_refs
-        >>> class A(AirtableModel): ...
-        >>> class B(AirtableModel): ...
-        ...     class B_One(AirtableModel): ...
-        ...     class B_Two(AirtableModel): ...
+        >>> class A(AirtableModel): pass
+        >>> class B(AirtableModel):
+        ...     class B_One(AirtableModel): pass
+        ...     class B_Two(AirtableModel): pass
         >>> update_forward_refs(vars())
     """
     # Avoid infinite circular loops

--- a/pyairtable/models/comment.py
+++ b/pyairtable/models/comment.py
@@ -48,11 +48,11 @@ class Comment(SerializableModel, writable=["text"]):
     #: The ISO 8601 timestamp of when the comment was last edited.
     last_updated_time: Optional[str]
 
-    #: The account which created the comment.
-    author: Collaborator
-
     #: Users or groups that were mentioned in the text.
     mentioned: Optional[Dict[str, "Comment.Mentioned"]]
+
+    #: The account which created the comment.
+    author: Collaborator
 
     class Mentioned(AirtableModel):
         """
@@ -73,10 +73,10 @@ class Comment(SerializableModel, writable=["text"]):
         See `User mentioned <https://airtable.com/developers/web/api/model/user-mentioned>`_ for more details.
         """
 
-        id: str
-        type: str
         display_name: str
         email: Optional[str] = None
+        id: str
+        type: str
 
 
 update_forward_refs(vars())

--- a/pyairtable/models/comment.py
+++ b/pyairtable/models/comment.py
@@ -12,9 +12,9 @@ class Comment(SerializableModel, writable=["text"]):
     >>> table.comments("recMNxslc6jG0XedV")
     [
         Comment(
-            id='comdVMNxslc6jG0Xe',
+            id='com...',
             text='Hello, @[usrVMNxslc6jG0Xed]!',
-            created_time='2023-06-07T17:46:24.435891',
+            created_time='...',
             last_updated_time=None,
             mentioned={
                 'usrVMNxslc6jG0Xed': Mentioned(
@@ -59,10 +59,10 @@ class Comment(SerializableModel, writable=["text"]):
         A user or group that was mentioned within a comment.
         Stored as a ``dict`` that is keyed by ID.
 
-        >>> comment = table.add_comment(record_id, "Hello, @[usrVMNxslc6jG0Xed]!")
+        >>> comment = table.add_comment("recMNxslc6jG0XedV", "Hello, @[usrVMNxslc6jG0Xed]!")
         >>> comment.mentioned
         {
-            "usrVMNxslc6jG0Xed": Mentioned(
+            'usrVMNxslc6jG0Xed': Mentioned(
                 display_name='Alice',
                 email='alice@example.com',
                 id='usrVMNxslc6jG0Xed',

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -142,8 +142,8 @@ class Model:
 
         The keyword argument ``id=`` special-cased and sets the record ID, not a field value.
 
-        >>> Contact(id="recWPqD9izdsNvlE", name="Bob")
-        <Contact id='recWPqD9izdsNvlE'>
+        >>> Contact(id="rec0WPqD9izdsNvlE", name="Bob")
+        <Contact id='rec0WPqD9izdsNvlE'>
         """
 
         if "id" in fields:

--- a/pyairtable/testing.py
+++ b/pyairtable/testing.py
@@ -4,9 +4,24 @@ Helper functions for writing tests that use the pyairtable library.
 import datetime
 import random
 import string
-from typing import Any, Optional
+from contextlib import ExitStack, contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union
+from unittest import mock
 
-from pyairtable.api.types import AttachmentDict, CollaboratorDict, Fields, RecordDict
+from pyairtable.api.api import Api
+from pyairtable.api.table import Table
+from pyairtable.api.types import (
+    AttachmentDict,
+    CollaboratorDict,
+    CreateRecordDict,
+    Fields,
+    RecordDeletedDict,
+    RecordDict,
+    UpdateRecordDict,
+    UpsertResultDict,
+    UserAndScopesDict,
+    WritableFields,
+)
 
 
 def fake_id(type: str = "rec", value: Any = None) -> str:
@@ -78,3 +93,144 @@ def fake_attachment() -> AttachmentDict:
         "size": 100,
         "type": "text/plain",
     }
+
+
+class FakeAirtable:
+    """
+    Used to mock the Airtable API for testing purposes.
+
+    FakeAirtable uses in-memory data structures to store and retrieve
+    instances of :class:`~pyairtable.api.types.RecordDict`. It does not
+    implement a lot of the functionality of the Airtable API; it only
+    provides a bare minimum to be able to mock common methods which interact
+    with the API for testing purposes.
+    """
+
+    def __init__(self) -> None:
+        self._records: Dict[Tuple[str, str], Dict[str, RecordDict]] = {}
+        self._immutable: Set[Tuple[str, str, str]] = set()
+
+    def add_records(
+        self,
+        base_id: str,
+        table_name: str,
+        records: Sequence[RecordDict],
+        immutable: bool = False,
+    ) -> None:
+        self._records.setdefault((base_id, table_name), {}).update(
+            {record["id"]: record for record in records}
+        )
+        if immutable:
+            self._immutable.update(
+                (base_id, table_name, record["id"]) for record in records
+            )
+
+    def _get(self, table: Table, record_id: str) -> RecordDict:
+        return self._records[(table.base.id, table.name)][record_id]
+
+    def _iterate(self, table: Table, **kwargs: Any) -> Iterator[List[RecordDict]]:
+        yield list(self._records[(table.base.id, table.name)].values())
+
+    def _create(
+        self, table: Table, fields: WritableFields, **kwargs: Any
+    ) -> RecordDict:
+        record: RecordDict = {
+            "id": fake_id(),
+            "createdTime": datetime.datetime.utcnow().isoformat(),
+            "fields": fields,
+        }
+        self.add_records(table.base.id, table.name, [record])
+        return record
+
+    def _update(
+        self, table: Table, record_id: str, fields: WritableFields, **kwargs: Any
+    ) -> RecordDict:
+        record = self._records[(table.base.id, table.name)][record_id]
+        if (table.base.id, table.name, record_id) not in self._immutable:
+            record["fields"].update(fields)
+        return record
+
+    def _delete(self, table: Table, record_id: str) -> RecordDeletedDict:
+        del self._records[(table.base.id, table.name)][record_id]
+        return {"id": record_id, "deleted": True}
+
+    def _batch_create(
+        self, table: Table, records: List[WritableFields], **kwargs: Any
+    ) -> List[RecordDict]:
+        return [self._create(table, fields) for fields in records]
+
+    def _batch_update(
+        self, table: Table, records: List[UpdateRecordDict], **kwargs: Any
+    ) -> List[RecordDict]:
+        return [
+            self._update(table, record["id"], record["fields"]) for record in records
+        ]
+
+    def _batch_delete(
+        self, table: Table, record_ids: List[str]
+    ) -> List[RecordDeletedDict]:
+        return [self._delete(table, record_id) for record_id in record_ids]
+
+    def _batch_upsert(
+        self,
+        table: Table,
+        records: List[UpdateRecordDict],
+        key_fields: List[str],
+        **kwargs: Any,
+    ) -> UpsertResultDict:
+        def key(
+            record: Union[CreateRecordDict, UpdateRecordDict, RecordDict]
+        ) -> Tuple[Any, ...]:
+            return tuple(record["fields"].get(f) for f in key_fields)
+
+        created: Dict[str, RecordDict] = {}
+        updated: Dict[str, RecordDict] = {}
+        existing = {
+            key(record): record
+            for record in self._records[(table.base.id, table.name)].values()
+        }
+
+        for record in records:
+            if "id" not in record and (found := existing.get(key(record))):
+                record["id"] = found["id"]
+            if "id" in record:
+                updated[record["id"]] = self._update(
+                    table, record["id"], record["fields"]
+                )
+                continue
+            created[c["id"]] = (c := self._create(table, record["fields"]))
+
+        return {
+            "createdRecords": list(created),
+            "updatedRecords": list(updated),
+            "records": list(created.values()) + list(updated.values()),
+        }
+
+    def _whoami(self, api: Api) -> UserAndScopesDict:
+        return {"id": "usrX9e810wHn3mMLz"}
+
+
+@contextmanager
+def fake_airtable() -> Iterator[FakeAirtable]:
+    """
+    Context manager that will mock all pyAirtable API endpoints to avoid making
+    network calls and to allow stubbing of basic interactions with pyAirtable.
+    """
+    fake = FakeAirtable()
+
+    with ExitStack() as stack:
+        for target, method in [
+            ("pyairtable.Table.get", fake._get),
+            ("pyairtable.Table.iterate", fake._iterate),
+            ("pyairtable.Table.create", fake._create),
+            ("pyairtable.Table.update", fake._update),
+            ("pyairtable.Table.delete", fake._delete),
+            ("pyairtable.Table.batch_create", fake._batch_create),
+            ("pyairtable.Table.batch_update", fake._batch_update),
+            ("pyairtable.Table.batch_delete", fake._batch_delete),
+            ("pyairtable.Table.batch_upsert", fake._batch_upsert),
+            ("pyairtable.Api.whoami", fake._whoami),
+        ]:
+            stack.enter_context(mock.patch(target, autospec=True, side_effect=method))
+
+        yield fake

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,12 +58,12 @@ def mock_records():
             "createdTime": "2017-06-06T18:30:57.000Z",
         },
         {
-            "id": "recyXhbY4uax4567",
+            "id": "rec0yXhbY4uax4567",
             "fields": {"SameField": 456, "Value": "def"},
             "createdTime": "2017-06-06T18:30:57.000Z",
         },
         {
-            "id": "recyXhbY4uax891",
+            "id": "rec00yXhbY4uax891",
             "fields": {"SameField": 789, "Value": "xyz"},
             "createdTime": "2017-06-06T18:30:57.000Z",
         },

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,9 @@ commands =
     python -m sphinx -T -E -b html {toxinidir}/docs/source {toxinidir}/docs/build
 
 [pytest]
+addopts = --doctest-modules
+doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
+testpaths = pyairtable tests
 markers =
     integration: integration tests, hit airtable api
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,9 +47,9 @@ commands =
     python -m sphinx -T -E -b html {toxinidir}/docs/source {toxinidir}/docs/build
 
 [pytest]
-addopts = --doctest-modules
+addopts = --doctest-modules --doctest-glob='*.rst'
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
-testpaths = pyairtable tests
+testpaths = docs/source pyairtable tests
 markers =
     integration: integration tests, hit airtable api
 


### PR DESCRIPTION
We've had a number of typos and other errors reported against this project's documentation, and one idea I had was to run pytest against all of the code samples in the docstrings. In order to do this, I needed to:
* Implement a `FakeAirtable` context manager class, which is capable of simulating basic interactions by mocking methods on other classes (like `Table` and `SerializableModel`).
* Implement a custom output checker for `doctest` that can support the JSON-style indentation we use in our examples, which is more legible (imho) but is _not_ how `repr()` output appears.
* Populate the fake Airtable object with some record data that matches the expectations of our docstrings, as well as rework quite a few examples.

Limitations/issues with this approach:
* It will be more work to add examples to our documentation, which might discourage patches.
* It will be very challenging to document scenarios that assume interactions with the Airtable UI in between lines of code being executed. I'm not sure we have any of those today.
* FakeAirtable cannot be nested because it uses `autospec`, which means it can't document its own use. I haven't figured out a clean way around this yet.

The branch has a few examples of the changes required to some of the library's modules in order to make them pass tests. I'm opening this as a WIP to solicit input on whether it's worth continuing down this route, or if I should just grab `FakeAirtable` (which is useful in other contexts) and ditch the rest.