### PR TITLE
Add formulas for missing logical operators

### DIFF
--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -218,3 +218,53 @@ def LOWER(value: str) -> str:
     "LOWER(TestValue)"
     """
     return "LOWER({})".format(value)
+
+
+def NOT_EQUAL(left: Any, right: Any) -> str:
+    """
+    Create an inequality assertion
+
+    >>> NOT_EQUAL(2,2)
+    '2!=2'
+    """
+    return "{}!={}".format(left, right)
+
+
+def LESS_EQUAL(left: Any, right: Any) -> str:
+    """
+    Create a less than assertion
+
+    >>> LESS_EQUAL(2,2)
+    '2<=2'
+    """
+    return "{}<={}".format(left, right)
+
+
+def GREATER_EQUAL(left: Any, right: Any) -> str:
+    """
+    Create a greater than assertion
+
+    >>> GREATER_EQUAL(2,2)
+    '2>=2'
+    """
+    return "{}>={}".format(left, right)
+
+
+def LESS(left: Any, right: Any) -> str:
+    """
+    Create a less assertion
+
+    >>> LESS(2,2)
+    '2<2'
+    """
+    return "{}<{}".format(left, right)
+
+
+def GREATER(left: Any, right: Any) -> str:
+    """
+    Create a greater assertion
+
+    >>> GREATER(2,2)
+    '2>2'
+    """
+    return "{}>{}".format(left, right)

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -5,8 +5,13 @@ from pyairtable.formulas import (
     EQUAL,
     FIELD,
     FIND,
+    GREATER,
+    GREATER_EQUAL,
     IF,
+    LESS,
+    LESS_EQUAL,
     LOWER,
+    NOT_EQUAL,
     OR,
     STR_VALUE,
     escape_quotes,
@@ -86,3 +91,23 @@ def test_escape_quotes(text, escaped):
 
 def test_lower():
     assert LOWER("TestValue") == "LOWER(TestValue)"
+
+
+def test_greater_equal():
+    assert GREATER_EQUAL("A", "B") == "A>=B"
+
+
+def test_less_equal():
+    assert LESS_EQUAL("A", "B") == "A<=B"
+
+
+def test_greater():
+    assert GREATER("A", "B") == "A>B"
+
+
+def test_less():
+    assert LESS("A", "B") == "A<B"
+
+
+def test_not_equal():
+    assert NOT_EQUAL("A", "B") == "A!=B"


### PR DESCRIPTION
Implements missing formulas from [section "Logical operators and functions" from documentation of "Formula field reference"](https://support.airtable.com/docs/formula-field-reference#logical-operators-and-functions). Currently only `EQUAL` is implemented.