### PR TITLE
Support for managing permissions and shares

### DIFF
--- a/docs/source/_substitutions.rst
+++ b/docs/source/_substitutions.rst
@@ -70,6 +70,9 @@
     If ``True``, will fetch information from the metadata API and validate the ID/name exists,
     raising ``KeyError`` if it does not.
 
+.. |kwarg_permission_level| replace::
+    See `application permission levels <https://airtable.com/developers/web/api/model/application-permission-levels>`__.
+
 .. |warn| unicode:: U+26A0 .. WARNING SIGN
 
 .. |enterprise_only| replace:: |warn| This feature is only available on Enterprise billing plans.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,8 @@ Changelog
 2.3.0 (TBD)
 ------------------------
 
-* Added support for :ref:`managing permissions and shares`.
+* Added support for :ref:`managing permissions and shares`
+  and :ref:`managing users`.
   - `PR #337 <https://github.com/gtalarico/pyairtable/pull/337>`_.
 * Added :meth:`Enterprise.audit_log <pyairtable.Enterprise.audit_log>`
   to iterate page-by-page through `audit log events <https://airtable.com/developers/web/api/audit-logs-overview>`__.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 2.3.0 (TBD)
 ------------------------
 
+* Added support for :ref:`managing permissions and shares`.
+  - `PR #337 <https://github.com/gtalarico/pyairtable/pull/337>`_.
 * Added :meth:`Enterprise.audit_log <pyairtable.Enterprise.audit_log>`
   to iterate page-by-page through `audit log events <https://airtable.com/developers/web/api/audit-logs-overview>`__.
   - `PR #330 <https://github.com/gtalarico/pyairtable/pull/330>`_.

--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -137,10 +137,6 @@ schema information, you might consider calling :meth:`~pyairtable.Api.request` d
 Managing users
 -------------------
 
-`Remove user from enterprise <https://airtable.com/developers/web/api/remove-user-from-enterprise>`__
-
-    >>> enterprise.remove_user("usrUserId", replacement="usrOtherUserId")
-
 `Manage user <https://airtable.com/developers/web/api/manage-user>`__
 
     >>> user = enterprise.user("usrUserId")
@@ -155,3 +151,11 @@ Managing users
 `Delete user by id <https://airtable.com/developers/web/api/delete-user-by-id>`__
 
     >>> user.delete()
+
+`Remove user from enterprise <https://airtable.com/developers/web/api/remove-user-from-enterprise>`__
+
+    >>> enterprise.remove_user("usrUserId", replacement="usrOtherUserId")
+
+`Manage user membership <https://airtable.com/developers/web/api/manage-user-membership>`__
+
+    >>> enterprise.claim_users({"userId": "managed"})

--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -140,3 +140,15 @@ Managing users
 `Remove user from enterprise <https://airtable.com/developers/web/api/remove-user-from-enterprise>`__
 
     >>> enterprise.remove_user("usrUserId", replacement="usrOtherUserId")
+
+`Manage user <https://airtable.com/developers/web/api/manage-user>`__
+
+    >>> u = enterprise.user("usrUserId")
+    >>> u.state = "deactivated"
+    >>> u.email = u.email.replace("@", "+deactivated@")
+    >>> u.save()
+
+`Delete user by id <https://airtable.com/developers/web/api/delete-user-by-id>`__
+
+    >>> u = enterprise.user("usrUserId")
+    >>> u.delete()

--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -101,7 +101,7 @@ schema information, you might consider calling :meth:`~pyairtable.Api.request` d
 
 `Delete interface invite <https://airtable.com/developers/web/api/delete-interface-invite>`__
 
-    >>> base.collaborators().interfaces["pbdLkNDICXNqxSDhG"].invite_links[0].delete()
+    >>> base.collaborators().interfaces[pbd].invite_links[0].delete()
 
 `Delete workspace invite <https://airtable.com/developers/web/api/delete-workspace-invite>`__
 
@@ -110,17 +110,9 @@ schema information, you might consider calling :meth:`~pyairtable.Api.request` d
 
 `Manage share <https://airtable.com/developers/web/api/manage-share>`__
 
-    .. code-block:: python
-
-        >>> share = base.shares()[0]
-        >>> share.disable()
-        >>> share.enable()
-
-    :meth:`~pyairtable.models.schema.BaseShares.Info.disable` and
-    :meth:`~pyairtable.models.schema.BaseShares.Info.enable` are shortcuts for:
-
-        >>> share.state = "enabled"
-        >>> share.save()
+    >>> share = base.shares()[0]
+    >>> share.disable()
+    >>> share.enable()
 
 `Delete share <https://airtable.com/developers/web/api/delete-share>`__
 
@@ -137,11 +129,14 @@ schema information, you might consider calling :meth:`~pyairtable.Api.request` d
 Managing users
 -------------------
 
+You can use pyAirtable to manage an enterprise's users
+via the following methods.
+
 `Manage user <https://airtable.com/developers/web/api/manage-user>`__
 
     >>> user = enterprise.user("usrUserId")
     >>> user.state = "deactivated"
-    >>> user.email = u.email.replace("@", "+deactivated@")
+    >>> user.email = user.email.replace("@", "+deactivated@")
     >>> user.save()
 
 `Logout user <https://airtable.com/developers/web/api/logout-user>`__
@@ -159,3 +154,7 @@ Managing users
 `Manage user membership <https://airtable.com/developers/web/api/manage-user-membership>`__
 
     >>> enterprise.claim_users({"userId": "managed"})
+
+`Delete users by email <https://airtable.com/developers/web/api/delete-users-by-email>`__
+
+    >>> enterprise.delete_users(["foo@example.com", "bar@example.com"])

--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -132,3 +132,11 @@ schema information, you might consider calling :meth:`~pyairtable.Api.request` d
     >>> r.invite_creation = "unrestricted"
     >>> r.share_creation = "onlyOwners"
     >>> r.save()
+
+
+Managing users
+-------------------
+
+`Remove user from enterprise <https://airtable.com/developers/web/api/remove-user-from-enterprise>`__
+
+    >>> enterprise.remove_user("usrUserId", replacement="usrOtherUserId")

--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -143,12 +143,15 @@ Managing users
 
 `Manage user <https://airtable.com/developers/web/api/manage-user>`__
 
-    >>> u = enterprise.user("usrUserId")
-    >>> u.state = "deactivated"
-    >>> u.email = u.email.replace("@", "+deactivated@")
-    >>> u.save()
+    >>> user = enterprise.user("usrUserId")
+    >>> user.state = "deactivated"
+    >>> user.email = u.email.replace("@", "+deactivated@")
+    >>> user.save()
+
+`Logout user <https://airtable.com/developers/web/api/logout-user>`__
+
+    >>> user.logout()
 
 `Delete user by id <https://airtable.com/developers/web/api/delete-user-by-id>`__
 
-    >>> u = enterprise.user("usrUserId")
-    >>> u.delete()
+    >>> user.delete()

--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -1,9 +1,13 @@
 .. include:: _substitutions.rst
 .. include:: _warn_latest.rst
 
+
 Enterprise Features
 ==============================
 
+
+Retrieving information
+----------------------
 
 pyAirtable exposes a number of classes and methods for interacting with enterprise organizations.
 The following methods are only available on an `Enterprise plan <https://airtable.com/pricing>`__.
@@ -25,5 +29,106 @@ return a 404 error, and pyAirtable will add a reminder to the exception to check
 .. automethod:: pyairtable.Enterprise.info
     :noindex:
 
+
+Retrieving audit logs
+---------------------
+
 .. automethod:: pyairtable.Enterprise.audit_log
     :noindex:
+
+
+Managing permissions and shares
+-------------------------------
+
+You can use pyAirtable to change permissions on a base or workspace
+via the following methods exposed on schema objects.
+
+If for some reason you need to call these API endpoints without first retrieving
+schema information, you might consider calling :meth:`~pyairtable.Api.request` directly.
+
+`Add base collaborator <https://airtable.com/developers/web/api/add-base-collaborator>`__
+
+    >>> base.collaborators().add_user("usrUserId", "read")
+    >>> base.collaborators().add_group("ugpGroupId", "edit")
+    >>> base.collaborators().add("user", "usrUserId", "comment")
+
+`Add interface collaborator <https://airtable.com/developers/web/api/add-interface-collaborator>`__
+
+    >>> base.collaborators().interfaces[pbd].add_user("usrUserId", "read")
+    >>> base.collaborators().interfaces[pbd].add_group("ugpGroupId", "read")
+    >>> base.collaborators().interfaces[pbd].add("user", "usrUserId", "read")
+
+`Add workspace collaborator <https://airtable.com/developers/web/api/add-workspace-collaborator>`__
+
+    >>> workspace.collaborators().add_user("usrUserId", "read")
+    >>> workspace.collaborators().add_group("ugpGroupId", "edit")
+    >>> workspace.collaborators().add("user", "usrUserId", "comment")
+
+`Update collaborator base permission <https://airtable.com/developers/web/api/update-collaborator-base-permission>`__
+
+    >>> base.collaborators().update("usrUserId", "edit")
+    >>> base.collaborators().update("ugpGroupId", "edit")
+
+`Update interface collaborator <https://airtable.com/developers/web/api/update-interface-collaborator>`__
+
+    >>> base.collaborators().interfaces[pbd].update("usrUserId", "edit")
+    >>> base.collaborators().interfaces[pbd].update("ugpGroupId", "edit")
+
+`Update workspace collaborator <https://airtable.com/developers/web/api/update-workspace-collaborator>`__
+
+    >>> workspace.collaborators().update("usrUserId", "edit")
+    >>> workspace.collaborators().update("ugpGroupId", "edit")
+
+`Delete base collaborator <https://airtable.com/developers/web/api/delete-base-collaborator>`__
+
+    >>> base.collaborators().remove("usrUserId")
+    >>> base.collaborators().remove("ugpGroupId")
+
+`Delete interface collaborator <https://airtable.com/developers/web/api/delete-interface-collaborator>`__
+
+    >>> base.collaborators().interfaces[pbd].remove("usrUserId")
+    >>> base.collaborators().interfaces[pbd].remove("ugpGroupId")
+
+`Delete workspace collaborator <https://airtable.com/developers/web/api/delete-workspace-collaborator>`__
+
+    >>> workspace.collaborators().remove("usrUserId")
+    >>> workspace.collaborators().remove("ugpGroupId")
+
+`Delete base invite <https://airtable.com/developers/web/api/delete-base-invite>`__
+
+    >>> base.collaborators().invite_links.via_base[0].delete()
+    >>> workspace.collaborators().invite_links.via_base[0].delete()
+
+`Delete interface invite <https://airtable.com/developers/web/api/delete-interface-invite>`__
+
+    >>> base.collaborators().interfaces["pbdLkNDICXNqxSDhG"].invite_links[0].delete()
+
+`Delete workspace invite <https://airtable.com/developers/web/api/delete-workspace-invite>`__
+
+    >>> base.collaborators().invite_links.via_workspace[0].delete()
+    >>> workspace.collaborators().invite_links.via_workspace[0].delete()
+
+`Manage share <https://airtable.com/developers/web/api/manage-share>`__
+
+    .. code-block:: python
+
+        >>> share = base.shares()[0]
+        >>> share.disable()
+        >>> share.enable()
+
+    :meth:`~pyairtable.models.schema.BaseShares.Info.disable` and
+    :meth:`~pyairtable.models.schema.BaseShares.Info.enable` are shortcuts for:
+
+        >>> share.state = "enabled"
+        >>> share.save()
+
+`Delete share <https://airtable.com/developers/web/api/delete-share>`__
+
+    >>> share.delete()
+
+`Update workspace restrictions <https://airtable.com/developers/web/api/update-workspace-restrictions>`__
+
+    >>> r = workspace.collaborators().restrictions
+    >>> r.invite_creation = "unrestricted"
+    >>> r.share_creation = "onlyOwners"
+    >>> r.save()

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -130,15 +130,14 @@ class Api:
         Return a schema object that represents all bases available via the API.
         """
         url = self.build_url("meta/bases")
-        return Bases.parse_obj(
-            {
-                "bases": [
-                    base_info
-                    for page in self.iterate_requests("GET", url)
-                    for base_info in page["bases"]
-                ]
-            }
-        )
+        data = {
+            "bases": [
+                base_info
+                for page in self.iterate_requests("GET", url)
+                for base_info in page["bases"]
+            ]
+        }
+        return Bases.from_api(data, self)
 
     def _base_from_info(self, base_info: Bases.Info) -> "pyairtable.api.base.Base":
         return pyairtable.api.base.Base(

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,4 +1,5 @@
 import posixpath
+from functools import partialmethod
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, TypeVar, Union
 
 import requests
@@ -267,6 +268,11 @@ class Api:
 
         response = self.session.send(prepared, timeout=self.timeout)
         return self._process_response(response)
+
+    get = partialmethod(request, "GET")
+    post = partialmethod(request, "POST")
+    patch = partialmethod(request, "PATCH")
+    delete = partialmethod(request, "DELETE")
 
     def _process_response(self, response: requests.Response) -> Any:
         try:

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -292,7 +292,7 @@ class Base:
         """
         params = {"include": ["collaborators", "inviteLinks", "interfaces"]}
         data = self.api.request("GET", self.meta_url(), params=params)
-        return BaseCollaborators.parse_obj(data)
+        return BaseCollaborators.from_api(data, self.api, context=self)
 
     @enterprise_only
     @cache_unless_forced

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -278,8 +278,23 @@ class Enterprise:
         response = self.api.post(f"{self.url}/users/claim", json=payload)
         return ClaimUsersResponse.from_api(response, self.api, context=self)
 
+    def delete_users(self, emails: Iterable[str]) -> "DeleteUsersResponse":
+        """
+        Delete multiple users by email.
+
+        Args:
+            emails: A list or other iterable of email addresses.
+        """
+        response = self.api.delete(f"{self.url}/users", params={"email": list(emails)})
+        return DeleteUsersResponse.from_api(response, self.api, context=self)
+
 
 class UserRemoved(AirtableModel):
+    """
+    Returned from the `Remove user from enterprise <https://airtable.com/developers/web/api/remove-user-from-enterprise>`__
+    endpoint.
+    """
+
     was_user_removed_as_admin: bool
     shared: "UserRemoved.Shared"
     unshared: "UserRemoved.Unshared"
@@ -318,7 +333,31 @@ class UserRemoved(AirtableModel):
             workspace_name: str
 
 
+class DeleteUsersResponse(AirtableModel):
+    """
+    Returned from the `Delete users by email <https://airtable.com/developers/web/api/delete-users-by-email>`__
+    endpoint.
+    """
+
+    deleted_users: List["DeleteUsersResponse.UserInfo"]
+    errors: List["DeleteUsersResponse.Error"]
+
+    class UserInfo(AirtableModel):
+        id: str
+        email: str
+
+    class Error(AirtableModel):
+        type: str
+        email: str
+        message: Optional[str] = None
+
+
 class ClaimUsersResponse(AirtableModel):
+    """
+    Returned from the `Manage user membership <https://airtable.com/developers/web/api/manage-user-membership>`__
+    endpoint.
+    """
+
     errors: List["ClaimUsersResponse.Error"]
 
     class Error(AirtableModel):

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional, Union
 
 from pyairtable.models._base import AirtableModel, update_forward_refs
 from pyairtable.models.audit import AuditLogResponse
@@ -250,6 +250,33 @@ class Enterprise:
             payload["replacementOwnerId"] = replacement
         response = self.api.post(url, json=payload)
         return UserRemoved.from_api(response, self.api, context=self)
+
+    def claim_users(
+        self, users: Dict[str, Literal["managed", "unmanaged"]]
+    ) -> "ClaimUsersResponse":
+        """
+        Batch manage organizations enterprise account users. This endpoint allows you
+        to change a user's membership status from being unmanaged to being an
+        organization member, and vice versa.
+
+        See `Manage user membership <https://airtable.com/developers/web/api/manage-user-membership>`__
+        for more information.
+
+        Args:
+            users: A ``dict`` mapping user IDs or emails to the desired state,
+                either ``"managed"`` or ``"unmanaged"``.
+        """
+        payload = {
+            "users": [
+                {
+                    ("email" if "@" in key else "id"): key,
+                    "state": value,
+                }
+                for (key, value) in users.items()
+            ]
+        }
+        response = self.api.post(f"{self.url}/users/claim", json=payload)
+        return ClaimUsersResponse.from_api(response, self.api, context=self)
 
 
 class UserRemoved(AirtableModel):

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -8,7 +8,6 @@ from pyairtable.utils import (
     coerce_iso_str,
     coerce_list_str,
     enterprise_only,
-    is_user_id,
 )
 
 
@@ -37,8 +36,8 @@ class Enterprise:
         Retrieve basic information about the enterprise, caching the result.
         """
         params = {"include": ["collaborators", "inviteLinks"]}
-        payload = self.api.request("GET", self.url, params=params)
-        return EnterpriseInfo.parse_obj(payload)
+        response = self.api.get(self.url, params=params)
+        return EnterpriseInfo.from_api(response, self.api)
 
     def group(self, group_id: str, collaborations: bool = True) -> UserGroup:
         """
@@ -51,7 +50,7 @@ class Enterprise:
         """
         params = {"include": ["collaborations"] if collaborations else []}
         url = self.api.build_url(f"meta/groups/{group_id}")
-        payload = self.api.request("GET", url, params=params)
+        payload = self.api.get(url, params=params)
         return UserGroup.parse_obj(payload)
 
     def user(self, id_or_email: str, collaborations: bool = True) -> UserInfo:
@@ -86,8 +85,7 @@ class Enterprise:
         for value in ids_or_emails:
             (emails if "@" in value else user_ids).append(value)
 
-        response = self.api.request(
-            method="GET",
+        response = self.api.get(
             url=f"{self.url}/users",
             params={
                 "id": user_ids,

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -199,7 +199,7 @@ class Table:
             user_locale: |kwarg_user_locale|
             return_fields_by_field_id: |kwarg_return_fields_by_field_id|
         """
-        record = self.api.request("get", self.record_url(record_id), options=options)
+        record = self.api.get(self.record_url(record_id), options=options)
         return assert_typed_dict(RecordDict, record)
 
     def iterate(self, **options: Any) -> Iterator[List[RecordDict]]:
@@ -304,8 +304,7 @@ class Table:
             typecast: |kwarg_typecast|
             return_fields_by_field_id: |kwarg_return_fields_by_field_id|
         """
-        created = self.api.request(
-            method="post",
+        created = self.api.post(
             url=self.url,
             json={
                 "fields": fields,
@@ -350,8 +349,7 @@ class Table:
 
         for chunk in self.api.chunked(records):
             new_records = [{"fields": fields} for fields in chunk]
-            response = self.api.request(
-                method="post",
+            response = self.api.post(
                 url=self.url,
                 json={
                     "records": new_records,
@@ -523,7 +521,7 @@ class Table:
         """
         return assert_typed_dict(
             RecordDeletedDict,
-            self.api.request("delete", self.record_url(record_id)),
+            self.api.delete(self.record_url(record_id)),
         )
 
     def batch_delete(self, record_ids: Iterable[RecordId]) -> List[RecordDeletedDict]:
@@ -548,7 +546,7 @@ class Table:
         record_ids = list(record_ids)
 
         for chunk in self.api.chunked(record_ids):
-            result = self.api.request("delete", self.url, params={"records[]": chunk})
+            result = self.api.delete(self.url, params={"records[]": chunk})
             deleted_records += assert_typed_dicts(RecordDeletedDict, result["records"])
 
         return deleted_records
@@ -615,7 +613,7 @@ class Table:
             text: The text of the comment. Use ``@[usrIdentifier]`` to mention users.
         """
         url = self.record_url(record_id, "comments")
-        response = self.api.request("POST", url, json={"text": text})
+        response = self.api.post(url, json={"text": text})
         return pyairtable.models.Comment.from_api(
             response, self.api, context={"record_url": self.record_url(record_id)}
         )
@@ -663,7 +661,7 @@ class Table:
             request["description"] = description
         if options:
             request["options"] = options
-        response = self.api.request("POST", self.meta_url("fields"), json=request)
+        response = self.api.post(self.meta_url("fields"), json=request)
         # This hopscotch ensures that the FieldSchema object we return has an API and a URL,
         # and that developers don't need to reload our schema to be able to access it.
         field_schema = parse_field_schema(response)

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -667,7 +667,7 @@ class Table:
         # This hopscotch ensures that the FieldSchema object we return has an API and a URL,
         # and that developers don't need to reload our schema to be able to access it.
         field_schema = parse_field_schema(response)
-        field_schema.set_api(
+        field_schema._set_api(
             self.api,
             context={
                 "base": self.base,

--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -2,6 +2,7 @@
 pyAirtable provides a number of type aliases and TypedDicts which are used as inputs
 and return values to various pyAirtable methods.
 """
+
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
@@ -23,6 +24,10 @@ Timestamp: TypeAlias = str
 #: An alias for ``str`` used internally for disambiguation.
 #: Field names can be any valid string.
 FieldName: TypeAlias = str
+
+
+class NestedIdDict(TypedDict):
+    id: str
 
 
 class AITextDict(TypedDict, total=False):
@@ -177,6 +182,29 @@ class CollaboratorEmailDict(TypedDict):
     """
 
     email: str
+
+
+class AddUserCollaboratorDict(TypedDict):
+    """
+    Used to add a user as a collaborator to a base, workspace, or interface.
+    """
+
+    user: NestedIdDict
+    permissionLevel: str
+
+
+class AddGroupCollaboratorDict(TypedDict):
+    """
+    Used to add a group as a collaborator to a base, workspace, or interface.
+    """
+
+    group: NestedIdDict
+    permissionLevel: str
+
+
+AddCollaboratorDict: TypeAlias = Union[
+    AddUserCollaboratorDict, AddGroupCollaboratorDict
+]
 
 
 #: Represents the types of values that we might receive from the API.

--- a/pyairtable/api/workspace.py
+++ b/pyairtable/api/workspace.py
@@ -45,7 +45,7 @@ class Workspace:
         """
         url = self.api.build_url("meta/bases")
         payload = {"name": name, "workspaceId": self.id, "tables": list(tables)}
-        response = self.api.request("POST", url, json=payload)
+        response = self.api.post(url, json=payload)
         return self.api.base(response["id"], validate=True, force=True)
 
     # Everything below here requires .info() and is therefore Enterprise-only
@@ -60,8 +60,8 @@ class Workspace:
         See https://airtable.com/developers/web/api/get-workspace-collaborators
         """
         params = {"include": ["collaborators", "inviteLinks"]}
-        payload = self.api.request("GET", self.url, params=params)
-        return WorkspaceCollaborators.parse_obj(payload)
+        payload = self.api.get(self.url, params=params)
+        return WorkspaceCollaborators.from_api(payload, self.api, context=self)
 
     @enterprise_only
     def bases(self) -> List["pyairtable.api.base.Base"]:
@@ -89,7 +89,7 @@ class Workspace:
             >>> ws = api.workspace("wspmhESAta6clCCwF")
             >>> ws.delete()
         """
-        self.api.request("DELETE", self.url)
+        self.api.delete(self.url)
 
     @enterprise_only
     def move_base(
@@ -114,7 +114,7 @@ class Workspace:
         if index is not None:
             payload["targetIndex"] = index
         url = self.url + "/moveBase"
-        self.api.request("POST", url, json=payload)
+        self.api.post(url, json=payload)
 
 
 # These are at the bottom of the module to avoid circular imports

--- a/pyairtable/models/_base.py
+++ b/pyairtable/models/_base.py
@@ -140,7 +140,10 @@ class RestfulModel(AirtableModel):
         try:
             self._url = self.__url_pattern.format(**context, self=self)
         except (KeyError, AttributeError) as exc:
-            exc.args = (*exc.args, context)
+            exc.args = (
+                *exc.args,
+                {k: v for (k, v) in context.items() if k != "__visited__"},
+            )
             raise
         if self._url and not self._url.startswith("http"):
             self._url = api.build_url(self._url)

--- a/pyairtable/models/_base.py
+++ b/pyairtable/models/_base.py
@@ -93,8 +93,8 @@ def cascade_api(
         for value in obj:
             cascade_api(value, api, context=context)
     if isinstance(obj, dict):
-        for value in obj.values():
-            cascade_api(value, api, context=context)
+        for key, value in obj.items():
+            cascade_api(value, api, context={**context, "key": key})
     if not isinstance(obj, AirtableModel):
         return
 

--- a/pyairtable/models/_base.py
+++ b/pyairtable/models/_base.py
@@ -198,6 +198,7 @@ class CanUpdateModel(RestfulModel):
     __writable: ClassVar[Optional[Iterable[str]]] = None
     __readonly: ClassVar[Optional[Iterable[str]]] = None
     __save_none: ClassVar[bool] = True
+    __save_http_method: ClassVar[str] = "PATCH"
     __reload_after_save: ClassVar[bool] = True
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -206,6 +207,7 @@ class CanUpdateModel(RestfulModel):
         cls.__writable = kwargs.pop("writable", cls.__writable)
         cls.__readonly = kwargs.pop("readonly", cls.__readonly)
         cls.__save_none = bool(kwargs.pop("save_null_values", cls.__save_none))
+        cls.__save_http_method = kwargs.pop("save_method", cls.__save_http_method)
         cls.__reload_after_save = bool(
             kwargs.pop("reload_after_save", cls.__reload_after_save)
         )
@@ -242,7 +244,7 @@ class CanUpdateModel(RestfulModel):
             exclude=exclude,
             exclude_none=(not self.__save_none),
         )
-        response = self._api.request("PATCH", self._url, json=data)
+        response = self._api.request(self.__save_http_method, self._url, json=data)
         if self.__reload_after_save:
             self._reload(response)
 

--- a/pyairtable/models/_base.py
+++ b/pyairtable/models/_base.py
@@ -29,10 +29,14 @@ class AirtableModel(pydantic.BaseModel):
 
     _raw: Any = pydantic.PrivateAttr()
 
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        self._raw = data
+
     @classmethod
     def from_api(
         cls,
-        obj: Any,
+        obj: Dict[str, Any],
         api: "pyairtable.api.api.Api",
         *,
         context: Optional[Any] = None,
@@ -49,8 +53,7 @@ class AirtableModel(pydantic.BaseModel):
                 which will be used as arguments to ``str.format()`` when constructing
                 the URL for a :class:`~pyairtable.models._base.RestfulModel`.
         """
-        instance = cls.parse_obj(obj)
-        instance._raw = obj
+        instance = cls(**obj)
         cascade_api(instance, api, context=context)
         return instance
 
@@ -130,7 +133,7 @@ class RestfulModel(AirtableModel):
 
     def _set_api(self, api: "pyairtable.api.api.Api", context: Dict[str, Any]) -> None:
         """
-        Set a link to the API and builds the REST URL used for this resource.
+        Set a link to the API and build the REST URL used for this resource.
         """
         self._api = api
         self._url = self.__url_pattern.format(**context, self=self)

--- a/pyairtable/models/_base.py
+++ b/pyairtable/models/_base.py
@@ -102,8 +102,8 @@ def cascade_api(
     # If it's a ModelNamedThis, the key will be model_named_this.
     context = {**context, _context_name(obj): obj}
 
-    # This is what we came here for
     if isinstance(obj, RestfulModel):
+        # This is what we came here for; set the API and URL on the RESTful model.
         obj._set_api(api, context=context)
 
     # Find and apply API/context to nested models in every Pydantic field.
@@ -136,8 +136,12 @@ class RestfulModel(AirtableModel):
         Set a link to the API and build the REST URL used for this resource.
         """
         self._api = api
-        self._url = self.__url_pattern.format(**context, self=self)
         self._url_context = context
+        try:
+            self._url = self.__url_pattern.format(**context, self=self)
+        except (KeyError, AttributeError) as exc:
+            exc.args = (*exc.args, context)
+            raise
         if self._url and not self._url.startswith("http"):
             self._url = api.build_url(self._url)
 

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -541,7 +541,12 @@ class Collaborations(AirtableModel):
         permission_level: str
 
 
-class UserInfo(AirtableModel):
+class UserInfo(
+    CanUpdateModel,
+    CanDeleteModel,
+    url="{enterprise.url}/users/{self.id}",
+    writable=["state", "email", "first_name", "last_name"],
+):
     """
     Detailed information about a user.
 

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -567,6 +567,9 @@ class UserInfo(
     groups: List[NestedId] = _FL()
     collaborations: "Collaborations" = pydantic.Field(default_factory=Collaborations)
 
+    def logout(self) -> None:
+        self._api.post(self._url + "/logout")
+
 
 class UserGroup(AirtableModel):
     """

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -61,7 +61,7 @@ class _Collaborators(RestfulModel):
             user_id: The user ID.
             permission_level: |kwarg_permission_level|
         """
-        self.add_collaborator("user", user_id, permission_level)
+        self.add("user", user_id, permission_level)
 
     def add_group(self, group_id: str, permission_level: str) -> None:
         """
@@ -71,9 +71,9 @@ class _Collaborators(RestfulModel):
             group_id: The group ID.
             permission_level: |kwarg_permission_level|
         """
-        self.add_collaborator("group", group_id, permission_level)
+        self.add("group", group_id, permission_level)
 
-    def add_collaborator(
+    def add(
         self,
         collaborator_type: str,
         collaborator_id: str,

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -205,7 +205,13 @@ class BaseShares(AirtableModel):
 
     shares: List["BaseShares.Info"]
 
-    class Info(AirtableModel):
+    class Info(
+        CanUpdateModel,
+        CanDeleteModel,
+        url="meta/bases/{base.id}/shares/{self.share_id}",
+        writable=["state"],
+        reload_after_save=False,
+    ):
         state: str
         created_by_user_id: str
         created_time: str
@@ -216,6 +222,14 @@ class BaseShares(AirtableModel):
         restricted_to_email_domains: List[str] = _FL()
         view_id: Optional[str] = None
         effective_email_domain_allow_list: List[str] = _FL()
+
+        def enable(self) -> None:
+            self.state = "enabled"
+            self.save()
+
+        def disable(self) -> None:
+            self.state = "disabled"
+            self.save()
 
 
 class BaseSchema(AirtableModel):

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -224,10 +224,16 @@ class BaseShares(AirtableModel):
         effective_email_domain_allow_list: List[str] = _FL()
 
         def enable(self) -> None:
+            """
+            Enable the base share.
+            """
             self.state = "enabled"
             self.save()
 
         def disable(self) -> None:
+            """
+            Disable the base share.
+            """
             self.state = "disabled"
             self.save()
 
@@ -448,7 +454,12 @@ class WorkspaceCollaborators(_Collaborators, url="meta/workspaces/{self.id}"):
     individual_collaborators: "WorkspaceCollaborators.IndividualCollaborators" = _F("WorkspaceCollaborators.IndividualCollaborators")  # fmt: skip
     invite_links: "WorkspaceCollaborators.InviteLinks" = _F("WorkspaceCollaborators.InviteLinks")  # fmt: skip
 
-    class Restrictions(AirtableModel):
+    class Restrictions(
+        CanUpdateModel,
+        url="{workspace_collaborators._url}/updateRestrictions",
+        save_method="POST",
+        reload_after_save=False,
+    ):
         invite_creation: str = pydantic.Field(alias="inviteCreationRestriction")
         share_creation: str = pydantic.Field(alias="shareCreationRestriction")
 

--- a/pyairtable/models/webhook.py
+++ b/pyairtable/models/webhook.py
@@ -147,7 +147,7 @@ class Webhook(CanDeleteModel, url="bases/{base.id}/webhooks/{self.id}"):
         ):
             payloads = page["payloads"]
             for index, payload in enumerate(payloads):
-                payload = WebhookPayload.parse_obj(payload)
+                payload = WebhookPayload.from_api(payload, self._api, context=self)
                 payload.cursor = cursor + index
                 yield payload
                 count += 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from mock import Mock
 from requests import HTTPError
 
-from pyairtable.api import Api, Base, Table
+from pyairtable import Api, Base, Table, Workspace
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def url_builder():
 def constants():
     return dict(
         API_KEY="FakeApiKey",
-        BASE_ID="appJMY16gZDQrMWpA",
+        BASE_ID="appLkNDICXNqxSDhG",
         TABLE_NAME="Table Name",
     )
 
@@ -54,6 +54,16 @@ def base(api: Api, base_id) -> Base:
 @pytest.fixture()
 def table(base: Base, constants) -> Table:
     return base.table(constants["TABLE_NAME"])
+
+
+@pytest.fixture
+def workspace_id() -> str:
+    return "wspmhESAta6clCCwF"  # see WorkspaceCollaborators.json
+
+
+@pytest.fixture
+def workspace(api: Api, workspace_id) -> Workspace:
+    return api.workspace(workspace_id)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,9 @@ def url_builder():
 @pytest.fixture
 def constants():
     return dict(
-        API_KEY="FakeApiKey", BASE_ID="appJMY16gZDQrMWpA", TABLE_NAME="Table Name"
+        API_KEY="FakeApiKey",
+        BASE_ID="appJMY16gZDQrMWpA",
+        TABLE_NAME="Table Name",
     )
 
 

--- a/tests/sample_data/BaseCollaborators.json
+++ b/tests/sample_data/BaseCollaborators.json
@@ -84,7 +84,17 @@
           "userId": "usrR8ZT9KtIgp8Bh3"
         }
       ],
-      "inviteLinks": [],
+      "inviteLinks": [
+        {
+          "createdTime": "2019-01-03T12:33:12.421Z",
+          "id": "invJiqaXmPqq6ABCD",
+          "invitedEmail": "bam@bam.com",
+          "permissionLevel": "edit",
+          "referredByUserId": "usrL2PNC5o3H4lBEi",
+          "restrictedToEmailDomains": [],
+          "type": "singleUse"
+        }
+      ],
       "name": "Interface"
     }
   },
@@ -105,7 +115,7 @@
     "workspaceInviteLinks": [
       {
         "createdTime": "2019-01-03T12:33:12.421Z",
-        "id": "invJiqaXmPqq6Ec87",
+        "id": "invJiqaXmPqq6Ec99",
         "invitedEmail": "bam@bam.com",
         "permissionLevel": "edit",
         "referredByUserId": "usrL2PNC5o3H4lBEi",

--- a/tests/sample_data/BaseCollaborators.json
+++ b/tests/sample_data/BaseCollaborators.json
@@ -61,6 +61,33 @@
       }
     ]
   },
+  "interfaces": {
+    "pbdLkNDICXNqxSDhG": {
+      "createdTime": "2024-02-04T02:28:06.000Z",
+      "firstPublishTime": "2024-02-04T02:28:12.000Z",
+      "groupCollaborators": [
+        {
+          "createdTime": "2024-02-04T02:28:20.184Z",
+          "grantedByUserId": "usrL2PNC5o3H4lBEi",
+          "groupId": "ugpR8ZT9KtIgp8Bh3",
+          "name": "Test Interface",
+          "permissionLevel": "read"
+        }
+      ],
+      "id": "pbdLkNDICXNqxSDhG",
+      "individualCollaborators": [
+        {
+          "createdTime": "2024-02-04T04:00:00.749Z",
+          "email": "test@example.com",
+          "grantedByUserId": "usrL2PNC5o3H4lBEi",
+          "permissionLevel": "edit",
+          "userId": "usrR8ZT9KtIgp8Bh3"
+        }
+      ],
+      "inviteLinks": [],
+      "name": "Interface"
+    }
+  },
   "inviteLinks": {
     "baseInviteLinks": [
       {

--- a/tests/sample_data/UserRemoved.json
+++ b/tests/sample_data/UserRemoved.json
@@ -1,0 +1,40 @@
+{
+  "shared": {
+    "workspaces": [
+      {
+        "permissionLevel": "owner",
+        "userId": "usrL2PNC5o3H4lBEi",
+        "workspaceId": "wsp00000000000000",
+        "workspaceName": "Workspace name"
+      }
+    ]
+  },
+  "unshared": {
+    "bases": [
+      {
+        "baseId": "app00000000000000",
+        "baseName": "Base name",
+        "formerPermissionLevel": "create",
+        "userId": "usr00000000000000"
+      }
+    ],
+    "interfaces": [
+      {
+        "baseId": "app00000000000000",
+        "formerPermissionLevel": "create",
+        "interfaceId": "pgb00000000000000",
+        "interfaceName": "Interface name",
+        "userId": "usr00000000000000"
+      }
+    ],
+    "workspaces": [
+      {
+        "formerPermissionLevel": "owner",
+        "userId": "usr00000000000000",
+        "workspaceId": "wsp00000000000000",
+        "workspaceName": "Workspace name"
+      }
+    ]
+  },
+  "wasUserRemovedAsAdmin": true
+}

--- a/tests/sample_data/WorkspaceCollaborators.json
+++ b/tests/sample_data/WorkspaceCollaborators.json
@@ -71,7 +71,7 @@
   "inviteLinks": {
     "baseInviteLinks": [
       {
-        "baseId": "appSW9R5uCNmRmfl6",
+        "baseId": "appLkNDICXNqxSDhG",
         "createdTime": "2019-01-03T12:33:12.421Z",
         "id": "invJiqaXmPqq6Ec87",
         "invitedEmail": null,

--- a/tests/sample_data/WorkspaceCollaborators.json
+++ b/tests/sample_data/WorkspaceCollaborators.json
@@ -73,7 +73,7 @@
       {
         "baseId": "appLkNDICXNqxSDhG",
         "createdTime": "2019-01-03T12:33:12.421Z",
-        "id": "invJiqaXmPqq6Ec87",
+        "id": "invJiqaXmPqqAPP99",
         "invitedEmail": null,
         "permissionLevel": "read",
         "referredByUserId": "usrsOEchC9xuwRgKk",
@@ -84,7 +84,7 @@
     "workspaceInviteLinks": [
       {
         "createdTime": "2019-01-03T12:33:12.421Z",
-        "id": "invJiqaXmPqq6Ec87",
+        "id": "invJiqaXmPqqWSP00",
         "invitedEmail": "bam@bam.com",
         "permissionLevel": "owner",
         "referredByUserId": "usrL2PNC5o3H4lBEi",

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -59,7 +59,7 @@ def test_repr(api, kwargs, expected):
 
 
 def test_url(base):
-    assert base.url == "https://api.airtable.com/v0/appJMY16gZDQrMWpA"
+    assert base.url == "https://api.airtable.com/v0/appLkNDICXNqxSDhG"
 
 
 def test_schema(base: Base, mock_tables_endpoint):

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -11,7 +11,7 @@ from pyairtable.utils import chunked
 
 
 @pytest.fixture()
-def table_schema(sample_json) -> TableSchema:
+def table_schema(sample_json, api, base) -> TableSchema:
     return TableSchema.parse_obj(sample_json("TableSchema"))
 
 

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -78,7 +78,7 @@ def test_invalid_constructor(api, base):
 
 
 def test_repr(table: Table):
-    assert repr(table) == "<Table base='appJMY16gZDQrMWpA' name='Table Name'>"
+    assert repr(table) == "<Table base='appLkNDICXNqxSDhG' name='Table Name'>"
 
 
 def test_schema(base, requests_mock, sample_json):

--- a/tests/test_models_schema.py
+++ b/tests/test_models_schema.py
@@ -266,7 +266,6 @@ def test_invite_link__delete(
         endpoint = requests_mock.delete(invite_link._url)
         invite_link.delete()
         assert endpoint.call_count == 1
-        assert endpoint.last_request.method == "DELETE"
 
 
 @pytest.fixture
@@ -463,3 +462,17 @@ def test_share__delete(base_share, requests_mock):
     base_share.delete()
     assert m.call_count == 1
     assert m.last_request.body is None
+
+
+def test_workspace_restrictions(workspace, mock_workspace_metadata, requests_mock):
+    restrictions = workspace.collaborators().restrictions
+    restrictions.invite_creation = "unrestricted"
+    restrictions.share_creation = "onlyOwners"
+
+    m = requests_mock.post(restrictions._url)
+    restrictions.save()
+    assert m.call_count == 1
+    assert m.last_request.json() == {
+        "inviteCreationRestriction": "unrestricted",
+        "shareCreationRestriction": "onlyOwners",
+    }

--- a/tests/test_models_schema.py
+++ b/tests/test_models_schema.py
@@ -116,3 +116,21 @@ def test_find():
         collection.find("0003")
     with pytest.raises(KeyError):
         collection.find("0004")
+
+
+@pytest.mark.parametrize(
+    "kind,collaborator",
+    [
+        ("user", "usrsOEchC9xuwRgKk"),
+        ("group", "ugpR8ZT9KtIgp8Bh3"),
+    ],
+)
+def test_base_collaborators__add(base, kind, collaborator, requests_mock, sample_json):
+    requests_mock.get(base.meta_url(), json=sample_json("BaseCollaborators"))
+    m = requests_mock.post(base.meta_url("collaborators"), body="")
+    method = getattr(base.collaborators(), f"add_{kind}")
+    method(collaborator, "read")
+    assert m.call_count == 1
+    assert m.last_request.json() == {
+        "collaborators": [{kind: {"id": collaborator}, "permissionLevel": "read"}]
+    }

--- a/tests/test_models_schema.py
+++ b/tests/test_models_schema.py
@@ -1,5 +1,5 @@
 from operator import attrgetter
-from typing import Any, List, Optional
+from typing import List, Optional
 
 import mock
 import pytest
@@ -7,31 +7,6 @@ import pytest
 from pyairtable.models import schema
 from pyairtable.models._base import AirtableModel
 from pyairtable.testing import fake_id
-
-
-@pytest.fixture
-def schema_obj(api, sample_json):
-    """
-    Test fixture that provides a callable function which retrieves
-    an object generated from tests/sample_data, and optionally
-    retrieves an attribute of that object.
-    """
-
-    def _get_schema_obj(name: str, *, context: Any = None) -> Any:
-        obj_name, _, obj_path = name.partition(".")
-        obj_data = sample_json(obj_name)
-        obj_cls = getattr(schema, obj_name)
-
-        if context:
-            obj = obj_cls.from_api(obj_data, api, context=context)
-        else:
-            obj = obj_cls.parse_obj(obj_data)
-
-        if obj_path:
-            obj = eval(f"obj.{obj_path}", None, {"obj": obj})
-        return obj
-
-    return _get_schema_obj
 
 
 @pytest.fixture


### PR DESCRIPTION
This is the last checkbox in the "Modify collaborations/sharing" section of the roadmap in #249. It supports the following operations:
  - [x] [Update collaborator base permission](https://airtable.com/developers/web/api/update-collaborator-base-permission)
  - [x] [Update interface collaborator](https://airtable.com/developers/web/api/update-interface-collaborator)
  - [x] [Update workspace collaborator](https://airtable.com/developers/web/api/update-workspace-collaborator)
  - [x] [Delete base collaborator](https://airtable.com/developers/web/api/delete-base-collaborator)
  - [x] [Delete interface collaborator](https://airtable.com/developers/web/api/delete-interface-collaborator)
  - [x] [Delete workspace collaborator](https://airtable.com/developers/web/api/delete-workspace-collaborator)
  - [x] [Add base collaborator](https://airtable.com/developers/web/api/add-base-collaborator)
  - [x] [Add interface collaborator](https://airtable.com/developers/web/api/add-interface-collaborator)
  - [x] [Add workspace collaborator](https://airtable.com/developers/web/api/add-workspace-collaborator)
  - [x] [Delete base invite](https://airtable.com/developers/web/api/delete-base-invite)
  - [x] [Delete interface invite](https://airtable.com/developers/web/api/delete-interface-invite)
  - [x] [Delete workspace invite](https://airtable.com/developers/web/api/delete-workspace-invite)
  - [x] [Delete share](https://airtable.com/developers/web/api/delete-share)
  - [x] [Manage share](https://airtable.com/developers/web/api/manage-share)
  - [x] [Update workspace restrictions](https://airtable.com/developers/web/api/update-workspace-restrictions)

See changes to `enterprise.rst` for examples of how the API works.