### PR TITLE
Support for iterating through the audit log

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -49,6 +49,14 @@ API: pyairtable.models
     :inherited-members: AirtableModel
 
 
+API: pyairtable.models.audit
+********************************
+
+.. automodule:: pyairtable.models.audit
+    :members:
+    :inherited-members: AirtableModel
+
+
 API: pyairtable.models.schema
 ********************************
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,9 @@ Changelog
 2.3.0 (TBD)
 ------------------------
 
+* Added :meth:`Enterprise.audit_log <pyairtable.Enterprise.audit_log>`
+  to iterate page-by-page through `audit log events <https://airtable.com/developers/web/api/audit-logs-overview>`__.
+  - `PR #330 <https://github.com/gtalarico/pyairtable/pull/330>`_.
 * :meth:`Api.base <pyairtable.Api.base>`,
   :meth:`Api.table <pyairtable.Api.table>`,
   and :meth:`Base.table <pyairtable.Base.table>`

--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -1,0 +1,29 @@
+.. include:: _substitutions.rst
+.. include:: _warn_latest.rst
+
+Enterprise Features
+==============================
+
+
+pyAirtable exposes a number of classes and methods for interacting with enterprise organizations.
+The following methods are only available on an `Enterprise plan <https://airtable.com/pricing>`__.
+If you call one of them against a base that is not part of an enterprise workspace, Airtable will
+return a 404 error, and pyAirtable will add a reminder to the exception to check your billing plan.
+
+.. automethod:: pyairtable.Api.enterprise
+    :noindex:
+
+.. automethod:: pyairtable.Base.collaborators
+    :noindex:
+
+.. automethod:: pyairtable.Base.shares
+    :noindex:
+
+.. automethod:: pyairtable.Workspace.collaborators
+    :noindex:
+
+.. automethod:: pyairtable.Enterprise.info
+    :noindex:
+
+.. automethod:: pyairtable.Enterprise.audit_log
+    :noindex:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,9 +27,9 @@ pyAirtable
    getting-started
    tables
    orm
-   webhooks
    metadata
-   migrations
+   webhooks
+   enterprise
    api
 
 
@@ -37,6 +37,7 @@ pyAirtable
    :caption: More
    :hidden:
 
+   migrations
    about
    changelog
    contributing

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -33,30 +33,6 @@ You'll find more detail in the API reference for :mod:`pyairtable.models.schema`
     :noindex:
 
 
-Enterprise information
------------------------------
-
-pyAirtable exposes a number of classes and methods for interacting with enterprise organizations.
-The following methods are only available on an `Enterprise plan <https://airtable.com/pricing>`__.
-If you call one of them against a base that is not part of an enterprise workspace, Airtable will
-return a 404 error, and pyAirtable will add a reminder to the exception to check your billing plan.
-
-.. automethod:: pyairtable.Api.enterprise
-    :noindex:
-
-.. automethod:: pyairtable.Base.collaborators
-    :noindex:
-
-.. automethod:: pyairtable.Base.shares
-    :noindex:
-
-.. automethod:: pyairtable.Workspace.collaborators
-    :noindex:
-
-.. automethod:: pyairtable.Enterprise.info
-    :noindex:
-
-
 Modifying existing schema
 -----------------------------
 

--- a/docs/source/webhooks.rst
+++ b/docs/source/webhooks.rst
@@ -1,3 +1,6 @@
+.. include:: _substitutions.rst
+.. include:: _warn_latest.rst
+
 Webhooks
 ==============================
 

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -1,11 +1,15 @@
 import datetime
-from typing import Any, Iterable, Iterator, List, Optional, Union, cast
-
-from typing_extensions import TypeVar
+from typing import Iterable, Iterator, List, Optional, Union
 
 from pyairtable.models.audit import AuditLogResponse
 from pyairtable.models.schema import EnterpriseInfo, UserGroup, UserInfo
-from pyairtable.utils import cache_unless_forced, enterprise_only
+from pyairtable.utils import (
+    cache_unless_forced,
+    coerce_iso_str,
+    coerce_list_str,
+    enterprise_only,
+    is_user_id,
+)
 
 
 @enterprise_only
@@ -187,12 +191,12 @@ class Enterprise:
             An object representing a single page of audit log results.
         """
 
-        start_time = _coerce_isoformat(start_time)
-        end_time = _coerce_isoformat(end_time)
-        user_id = _coerce_list(user_id)
-        event_type = _coerce_list(event_type)
-        model_id = _coerce_list(model_id)
-        category = _coerce_list(category)
+        start_time = coerce_iso_str(start_time)
+        end_time = coerce_iso_str(end_time)
+        user_id = coerce_list_str(user_id)
+        event_type = coerce_list_str(event_type)
+        model_id = coerce_list_str(model_id)
+        category = coerce_list_str(category)
         params = {
             "startTime": start_time,
             "endTime": end_time,
@@ -221,28 +225,6 @@ class Enterprise:
                 return
             if page_limit is not None and count >= page_limit:
                 return
-
-
-def _coerce_isoformat(value: Any) -> Optional[str]:
-    if value is None:
-        return value
-    if isinstance(value, str):
-        datetime.datetime.fromisoformat(value)  # validates type, nothing more
-        return value
-    if isinstance(value, (datetime.date, datetime.datetime)):
-        return value.isoformat()
-    raise TypeError(f"cannot coerce {type(value)} into ISO 8601 str")
-
-
-T = TypeVar("T")
-
-
-def _coerce_list(value: Optional[Union[str, Iterable[T]]]) -> List[T]:
-    if value is None:
-        return []
-    if isinstance(value, str):
-        return cast(List[T], [value])
-    return list(value)
 
 
 # These are at the bottom of the module to avoid circular imports

--- a/pyairtable/models/audit.py
+++ b/pyairtable/models/audit.py
@@ -6,6 +6,13 @@ from pyairtable.models._base import AirtableModel, update_forward_refs
 
 
 class AuditLogResponse(AirtableModel):
+    """
+    Represents a page of audit log events.
+
+    See `Audit log events <https://airtable.com/developers/web/api/audit-log-events>`__
+    for more information on how to interpret this data structure.
+    """
+
     events: List["AuditLogEvent"]
     pagination: Optional["AuditLogResponse.Pagination"] = None
 
@@ -15,6 +22,13 @@ class AuditLogResponse(AirtableModel):
 
 
 class AuditLogEvent(AirtableModel):
+    """
+    Represents a single audit log event.
+
+    See `Audit log events <https://airtable.com/developers/web/api/audit-log-events>`__
+    for more information on how to interpret this data structure.
+    """
+
     id: str
     timestamp: str
     action: str

--- a/pyairtable/models/audit.py
+++ b/pyairtable/models/audit.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, List, Optional
+
+from typing_extensions import TypeAlias
+
+from pyairtable.models._base import AirtableModel, update_forward_refs
+
+
+class AuditLogResponse(AirtableModel):
+    events: List["AuditLogEvent"]
+    pagination: Optional["AuditLogResponse.Pagination"] = None
+
+    class Pagination(AirtableModel):
+        next: Optional[str]
+        previous: Optional[str]
+
+
+class AuditLogEvent(AirtableModel):
+    id: str
+    timestamp: str
+    action: str
+    actor: "AuditLogActor"
+    model_id: str
+    model_type: str
+    payload: "AuditLogPayload"
+    payload_version: str
+    context: "AuditLogEvent.Context"
+    origin: "AuditLogEvent.Origin"
+
+    class Context(AirtableModel):
+        base_id: Optional[str] = None
+        action_id: str
+        enterprise_account_id: str
+        descendant_enterprise_account_id: Optional[str] = None
+        interface_id: Optional[str] = None
+        workspace_id: Optional[str] = None
+
+    class Origin(AirtableModel):
+        ip_address: str
+        user_agent: str
+        oauth_access_token_id: Optional[str] = None
+        personal_access_token_id: Optional[str] = None
+        session_id: Optional[str] = None
+
+
+class AuditLogActor(AirtableModel):
+    type: str
+    user: Optional["AuditLogActor.UserInfo"] = None
+    view_id: Optional[str] = None
+    automation_id: Optional[str] = None
+
+    class UserInfo(AirtableModel):
+        id: str
+        email: str
+        name: Optional[str] = None
+
+
+# Placeholder until we can parse https://airtable.com/developers/web/api/audit-log-event-types
+AuditLogPayload: TypeAlias = Dict[str, Any]
+
+
+update_forward_refs(vars())

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -3,7 +3,19 @@ import re
 import textwrap
 from datetime import date, datetime
 from functools import partial, wraps
-from typing import Any, Callable, Generic, Iterator, Sequence, TypeVar, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import requests
 from typing_extensions import ParamSpec, Protocol
@@ -208,3 +220,29 @@ def cache_unless_forced(func: Callable[P, R]) -> FetchMethod[R]:
     _append_docstring_text(_inner, "Args:\n\tforce: |kwarg_force_metadata|")
 
     return _inner
+
+
+def coerce_iso_str(value: Any) -> Optional[str]:
+    """
+    Given an input that might be a date or datetime, or an ISO 8601 formatted str,
+    convert the value into an ISO 8601 formatted str.
+    """
+    if value is None:
+        return value
+    if isinstance(value, str):
+        datetime.fromisoformat(value)  # validates type, nothing more
+        return value
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    raise TypeError(f"cannot coerce {type(value)} into ISO 8601 str")
+
+
+def coerce_list_str(value: Optional[Union[str, Iterable[str]]]) -> List[str]:
+    """
+    Given an input that is either a str or an iterable of str, return a list.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return list(value)

--- a/tests/integration/test_integration_enterprise.py
+++ b/tests/integration/test_integration_enterprise.py
@@ -133,3 +133,16 @@ def test_update_field(blank_base: pyairtable.Base):
     field.description = "Renamed"
     field.save()
     assert reload_field().description == "Renamed"
+
+
+def test_audit_log(api):
+    """
+    Test that we can call the audit log endpoint.
+    """
+    if "AIRTABLE_ENTERPRISE_ID" not in os.environ:
+        return pytest.skip("test_audit_log requires AIRTABLE_ENTERPRISE_ID")
+
+    enterprise = api.enterprise(os.environ["AIRTABLE_ENTERPRISE_ID"])
+    for page in enterprise.audit_log(page_limit=1):
+        for event in page.events:
+            assert isinstance(event.action, str)

--- a/tests/test_api_enterprise.py
+++ b/tests/test_api_enterprise.py
@@ -1,9 +1,11 @@
-from unittest.mock import Mock
+import datetime
+from unittest.mock import Mock, call
 
 import pytest
 
 from pyairtable.api.enterprise import Enterprise
 from pyairtable.models.schema import EnterpriseInfo, UserGroup, UserInfo
+from pyairtable.testing import fake_id
 
 
 @pytest.fixture
@@ -11,7 +13,11 @@ def enterprise(api):
     return Enterprise(api, "entUBq2RGdihxl3vU")
 
 
-@pytest.fixture
+N_AUDIT_PAGES = 15
+N_AUDIT_PAGE_SIZE = 10
+
+
+@pytest.fixture(autouse=True)
 def enterprise_mocks(enterprise, requests_mock, sample_json):
     m = Mock()
     m.json_user = sample_json("UserInfo")
@@ -25,7 +31,46 @@ def enterprise_mocks(enterprise, requests_mock, sample_json):
         enterprise.api.build_url(f"meta/groups/{m.json_group['id']}"),
         json=m.json_group,
     )
+    m.get_audit_log = requests_mock.get(
+        enterprise.api.build_url(
+            f"meta/enterpriseAccounts/{enterprise.id}/auditLogEvents"
+        ),
+        response_list=[
+            {
+                "json": {
+                    "events": fake_audit_log_events(n),
+                    "pagination": (
+                        None if n == N_AUDIT_PAGES - 1 else {"previous": "dummy"}
+                    ),
+                }
+            }
+            for n in range(N_AUDIT_PAGES)
+        ],
+    )
     return m
+
+
+def fake_audit_log_events(counter, page_size=N_AUDIT_PAGE_SIZE):
+    return [
+        {
+            "id": str(counter * 1000 + n),
+            "timestamp": datetime.datetime.now().isoformat(),
+            "action": "viewBase",
+            "actor": {"type": "anonymousUser"},
+            "model_id": (base_id := fake_id("app")),
+            "model_type": "base",
+            "payload": {"name": "The Base Name"},
+            "payloadVersion": "1.0",
+            "context": {
+                "baseId": base_id,
+                "actionId": fake_id("act"),
+                "enterpriseAccountId": fake_id("ent"),
+                "workspaceId": fake_id("wsp"),
+            },
+            "origin": {"ipAddress": "8.8.8.8", "userAgent": "Internet Explorer"},
+        }
+        for n in range(page_size)
+    ]
 
 
 def test_info(enterprise, enterprise_mocks):
@@ -70,7 +115,7 @@ def test_user__no_collaboration(enterprise, enterprise_mocks):
         ["usrL2PNC5o3H4lBEi", "foo@bar.com"],  # should not return duplicates
     ),
 )
-def test_users(enterprise, enterprise_mocks, search_for):
+def test_users(enterprise, search_for):
     results = enterprise.users(search_for)
     assert len(results) == 1
     assert isinstance(user := results[0], UserInfo)
@@ -102,3 +147,19 @@ def test_group__no_collaboration(enterprise, enterprise_mocks):
     assert not grp.collaborations.bases
     assert not grp.collaborations.interfaces
     assert not grp.collaborations.workspaces
+
+
+@pytest.mark.parametrize(
+    "fncall,length",
+    [
+        (call(), N_AUDIT_PAGES * N_AUDIT_PAGE_SIZE),
+    ],
+)
+def test_audit_log(enterprise, fncall, length):
+    events = [
+        event
+        for page in enterprise.audit_log(*fncall.args, **fncall.kwargs)
+        for event in page.events
+    ]
+    print(repr(events))
+    assert len(events) == length

--- a/tests/test_api_enterprise.py
+++ b/tests/test_api_enterprise.py
@@ -157,6 +157,9 @@ def test_group__no_collaboration(enterprise, enterprise_mocks):
     ],
 )
 def test_audit_log(enterprise, fncall, expected_size):
+    """
+    Test that we iterate through multiple pages of the audit log. correctly
+    """
     events = [
         event
         for page in enterprise.audit_log(*fncall.args, **fncall.kwargs)
@@ -197,6 +200,10 @@ def test_audit_log__sortorder(
     sortorder,
     offset_field,
 ):
+    """
+    Test that we calculate sortorder and offset_field correctly
+    dpeending on whether we're ascending or descending.
+    """
     with patch.object(api, "iterate_requests", wraps=api.iterate_requests) as m:
         list(enterprise.audit_log(*fncall.args, **fncall.kwargs))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,3 +58,32 @@ def test_attachment():
 )
 def test_id_check(func, value, expected):
     assert func(value) is expected
+
+
+@pytest.mark.parametrize(
+    "func,input,expected",
+    [
+        (utils.coerce_iso_str, None, None),
+        (utils.coerce_iso_str, "asdf", ValueError),
+        (utils.coerce_iso_str, -1, TypeError),
+        (utils.coerce_iso_str, "2023-01-01", "2023-01-01"),
+        (utils.coerce_iso_str, "2023-01-01 12:34:56", "2023-01-01 12:34:56"),
+        (utils.coerce_iso_str, date(2023, 1, 1), "2023-01-01"),
+        (
+            utils.coerce_iso_str,
+            datetime(2023, 1, 1, 12, 34, 56),
+            "2023-01-01T12:34:56",
+        ),
+        (utils.coerce_list_str, None, []),
+        (utils.coerce_list_str, "asdf", ["asdf"]),
+        (utils.coerce_list_str, ("one", "two", "three"), ["one", "two", "three"]),
+        (utils.coerce_list_str, -1, TypeError),
+    ],
+)
+def test_converter(func, input, expected):
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            func(input)
+        return
+
+    assert func(input) == expected


### PR DESCRIPTION
This branch allows enterprise users to iterate through [audit log events](https://airtable.com/developers/web/api/audit-log-events) with something like this:

```python
enterprise = api.enterprise("ent...")
for page in enterprise.audit_log(sort_asc=True):
    for event in page.events:
        handle_event(event)
```
