### PR TITLE
Remove validation on `base.create_table`

### DIFF
--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -160,7 +160,7 @@ class Base:
         if description:
             payload["description"] = description
         response = self.api.post(url, json=payload)
-        return self.table(response["id"], validate=False)
+        return self.table(response["id"], validate=True)
 
     @property
     def url(self) -> str:

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -160,7 +160,7 @@ class Base:
         if description:
             payload["description"] = description
         response = self.api.post(url, json=payload)
-        return self.table(response["id"], validate=True)
+        return self.table(response["id"], validate=False)
 
     @property
     def url(self) -> str:


### PR DESCRIPTION
I was getting an error thrown when using `base.create_table`, see #343 .
I'm still getting used to the changes to PyAirtable, and I'm not sure if having `validation` set to True is necessary to meet other objectives.

Let me know if another approach is better, or if the error can't be reproduced.