### PR TITLE
Better timezone support in orm.fields.DatetimeField

### DIFF
--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -289,7 +289,7 @@ class Model:
             field: name_field_map[field].to_internal_value(value)
             for (field, value) in record["fields"].items()
             # Silently proceed if Airtable returns fields we don't recognize
-            if field in name_field_map
+            if field in name_field_map and value is not None
         }
         # Since instance(**field_values) will perform validation and fail on
         # any readonly fields, instead we directly set instance._fields.

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -35,7 +35,7 @@ def datetime_to_iso_str(value: datetime) -> str:
     Args:
         value: datetime object
     """
-    return value.isoformat(timespec="milliseconds") + "Z"
+    return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def datetime_from_iso_str(value: str) -> datetime:
@@ -45,7 +45,9 @@ def datetime_from_iso_str(value: str) -> datetime:
     Args:
         value: datetime string, e.g. "2014-09-05T07:00:00.000Z"
     """
-    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
 
 
 def date_to_iso_str(value: Union[date, datetime]) -> str:

--- a/tests/integration/test_integration_api.py
+++ b/tests/integration/test_integration_api.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
@@ -223,10 +223,11 @@ def test_batch_upsert(table: Table, cols):
 
 
 def test_integration_formula_datetime(table: Table, cols):
-    VALUE = datetime.utcnow()
-    str_value = fo.to_airtable_value(VALUE)
+    value = datetime.utcnow().replace(tzinfo=timezone.utc)
+    str_value = fo.to_airtable_value(value)
+    formula = fo.match({cols.DATETIME: str_value})
     rv_create = table.create({cols.DATETIME: str_value})
-    rv_first = table.first(formula=fo.match({cols.DATETIME: str_value}))
+    rv_first = table.first(formula=formula)
     assert rv_first and rv_first["id"] == rv_create["id"]
 
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -114,7 +114,11 @@ def test_from_record():
         m_get.return_value = {
             "id": "recwnBLPIeQJoYVt4",
             "createdTime": "",
-            "fields": {"First Name": "X", "Created At": "2014-09-05T12:34:56.000Z"},
+            "fields": {
+                "First Name": "X",
+                "Birthday": None,
+                "Created At": "2014-09-05T12:34:56.000Z",
+            },
         }
         contact = Contact.from_id("recwnBLPIeQJoYVt4")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,22 +1,29 @@
-from datetime import date, datetime
+from datetime import date, datetime, timezone
+from functools import partial
 
 import pytest
 
 from pyairtable import utils
 
+utc_tz = partial(datetime, tzinfo=timezone.utc)
+
 
 @pytest.mark.parametrize(
-    "datetime_obj,datetime_str",
+    "dt_obj,dt_str",
     [
-        (datetime(2000, 1, 2, 3, 4, 5, 0), "2000-01-02T03:04:05.000Z"),
-        (datetime(2025, 12, 31, 23, 59, 59, 0), "2025-12-31T23:59:59.000Z"),
-        (datetime(2025, 12, 31, 23, 59, 59, 5_000), "2025-12-31T23:59:59.005Z"),
-        (datetime(2025, 12, 31, 23, 59, 59, 555_000), "2025-12-31T23:59:59.555Z"),
+        (datetime(2000, 1, 2, 3, 4, 5, 0), "2000-01-02T03:04:05.000"),
+        (datetime(2025, 12, 31, 23, 59, 59, 0), "2025-12-31T23:59:59.000"),
+        (datetime(2025, 12, 31, 23, 59, 59, 5_000), "2025-12-31T23:59:59.005"),
+        (datetime(2025, 12, 31, 23, 59, 59, 555_000), "2025-12-31T23:59:59.555"),
+        (utc_tz(2000, 1, 2, 3, 4, 5, 0), "2000-01-02T03:04:05.000Z"),
+        (utc_tz(2025, 12, 31, 23, 59, 59, 0), "2025-12-31T23:59:59.000Z"),
+        (utc_tz(2025, 12, 31, 23, 59, 59, 5_000), "2025-12-31T23:59:59.005Z"),
+        (utc_tz(2025, 12, 31, 23, 59, 59, 555_000), "2025-12-31T23:59:59.555Z"),
     ],
 )
-def test_datetime_utils(datetime_obj, datetime_str):
-    assert utils.datetime_to_iso_str(datetime_obj) == datetime_str
-    assert utils.datetime_from_iso_str(datetime_str) == datetime_obj
+def test_datetime_utils(dt_obj, dt_str):
+    assert utils.datetime_to_iso_str(dt_obj) == dt_str
+    assert utils.datetime_from_iso_str(dt_str) == dt_obj
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This addresses a few bugs we've run into:

1. It was not possible to set a DatetimeField using a timestamp that includes a timezone, based on how we were parsing it.
2. Timezones were not always sent correctly to the Airtable API.
3. Using `Model.from_record` with a field value of `None` would cause a crash.

We're doing a bit of extra text munging to replace `+00:00` with `Z` because that's how Airtable expects it (for example, when passing a datetime into a filter formula). This might make the test suite slightly slower, but I'm still profiling to see if that's measurable before I do anything about it.