### PR TITLE
⚡️ Add hashing to core types

### DIFF
--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -93,6 +93,9 @@ class Base:
             repr += f" {permission_level=}"
         return repr + ">"
 
+    def __hash__(self) -> int:
+        return hash(self.id)
+
     def table(
         self,
         id_or_name: str,

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -130,6 +130,9 @@ class Table:
             return f"<Table base={self.base.id!r} id={self._schema.id!r} name={self._schema.name!r}>"
         return f"<Table base={self.base.id!r} name={self.name!r}>"
 
+    def __hash__(self) -> int:
+        return hash((self.id, self.base.id))
+
     @property
     def id(self) -> str:
         """


### PR DESCRIPTION
Both `Base` and `Table` primitives have a unique identifiers but neither of them implements `__hash__`. This is problematic, because user application might want to want to use the primitives in cached function(`lru_cache`), but they will not work out of the box without `__hash__` function.

I wanted to also add `__hash_` to `RecordDict`, however since it's a dict I can't.
Is there any reason why `RecordDict` is not `dataclass` ? 