### PR TITLE
Add base.duplicate_table method 

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -68,6 +68,9 @@ The following methods allow creating bases, tables, or fields:
 .. automethod:: pyairtable.Base.create_table
     :noindex:
 
+.. automethod:: pyairtable.Base.duplicate_table
+    :noindex:
+
 .. automethod:: pyairtable.Table.create_field
     :noindex:
 

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -165,7 +165,7 @@ class Base:
     def duplicate_table(
         self,
         table: "pyairtable.api.table.Table",
-        new_name: str = None,
+        name: str = None,
         copy_records: bool = False,
     ) -> "pyairtable.api.table.Table":
         """
@@ -173,7 +173,7 @@ class Base:
 
         Args:
             table: The table to duplicate.
-            new_name: The duplicate table name. "copy {# of duplicates}" will be appended if the name is not unique.
+            name: The table name for the created table. "copy {# of duplicates}" will be appended if the name is not unique.
             copy_records: If set to ``True`` will copy records from the existing table into the new table.
         """
 
@@ -184,19 +184,7 @@ class Base:
             if not field["description"]:
                 del field["description"]
 
-        table_names = [tbl.name for tbl in self.tables(force=True)]
-
-        if not new_name:
-            new_name = table.name
-
-        ndupes = 1
-        table_name = f"{new_name} copy"
-
-        while table_name in table_names:
-            ndupes += 1
-            table_name = f"{table.name} copy {ndupes}"
-
-        new_table = self.create_table(name=table_name, fields=fields)
+        new_table = self.create_table(name=name, fields=fields)
 
         if copy_records:
             new_table.batch_create(

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -247,6 +247,25 @@ def test_create_table(base, requests_mock, mock_tables_endpoint):
     assert table.schema().primary_field_id == "fldWasJustCreated"
 
 
+def test_duplicate_table(base, requests_mock, mock_tables_endpoint):
+    """
+    Test that Base.duplicate_table() makes appropriate calls to duplicate a table,
+    including an optional step of copying records if specified.
+    """
+
+    table = base.create_table(
+        "Table Name",
+        fields=[{"name": "Whatever"}],
+        description="Description",
+    )
+
+    duped_table = base.duplicate_table(table)
+
+    assert table.schema().dict() == duped_table.schema().dict()
+    assert table.name + " copy" == duped_table.name
+    assert len(duped_table.all()) == 0
+
+
 def test_delete(base, requests_mock):
     """
     Test that Base.delete() hits the right endpoint.


### PR DESCRIPTION
Not sure if this is a feature we want, but seeing as it can be done in the web UI I figured it may be worth adding.

Adds test function emulating duplicating a table with and without copying records.
The schema is always duplicated.