### PR TITLE
Add `force=` kwarg to `base()` and `table()` methods

### DIFF
--- a/docs/source/_substitutions.rst
+++ b/docs/source/_substitutions.rst
@@ -1,6 +1,6 @@
-.. |arg_base_id| replace:: An Airtable base id.
+.. |arg_base_id| replace:: An Airtable base ID.
 
-.. |arg_record_id| replace:: An Airtable record id.
+.. |arg_record_id| replace:: An Airtable record ID.
 
 .. |kwarg_view| replace:: The name or ID of a view.
     If set, only the records in that view will be returned.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,18 @@
 Changelog
 =========
 
+2.3.0 (TBD)
+------------------------
+
+* :meth:`Api.base <pyairtable.Api.base>`,
+  :meth:`Api.table <pyairtable.Api.table>`,
+  and :meth:`Base.table <pyairtable.Base.table>`
+  will use cached base metadata when called multiple times with ``validate=True``,
+  unless the caller passes a new keyword argument ``force=True``.
+  This allows callers to validate the IDs/names of many bases or tables at once
+  without having to perform expensive network overhead each time.
+  - `PR #336 <https://github.com/gtalarico/pyairtable/pull/336>`_.
+
 2.2.2 (2023-01-28)
 ------------------------
 

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -59,7 +59,10 @@ class Base:
 
         Args:
             api: An instance of :class:`Api` or an Airtable access token.
-            base_id: |arg_base_id|
+            base_id: An Airtable base ID.
+            name: The name of the Airtable base, if known.
+            permission_level: The permission level the current authenticated user
+                has upon the Airtable base, if known.
         """
         if isinstance(api, str):
             warnings.warn(
@@ -98,6 +101,7 @@ class Base:
         id_or_name: str,
         *,
         validate: bool = False,
+        force: bool = False,
     ) -> "pyairtable.api.table.Table":
         """
         Build a new :class:`Table` instance using this instance of :class:`Base`.
@@ -106,13 +110,14 @@ class Base:
             id_or_name: An Airtable table ID or name. Table name should be unencoded,
                 as shown on browser.
             validate: |kwarg_validate_metadata|
+            force: |kwarg_force_metadata|
 
         Usage:
             >>> base.table('Apartments')
             <Table base='appLkNDICXNqxSDhG' name='Apartments'>
         """
         if validate:
-            schema = self.schema(force=True).table(id_or_name)
+            schema = self.schema(force=force).table(id_or_name)
             return pyairtable.api.table.Table(None, self, schema)
         return pyairtable.api.table.Table(None, self, id_or_name)
 

--- a/pyairtable/api/workspace.py
+++ b/pyairtable/api/workspace.py
@@ -46,7 +46,7 @@ class Workspace:
         url = self.api.build_url("meta/bases")
         payload = {"name": name, "workspaceId": self.id, "tables": list(tables)}
         response = self.api.request("POST", url, json=payload)
-        return self.api.base(response["id"], validate=True)
+        return self.api.base(response["id"], validate=True, force=True)
 
     # Everything below here requires .info() and is therefore Enterprise-only
 


### PR DESCRIPTION
Calling `api.base(..., validate=True)` multiple times in a row causes excessive network traffic. This branch adds a new `force=` kwarg that determines whether we ignore cached metadata when validating an ID/name, and by default leaves that behavior off.

Along the way I noticed a test that was broken (it passed when it really shouldn't). Fixed that too.