### PR TITLE
Return `""` and `False` from TextField, CheckboxField

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 3.0 (TBD)
 ------------------------
 
+* ORM fields :class:`~pyairtable.orm.fields.TextField` and
+  :class:`~pyairtable.orm.fields.CheckboxField` will no longer
+  return ``None`` when the field is empty.
+  - `PR #347 <https://github.com/gtalarico/pyairtable/pull/347>`_.
 * Rewrite of :mod:`pyairtable.formulas` module.
   - `PR #329 <https://github.com/gtalarico/pyairtable/pull/329>`_.
 

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -846,12 +846,15 @@ class RichTextField(TextField):
     """
 
 
-class SelectField(TextField):
+class SelectField(Field[str, str, None]):
     """
-    Equivalent to :class:`~TextField`.
+    Represents a single select dropdown field. This will return ``None`` if no value is set,
+    and will only return ``""`` if an empty dropdown option is available and selected.
 
     See `Single select <https://airtable.com/developers/web/api/field-model#select>`__.
     """
+
+    valid_types = str
 
 
 class UrlField(TextField):

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -64,19 +64,22 @@ if TYPE_CHECKING:
 
 _ClassInfo: TypeAlias = Union[type, Tuple["_ClassInfo", ...]]
 T = TypeVar("T")
-T_Linked = TypeVar("T_Linked", bound="Model")
+T_Linked = TypeVar("T_Linked", bound="Model")  # used by LinkField
 T_API = TypeVar("T_API")  # type used to exchange values w/ Airtable API
 T_ORM = TypeVar("T_ORM")  # type used to store values internally
+T_Missing = TypeVar("T_Missing")  # type returned when Airtable has no value
 
 
-class Field(Generic[T_API, T_ORM], metaclass=abc.ABCMeta):
+class Field(Generic[T_API, T_ORM, T_Missing], metaclass=abc.ABCMeta):
     """
     A generic class for an Airtable field descriptor that will be
     included in an ORM model.
 
-    Type-checked subclasses should provide two type parameters,
-    ``T_API`` and ``T_ORM``, which indicate the type returned
-    by the API and the type used to store values internally.
+    Type-checked subclasses should provide three type parameters:
+
+        * ``T_API``, indicating the JSON-serializable type returned by the API
+        * ``T_ORM``, indicating the type used to store values internally
+        * ``T_Missing``, indicating the type of value returned if the field is empty
 
     Subclasses should also define ``valid_types`` as a type
     or tuple of types, which will be used to validate the type
@@ -149,11 +152,13 @@ class Field(Generic[T_API, T_ORM], metaclass=abc.ABCMeta):
 
     # obj.field will call __get__(instance=obj, owner=Model)
     @overload
-    def __get__(self, instance: "Model", owner: Type[Any]) -> Optional[T_ORM]: ...
+    def __get__(
+        self, instance: "Model", owner: Type[Any]
+    ) -> Union[T_ORM, T_Missing]: ...
 
     def __get__(
         self, instance: Optional["Model"], owner: Type[Any]
-    ) -> Union[SelfType, Optional[T_ORM]]:
+    ) -> Union[SelfType, T_ORM, T_Missing]:
         # allow calling Model.field to get the field object instead of a value
         if not instance:
             return self
@@ -173,8 +178,12 @@ class Field(Generic[T_API, T_ORM], metaclass=abc.ABCMeta):
     def __delete__(self, instance: "Model") -> None:
         raise AttributeError(f"cannot delete {self._description}")
 
-    def _missing_value(self) -> Optional[T_ORM]:
-        return None
+    @classmethod
+    def _missing_value(cls) -> T_Missing:
+        # This assumes Field[T_API, T_ORM, None]. If a subclass defines T_Missing as
+        # something different, it needs to override _missing_value.
+        # This can be tidied in 3.13 with T_Missing(default=None). See PEP-696.
+        return cast(T_Missing, None)
 
     def to_record_value(self, value: Any) -> Any:
         """
@@ -249,17 +258,36 @@ class Field(Generic[T_API, T_ORM], metaclass=abc.ABCMeta):
         return formulas.LTE(self, value)
 
 
-#: A generic Field whose internal and API representations are the same type.
-_BasicField: TypeAlias = Field[T, T]
+class _FieldWithTypedDefaultValue(Generic[T], Field[T, T, T]):
+    """
+    A generic Field with default value of the same type as internal and API representations.
+
+    For now this is used for TextField and CheckboxField, because Airtable stores the empty
+    values for those types ("" and False) internally as None.
+    """
+
+    @classmethod
+    def _missing_value(cls) -> T:
+        first_type = cls.valid_types
+        while isinstance(first_type, tuple):
+            if not first_type:
+                raise RuntimeError(f"{cls.__qualname__}.valid_types is malformed")
+            first_type = first_type[0]
+        return cast(T, first_type())
+
+
+#: A generic Field with internal and API representations that are the same type.
+_BasicField: TypeAlias = Field[T, T, None]
 
 
 #: An alias for any type of Field.
-AnyField: TypeAlias = _BasicField[Any]
+AnyField: TypeAlias = Field[Any, Any, Any]
 
 
-class TextField(_BasicField[str]):
+class TextField(_FieldWithTypedDefaultValue[str]):
     """
-    Used for all Airtable text fields. Accepts ``str``.
+    Accepts ``str``.
+    Returns ``""`` instead of ``None`` if the field is empty on the Airtable base.
 
     See `Single line text <https://airtable.com/developers/web/api/field-model#simpletext>`__
     and `Long text <https://airtable.com/developers/web/api/field-model#multilinetext>`__.
@@ -329,8 +357,9 @@ class RatingField(IntegerField):
             raise ValueError("rating cannot be below 1")
 
 
-class CheckboxField(_BasicField[bool]):
+class CheckboxField(_FieldWithTypedDefaultValue[bool]):
     """
+    Accepts ``bool``.
     Returns ``False`` instead of ``None`` if the field is empty on the Airtable base.
 
     See `Checkbox <https://airtable.com/developers/web/api/field-model#checkbox>`__.
@@ -338,11 +367,8 @@ class CheckboxField(_BasicField[bool]):
 
     valid_types = bool
 
-    def _missing_value(self) -> bool:
-        return False
 
-
-class DatetimeField(Field[str, datetime]):
+class DatetimeField(Field[str, datetime, None]):
     """
     DateTime field. Accepts only `datetime <https://docs.python.org/3/library/datetime.html#datetime-objects>`_ values.
 
@@ -364,7 +390,7 @@ class DatetimeField(Field[str, datetime]):
         return utils.datetime_from_iso_str(value)
 
 
-class DateField(Field[str, date]):
+class DateField(Field[str, date, None]):
     """
     Date field. Accepts only `date <https://docs.python.org/3/library/datetime.html#date-objects>`_ values.
 
@@ -386,7 +412,7 @@ class DateField(Field[str, date]):
         return utils.date_from_iso_str(value)
 
 
-class DurationField(Field[int, timedelta]):
+class DurationField(Field[int, timedelta, None]):
     """
     Duration field. Accepts only `timedelta <https://docs.python.org/3/library/datetime.html#timedelta-objects>`_ values.
 
@@ -418,7 +444,7 @@ class _DictField(Generic[T], _BasicField[T]):
     valid_types = dict
 
 
-class _ListField(Generic[T_API, T_ORM], Field[List[T_API], List[T_ORM]]):
+class _ListField(Generic[T_API, T_ORM], Field[List[T_API], List[T_ORM], List[T_ORM]]):
     """
     Generic type for a field that stores a list of values. Can be used
     to refer to a lookup field that might return more than one value.
@@ -453,11 +479,6 @@ class _ListField(Generic[T_API, T_ORM], Field[List[T_API], List[T_ORM]]):
             # set this empty list as the field's value.
             if not self.readonly:
                 instance._fields[self.field_name] = value
-        return value
-
-    def to_internal_value(self, value: Optional[List[T_ORM]]) -> List[T_ORM]:
-        if value is None:
-            value = []
         return value
 
 

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -944,10 +944,10 @@ import re
 with open(cog.inFile) as fp:
     src = fp.read()
 
-classes = re.findall(r"class ([A-Z]\w+Field)", src)
-constants = re.findall(r"^([A-Z][A-Z_+]) = ", src)
+classes = re.findall(r"class ((?:[A-Z]\w+)?Field)", src)
+constants = re.findall(r"^(?!T_)([A-Z][A-Z_]+) = ", src, re.MULTILINE)
 extras = ["LinkSelf"]
-names = sorted(classes + constants + extras)
+names = sorted(classes) + constants + extras
 
 cog.outl("\n\n__all__ = [")
 for name in ["Field", *names]:
@@ -974,12 +974,12 @@ __all__ = [
     "DurationField",
     "EmailField",
     "ExternalSyncSourceField",
+    "Field",
     "FloatField",
     "IntegerField",
     "LastModifiedByField",
     "LastModifiedTimeField",
     "LinkField",
-    "LinkSelf",
     "LookupField",
     "MultipleCollaboratorsField",
     "MultipleSelectField",
@@ -991,8 +991,13 @@ __all__ = [
     "SelectField",
     "TextField",
     "UrlField",
+    "ALL_FIELDS",
+    "READONLY_FIELDS",
+    "FIELD_TYPES_TO_CLASSES",
+    "FIELD_CLASSES_TO_TYPES",
+    "LinkSelf",
 ]
-# [[[end]]] (checksum: 3fa8c12315457baf170f9766fd8c9f8e)
+# [[[end]]] (checksum: 2aa36f4e76db73f3d0b741b6be6c9e9e)
 
 
 # Delayed import to avoid circular dependency

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -286,10 +286,14 @@ class Model:
         # Convert Column Names into model field names
         field_values = {
             # Use field's to_internal_value to cast into model fields
-            field: name_field_map[field].to_internal_value(value)
+            field: (
+                name_field_map[field].to_internal_value(value)
+                if value is not None
+                else None
+            )
             for (field, value) in record["fields"].items()
             # Silently proceed if Airtable returns fields we don't recognize
-            if field in name_field_map and value is not None
+            if field in name_field_map
         }
         # Since instance(**field_values) will perform validation and fail on
         # any readonly fields, instead we directly set instance._fields.

--- a/tests/integration/test_integration_orm.py
+++ b/tests/integration/test_integration_orm.py
@@ -219,7 +219,7 @@ def test_every_field(Everything):
 
     # The ORM won't refresh the model's field values after save()
     assert record.formula_integer is None
-    assert record.formula_nan is None
+    assert record.formula_nan == ""
     assert record.link_count is None
     assert record.lookup_error == []
     assert record.lookup_integer == []

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -1,6 +1,7 @@
 import datetime
 import operator
 import re
+from unittest import mock
 
 import pytest
 
@@ -727,3 +728,29 @@ def test_missing_value__invalid_classinfo(classinfo, exc_class):
     obj = T()
     with pytest.raises(exc_class):
         obj.the_field
+
+
+@pytest.mark.parametrize(
+    "fields,expected",
+    [
+        ({}, None),
+        ({"Field": None}, None),
+        ({"Field": ""}, ""),
+        ({"Field": "xyz"}, "xyz"),
+    ],
+)
+def test_select_field(fields, expected):
+    """
+    Test that select field distinguishes between empty string and None.
+    """
+
+    class T(Model):
+        Meta = fake_meta()
+        the_field = f.SelectField("Field")
+
+    obj = T.from_record(fake_record(**fields))
+    assert obj.the_field == expected
+
+    with mock.patch("pyairtable.Table.update", return_value=obj.to_record()) as m:
+        obj.save()
+        m.assert_called_once_with(obj.id, fields, typecast=True)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -71,7 +71,7 @@ if TYPE_CHECKING:
         name = orm.fields.TextField("Name")
         logins = orm.fields.MultipleCollaboratorsField("Logins")
 
-    assert_type(Actor().name, Optional[str])
+    assert_type(Actor().name, str)
     assert_type(Actor().logins, List[T.CollaboratorDict])
 
     class Movie(orm.Model):
@@ -81,11 +81,11 @@ if TYPE_CHECKING:
         actors = orm.fields.LinkField("Actors", Actor)
 
     movie = Movie()
-    assert_type(movie.name, Optional[str])
+    assert_type(movie.name, str)
     assert_type(movie.rating, Optional[int])
     assert_type(movie.actors, List[Actor])
     assert_type(movie.prequels, List[Movie])
-    assert_type(movie.actors[0].name, Optional[str])
+    assert_type(movie.actors[0].name, str)
 
     class EveryField(orm.Model):
         aitext = orm.fields.AITextField("AI Generated Text")
@@ -123,7 +123,7 @@ if TYPE_CHECKING:
     assert_type(record.autonumber, Optional[int])
     assert_type(record.barcode, Optional[T.BarcodeDict])
     assert_type(record.button, Optional[T.ButtonDict])
-    assert_type(record.checkbox, Optional[bool])
+    assert_type(record.checkbox, bool)
     assert_type(record.collaborator, Optional[T.CollaboratorDict])
     assert_type(record.count, Optional[int])
     assert_type(record.created_by, Optional[T.CollaboratorDict])
@@ -132,7 +132,7 @@ if TYPE_CHECKING:
     assert_type(record.date, Optional[datetime.date])
     assert_type(record.datetime, Optional[datetime.datetime])
     assert_type(record.duration, Optional[datetime.timedelta])
-    assert_type(record.email, Optional[str])
+    assert_type(record.email, str)
     assert_type(record.float, Optional[float])
     assert_type(record.integer, Optional[int])
     assert_type(record.last_modified_by, Optional[T.CollaboratorDict])
@@ -141,8 +141,8 @@ if TYPE_CHECKING:
     assert_type(record.multi_select, List[str])
     assert_type(record.number, Optional[Union[int, float]])
     assert_type(record.percent, Optional[Union[int, float]])
-    assert_type(record.phone, Optional[str])
+    assert_type(record.phone, str)
     assert_type(record.rating, Optional[int])
-    assert_type(record.rich_text, Optional[str])
-    assert_type(record.select, Optional[str])
-    assert_type(record.url, Optional[str])
+    assert_type(record.rich_text, str)
+    assert_type(record.select, str)
+    assert_type(record.url, str)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -144,5 +144,5 @@ if TYPE_CHECKING:
     assert_type(record.phone, str)
     assert_type(record.rating, Optional[int])
     assert_type(record.rich_text, str)
-    assert_type(record.select, str)
+    assert_type(record.select, Optional[str])
     assert_type(record.url, str)


### PR DESCRIPTION
It doesn't really make sense for a TextField or CheckboxField to return `None`, since Airtable will return `null` for a text field with an empty value or a checkbox field that is unchecked. This branch allows those fields to return empty strings or `False` as their "missing value", which will reduce the amount of defensive `if model.field is None: ...` style of type checking required by implementers.