### PR TITLE
Update `base.create_table`

### DIFF
--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -160,7 +160,7 @@ class Base:
         if description:
             payload["description"] = description
         response = self.api.post(url, json=payload)
-        return self.table(response["id"], validate=True)
+        return self.table(response["id"], validate=False)
 
     @property
     def url(self) -> str:

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -160,7 +160,7 @@ class Base:
         if description:
             payload["description"] = description
         response = self.api.post(url, json=payload)
-        return self.table(response["id"], validate=False)
+        return self.table(response["id"], validate=True, force=True)
 
     @property
     def url(self) -> str:


### PR DESCRIPTION
Turn on `force` during `base.create_table` when trying to return the newly created table. The newly created table is not included in the cached tables, setting `force` to `True` makes sure to use the updated table list.

I believe this is necessary, as adding a `force` parameter to the arguments list of `base.create_table` does not make sense. I can't see any utility in not refreshing the tables list, unless we set returning the new table to optional.

See issue #343