### PR TITLE
Note an accidental breaking change in 2.3

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 2.3.0 (2024-02-25)
 ------------------------
 
+* A breaking API change was accidentally introduced.
+  Read more in :ref:`Migrating from 2.2 to 2.3`.
 * Added support for :ref:`managing permissions and shares`
   and :ref:`managing users`.
   - `PR #337 <https://github.com/gtalarico/pyairtable/pull/337>`_.

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -6,6 +6,31 @@ Migration Guide
 *****************
 
 
+Migrating from 2.2 to 2.3
+============================
+
+A breaking API change was accidentally introduced into the 2.3 minor release
+by renaming some nested fields of :class:`~pyairtable.models.schema.BaseCollaborators`
+and :class:`~pyairtable.models.schema.WorkspaceCollaborators`.
+
+    * - | ``base.collaborators().invite_links.base_invite_links``
+        | has become ``base.collaborators().invite_links.via_base``
+    * - | ``base.collaborators().invite_links.workspace_invite_links``
+        | has become ``base.collaborators().invite_links.via_workspace``
+    * - | ``ws.collaborators().invite_links.base_invite_links``
+        | has become ``ws.collaborators().invite_links.via_base``
+    * - | ``ws.collaborators().invite_links.workspace_invite_links``
+        | has become ``ws.collaborators().invite_links.via_workspace``
+    * - | ``ws.collaborators().individual_collaborators.base_collaborators``
+        | has become ``ws.collaborators().individual_collaborators.via_base``
+    * - | ``ws.collaborators().individual_collaborators.workspace_collaborators``
+        | has become ``ws.collaborators().individual_collaborators.via_workspace``
+    * - | ``ws.collaborators().group_collaborators.base_collaborators``
+        | has become ``ws.collaborators().group_collaborators.via_base``
+    * - | ``ws.collaborators().group_collaborators.workspace_collaborators``
+        | has become ``ws.collaborators().group_collaborators.via_workspace``
+
+
 Migrating from 1.x to 2.0
 ============================
 

--- a/pyairtable/__init__.py
+++ b/pyairtable/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.0"
+__version__ = "2.3.0.post1"
 
 from .api import Api, Base, Table
 from .api.enterprise import Enterprise


### PR DESCRIPTION
Field name changes should have been left out as they're technically a breaking API change; I didn't catch that when I released 2.3.0. Since it's already out, we're not going to yank it, but we'll publish a post-release update clarifying the change in the migration guide.