### PR TITLE
Use improved enterprise "get users" endpoint, and simplify collaborations model

### DIFF
--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -38,16 +38,22 @@ class Enterprise:
         payload = self.api.request("GET", url, params=params)
         return UserGroup.parse_obj(payload)
 
-    def user(self, id_or_email: str) -> UserInfo:
+    def user(self, id_or_email: str, collaborations: bool = True) -> UserInfo:
         """
         Retrieve information on a single user with the given ID or email.
 
         Args:
             id_or_email: A user ID (``usrQBq2RGdihxl3vU``) or email address.
+            collaborations: If ``False``, no collaboration data will be requested
+                from Airtable. This may result in faster responses.
         """
-        return self.users([id_or_email])[0]
+        return self.users([id_or_email], collaborations=collaborations)[0]
 
-    def users(self, ids_or_emails: Iterable[str]) -> List[UserInfo]:
+    def users(
+        self,
+        ids_or_emails: Iterable[str],
+        collaborations: bool = True,
+    ) -> List[UserInfo]:
         """
         Retrieve information on the users with the given IDs or emails.
 
@@ -56,6 +62,8 @@ class Enterprise:
         Args:
             ids_or_emails: A sequence of user IDs (``usrQBq2RGdihxl3vU``)
                 or email addresses (or both).
+            collaborations: If ``False``, no collaboration data will be requested
+                from Airtable. This may result in faster responses.
         """
         user_ids: List[str] = []
         emails: List[str] = []
@@ -68,7 +76,7 @@ class Enterprise:
             params={
                 "id": user_ids,
                 "email": emails,
-                "include": ["collaborations"],
+                "include": ["collaborations"] if collaborations else [],
             },
         )
         # key by user ID to avoid returning duplicates

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -32,8 +32,8 @@ class Enterprise:
         payload = self.api.request("GET", self.url, params=params)
         return EnterpriseInfo.parse_obj(payload)
 
-    def group(self, group_id: str) -> UserGroup:
-        params = {"include": ["collaborations"]}
+    def group(self, group_id: str, collaborations: bool = True) -> UserGroup:
+        params = {"include": ["collaborations"] if collaborations else []}
         url = self.api.build_url(f"meta/groups/{group_id}")
         payload = self.api.request("GET", url, params=params)
         return UserGroup.parse_obj(payload)

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -337,7 +337,7 @@ class UserInfo(AirtableModel):
     enterprise_user_type: Optional[str]
     invited_to_airtable_by_user_id: Optional[str]
     is_managed: bool = False
-    collaborations: Optional["Collaborations"]
+    collaborations: "Collaborations"
     groups: List[NestedId] = pydantic.Field(default_factory=list)
 
 
@@ -351,6 +351,27 @@ class Collaborations(AirtableModel):
     base_collaborations: List["Collaborations.BaseCollaboration"]
     interface_collaborations: List["Collaborations.InterfaceCollaboration"]
     workspace_collaborations: List["Collaborations.WorkspaceCollaboration"]
+
+    @property
+    def bases(self) -> Dict[str, "Collaborations.BaseCollaboration"]:
+        """
+        Mapping of base IDs to collaborations, to make lookups easier.
+        """
+        return {c.base_id: c for c in self.base_collaborations}
+
+    @property
+    def interfaces(self) -> Dict[str, "Collaborations.InterfaceCollaboration"]:
+        """
+        Mapping of interface IDs to collaborations, to make lookups easier.
+        """
+        return {c.interface_id: c for c in self.interface_collaborations}
+
+    @property
+    def workspaces(self) -> Dict[str, "Collaborations.WorkspaceCollaboration"]:
+        """
+        Mapping of workspace IDs to collaborations, to make lookups easier.
+        """
+        return {c.workspace_id: c for c in self.workspace_collaborations}
 
     class BaseCollaboration(AirtableModel):
         base_id: str
@@ -381,7 +402,7 @@ class UserGroup(AirtableModel):
     created_time: str
     updated_time: str
     members: List["UserGroup.Member"]
-    collaborations: Optional["Collaborations"]
+    collaborations: "Collaborations"
 
     class Member(AirtableModel):
         user_id: str

--- a/tests/test_api_enterprise.py
+++ b/tests/test_api_enterprise.py
@@ -21,10 +21,6 @@ def enterprise_mocks(enterprise, requests_mock, sample_json):
         enterprise.url,
         json=sample_json("EnterpriseInfo"),
     )
-    m.get_user = requests_mock.get(
-        f"{enterprise.url}/users/{m.user_id}",
-        json=user_json,
-    )
     m.get_users = requests_mock.get(
         f"{enterprise.url}/users",
         json={"users": [user_json]},
@@ -50,7 +46,7 @@ def test_info(enterprise, enterprise_mocks):
 def test_user(enterprise, enterprise_mocks):
     user = enterprise.user(enterprise_mocks.user_id)
     assert isinstance(user, UserInfo)
-    assert enterprise_mocks.get_user.call_count == 1
+    assert enterprise_mocks.get_users.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -67,11 +63,6 @@ def test_users(enterprise, enterprise_mocks, search_for):
     assert isinstance(user := results[0], UserInfo)
     assert user.id == "usrL2PNC5o3H4lBEi"
     assert user.state == "provisioned"
-
-
-def test_users__invalid_value(enterprise, enterprise_mocks):
-    with pytest.raises(ValueError):
-        enterprise.users(["not an ID or email"])
 
 
 def test_group(enterprise, enterprise_mocks):

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,9 @@ deps = -r requirements-dev.txt
 commands = mypy --strict pyairtable tests/test_typing.py
 
 [testenv]
-passenv = AIRTABLE_API_KEY
+passenv =
+    AIRTABLE_API_KEY
+    AIRTABLE_ENTERPRISE_ID
 addopts = -v
 testpaths = tests
 commands = python -m pytest {posargs}


### PR DESCRIPTION
Two changes here:

1. Calling `enterprise.user()` or `enterprise.users()` now uses the [get users by id or email](https://airtable.com/developers/web/api/get-users-by-id-or-email) endpoint, which used to only accept emails (at least, according to its documentation). This removes the need to iterate over IDs and call [get user by id](https://airtable.com/developers/web/api/get-user-by-id) one by one.
2. When retrieving a user or group, we will now request collaborations by default. This can be disabled by passing `collaborations=False` as a keyword argument to `user()`, `users()`, or `group()`. This removes the need for type-checked code to do `if user.collaborations: ...` to check against `None`.