### PR TITLE
Add Python 3.12 to tox

### DIFF
--- a/.github/workflows/test_lint_deploy.yml
+++ b/.github/workflows/test_lint_deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist =
     pre-commit
     mypy
     mypy-pydantic1
-    py3{8,9,10,11}-requests{min,max}
-    py3{8,9,10,11}-pydantic1
+    py3{8,9,10,11,12}-requests{min,max}
+    py3{8,9,10,11,12}-pydantic1
     coverage
 
 [gh-actions]
@@ -13,6 +13,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv:pre-commit]
 deps = pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,7 @@
 envlist =
     pre-commit
     mypy
-    mypy-pydantic1
-    py3{8,9,10,11,12}-requests{min,max}
-    py3{8,9,10,11,12}-pydantic1
+    py3{8,9,10,11,12}{,-pydantic1,-requestsmin}
     coverage
 
 [gh-actions]
@@ -33,7 +31,6 @@ commands = python -m pytest {posargs}
 deps =
     -r requirements-test.txt
     requestsmin: requests==2.22.0  # Keep in sync with setup.cfg
-    requestsmax: requests>=2.22.0  # Keep in sync with setup.cfg
     pydantic1: pydantic<2  # Lots of projects still use 1.x
 
 [testenv:coverage]


### PR DESCRIPTION
Python 3.12.0 was released last year, so we should definitely cover it in our test suite.