### PR TITLE
orm.fields.SingleLinkField

### DIFF
--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -484,6 +484,11 @@ class FunctionCall(Formula):
         self.name = name
         self.args = args
 
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, FunctionCall):
+            return False
+        return (self.name, self.args) == (other.name, other.args)
+
     def __str__(self) -> str:
         joined_args = ", ".join(to_formula_str(v) for v in self.args)
         return f"{self.name}({joined_args})"

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -539,7 +539,7 @@ class LinkField(_ListField[RecordId, T_Linked]):
             readonly: If ``True``, any attempt to write a value to this field will
                 raise an ``AttributeError``. This will not, however, prevent any
                 modification of the list object returned by this field.
-            lazy: If ``True``, this field will return empty objects with oly IDs;
+            lazy: If ``True``, this field will return empty objects with only IDs;
                 call :meth:`~pyairtable.orm.Model.fetch` to retrieve values.
         """
         from pyairtable.orm import Model  # noqa, avoid circular import
@@ -640,6 +640,151 @@ class LinkField(_ListField[RecordId, T_Linked]):
         for obj in value:
             if not isinstance(obj, self.linked_model):
                 raise TypeError(f"expected {self.linked_model}; got {type(obj)}")
+
+
+class SingleLinkField(Generic[T_Linked], Field[List[str], T_Linked, None]):
+    """
+    Represents a MultipleRecordLinks field which we assume will only ever contain one link.
+    Returns and accepts a single instance of the linked model, which will be converted to/from
+    a list of IDs when communicating with the Airtable API.
+
+    See `Link to another record <https://airtable.com/developers/web/api/field-model#foreignkey>`__.
+
+    .. warning::
+
+        If Airtable returns multiple IDs for a SingleLinkField and you modify the field value,
+        only the first ID will be saved to the API once you call ``.save()``. The other IDs will be lost.
+
+    By default, a SingleLinkField will ignore the 2nd...Nth IDs if it receives multiple IDs from the API.
+    This behavior can be overridden by passing ``raise_if_many=True`` to the constructor.
+
+    .. code-block:: python
+
+        from pyairtable.orm import Model, fields as F
+
+        class Book(Model):
+            class Meta: ...
+
+            author = F.SingleLinkField("Author", Person)
+            editor = F.SingleLinkField("Editor", Person, raise_if_many=True)
+
+    Given the model configuration above and the data below,
+    one field will silently return a single value,
+    while the other field will throw an exception.
+
+    .. code-block:: python
+
+        >>> book = Book.from_record({
+        ...     "id": "recZ6qSLw0OCA61ul",
+        ...     "createdTime": ...,
+        ...     "fields": {
+        ...         "Author": ["reculZ6qSLw0OCA61", "rec61ulZ6qSLw0OCA"],
+        ...         "Editor": ["recLw0OCA61ulZ6qS", "recOCA61ulZ6qSLw0"],
+        ...     }
+        ... })
+        >>> book.author
+        <Person id='reculZ6qSLw0OCA61'>
+        >>> book.editor
+        Traceback (most recent call last):
+          ...
+        MultipleValues: Book.editor got more than one linked record
+
+    """
+
+    def __init__(
+        self,
+        field_name: str,
+        model: Union[str, Literal[_LinkFieldOptions.LinkSelf], Type[T_Linked]],
+        validate_type: bool = True,
+        readonly: Optional[bool] = None,
+        lazy: bool = False,
+        raise_if_many: bool = False,
+    ):
+        """
+        Args:
+            field_name: Name of the Airtable field.
+            model:
+                Model class representing the linked table. There are a few options:
+
+                1. You can provide a ``str`` that is the fully qualified module and class name.
+                   For example, ``"your.module.Model"`` will import ``Model`` from ``your.module``.
+                2. You can provide a ``str`` that is *just* the class name, and it will be imported
+                   from the same module as the model class.
+                3. You can provide the sentinel value :data:`~LinkSelf`, and the link field
+                   will point to the same model where the link field is created.
+
+            validate_type: Whether to raise a TypeError if attempting to write
+                an object of an unsupported type as a field value. If ``False``, you
+                may encounter unpredictable behavior from the Airtable API.
+            readonly: If ``True``, any attempt to write a value to this field will
+                raise an ``AttributeError``. This will not, however, prevent any
+                modification of the list object returned by this field.
+            lazy: If ``True``, this field will return empty objects with only IDs;
+                call :meth:`~pyairtable.orm.Model.fetch` to retrieve values.
+            raise_if_many: If ``True``, this field will raise a
+                :class:`~pyairtable.orm.fields.MultipleValues` exception upon
+                being accessed if the underlying field contains multiple values.
+        """
+        super().__init__(field_name, validate_type=validate_type, readonly=readonly)
+        self._raise_if_many = raise_if_many
+        # composition is easier than inheritance in this case ¯\_(ツ)_/¯
+        self._link_field = LinkField[T_Linked](
+            field_name,
+            model,
+            validate_type=validate_type,
+            readonly=readonly,
+            lazy=lazy,
+        )
+
+    @overload
+    def __get__(self, instance: None, owner: Type[Any]) -> SelfType: ...
+
+    @overload
+    def __get__(self, instance: "Model", owner: Type[Any]) -> Optional[T_Linked]: ...
+
+    def __get__(
+        self, instance: Optional["Model"], owner: Type[Any]
+    ) -> Union[SelfType, Optional[T_Linked]]:
+        if not instance:
+            return self
+        if self._raise_if_many and len(instance._fields.get(self.field_name) or []) > 1:
+            raise MultipleValues(f"{self._description} got more than one linked record")
+        links = self._link_field.__get__(instance, owner)
+        try:
+            return links[0]
+        except IndexError:
+            return self._missing_value()
+
+    def __set__(self, instance: "Model", value: Optional[T_Linked]) -> None:
+        self._raise_if_readonly()
+        values = None if value is None else [value]
+        self._link_field.__set__(instance, values)
+
+    def __set_name__(self, owner: Any, name: str) -> None:
+        super().__set_name__(owner, name)
+        self._link_field.__set_name__(owner, name)
+
+    def to_record_value(self, value: Union[List[str], List[T_Linked]]) -> List[str]:
+        return self._link_field.to_record_value(value)
+
+    def _repr_fields(self) -> List[Tuple[str, Any]]:
+        return [
+            ("model", self._link_field._linked_model),
+            ("validate_type", self.validate_type),
+            ("readonly", self.readonly),
+            ("lazy", self._link_field._lazy),
+            ("raise_if_many", self._raise_if_many),
+        ]
+
+    @property
+    def linked_model(self) -> Type[T_Linked]:
+        return self._link_field.linked_model
+
+
+class MultipleValues(ValueError):
+    """
+    SingleLinkField received more than one value from either Airtable or calling code.
+    """
 
 
 # Many of these are "passthrough" subclasses for now. E.g. there is no real
@@ -993,6 +1138,7 @@ __all__ = [
     "RatingField",
     "RichTextField",
     "SelectField",
+    "SingleLinkField",
     "TextField",
     "UrlField",
     "ALL_FIELDS",
@@ -1001,7 +1147,7 @@ __all__ = [
     "FIELD_CLASSES_TO_TYPES",
     "LinkSelf",
 ]
-# [[[end]]] (checksum: 2aa36f4e76db73f3d0b741b6be6c9e9e)
+# [[[end]]] (checksum: 314db7bbb782c156d620305a1c42dfef)
 
 
 # Delayed import to avoid circular dependency

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -278,6 +278,14 @@ def test_function_call():
     assert str(fc) == "IF(1, TRUE(), FALSE())"
 
 
+def test_function_call_equivalence():
+    assert F.TODAY() == F.TODAY()
+    assert F.TODAY() != F.NOW()
+    assert F.CEILING(1) == F.CEILING(1)
+    assert F.CEILING(1) != F.CEILING(2)
+    assert F.TODAY() != F.Formula("TODAY()")
+
+
 def test_field_name():
     assert F.field_name("First Name") == "{First Name}"
     assert F.field_name("Guest's Name") == "{Guest\\'s Name}"

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 
+from pyairtable.formulas import OR, RECORD_ID
 from pyairtable.orm import fields as f
 from pyairtable.orm.model import Model
 from pyairtable.testing import (
@@ -19,6 +20,10 @@ DATE_S = "2023-01-01"
 DATE_V = datetime.date(2023, 1, 1)
 DATETIME_S = "2023-04-12T09:30:00.000Z"
 DATETIME_V = datetime.datetime(2023, 4, 12, 9, 30, 0, tzinfo=datetime.timezone.utc)
+
+
+class Dummy(Model):
+    Meta = fake_meta()
 
 
 def test_field():
@@ -70,6 +75,12 @@ def test_description():
         (
             f.LinkField("Records", type("TestModel", (Model,), {"Meta": fake_meta()})),
             "LinkField('Records', model=<class 'test_orm_fields.TestModel'>, validate_type=True, readonly=False, lazy=False)",
+        ),
+        (
+            f.SingleLinkField(
+                "Records", type("TestModel", (Model,), {"Meta": fake_meta()})
+            ),
+            "SingleLinkField('Records', model=<class 'test_orm_fields.TestModel'>, validate_type=True, readonly=False, lazy=False, raise_if_many=False)",
         ),
     ],
 )
@@ -321,11 +332,13 @@ def test_completeness():
     assert_all_fields_tested_by(test_writable_fields, test_readonly_fields)
     assert_all_fields_tested_by(
         test_type_validation,
-        exclude=f.READONLY_FIELDS | {f.LinkField},
+        exclude=f.READONLY_FIELDS | {f.LinkField, f.SingleLinkField},
     )
 
 
-def assert_all_fields_tested_by(*test_fns, exclude=(f.Field, f.LinkField)):
+def assert_all_fields_tested_by(
+    *test_fns, exclude=(f.Field, f.LinkField, f.SingleLinkField)
+):
     """
     Allows meta-tests that fail if any new Field classes appear in pyairtable.orm.fields
     which are not covered by one of a few basic tests. This is intended to help remind
@@ -436,12 +449,13 @@ def test_list_field_with_string():
         t.items = "hello!"
 
 
-def test_link_field_must_link_to_model():
+@pytest.mark.parametrize("cls", (f.LinkField, f.SingleLinkField))
+def test_link_field_must_link_to_model(cls):
     """
     Tests that a LinkField cannot link to an arbitrary type.
     """
     with pytest.raises(TypeError):
-        f.LinkField("Field Name", model=dict)
+        cls("Field Name", model=dict)
 
 
 def test_link_field():
@@ -469,10 +483,6 @@ def test_link_field():
 
     with pytest.raises(TypeError):
         author.books = -1
-
-
-class Dummy(Model):
-    Meta = fake_meta()
 
 
 def test_link_field__linked_model():
@@ -588,6 +598,114 @@ def test_link_field__load_many(requests_mock):
     assert [friend.id for friend in person.friends] == friend_ids
     # Make sure we didn't keep calling the API on every `person.friends`
     assert mock_list.call_count == 2
+
+
+def test_single_link_field():
+    class Author(Model):
+        Meta = fake_meta()
+        name = f.TextField("Name")
+
+    class Book(Model):
+        Meta = fake_meta()
+        author = f.SingleLinkField("Author", Author, lazy=True)
+
+    assert Book.author.linked_model is Author
+
+    book = Book()
+    assert book.author is None
+
+    with pytest.raises(TypeError):
+        book.author = [Author()]
+
+    with pytest.raises(TypeError):
+        book.author = []
+
+    alice = Author.from_record(fake_record(Name="Alice"))
+    book.author = alice
+
+    with mock.patch("pyairtable.Table.get", return_value=alice.to_record()) as m:
+        book.author.fetch()
+        m.assert_called_once_with(alice.id)
+
+    assert book.author.id == alice.id
+    assert book.author.name == "Alice"
+
+    book.author = (bob := Author(name="Bob"))
+    assert not book.author.exists()
+    assert book.author.name == "Bob"
+
+    with mock.patch("pyairtable.Table.create", return_value=fake_record()) as m:
+        book.author.save()
+        m.assert_called_once_with({"Name": "Bob"}, typecast=True)
+
+    with mock.patch("pyairtable.Table.create", return_value=fake_record()) as m:
+        book.save()
+        m.assert_called_once_with({"Author": [bob.id]}, typecast=True)
+
+    with mock.patch("pyairtable.Table.update", return_value=book.to_record()) as m:
+        book.author = None
+        book.save()
+        m.assert_called_once_with(book.id, {"Author": None}, typecast=True)
+
+
+def test_single_link_field__multiple_values():
+    """
+    Test the behavior of SingleLinkField when the Airtable API
+    returns multiple values.
+    """
+
+    class Author(Model):
+        Meta = fake_meta()
+        name = f.TextField("Name")
+
+    class Book(Model):
+        Meta = fake_meta()
+        author = f.SingleLinkField("Author", Author)
+
+    records = [fake_record(Name=f"Author {n+1}") for n in range(3)]
+    a1, a2, a3 = [r["id"] for r in records]
+
+    # if Airtable sends back multiple IDs, we'll retrieve all of them,
+    # but we will only return the first one from the field descriptor.
+    book = Book.from_record(fake_record(Author=[a1, a2, a3]))
+    with mock.patch("pyairtable.Table.all", return_value=records) as m:
+        book.author
+        m.assert_called_once_with(
+            formula=OR(RECORD_ID().eq(r["id"]) for r in records),
+        )
+
+    assert book.author.id == a1
+    assert book.author.name == "Author 1"
+
+    # if no modifications made, the entire list will be sent back to the API
+    with mock.patch("pyairtable.Table.update", return_value=book.to_record()) as m:
+        book.save()
+        m.assert_called_once_with(book.id, {"Author": [a1, a2, a3]}, typecast=True)
+
+    # if we modify the field value, it will drop items 2-N
+    book.author = Author.from_record(fake_record())
+    with mock.patch("pyairtable.Table.update", return_value=book.to_record()) as m:
+        book.save()
+        m.assert_called_once_with(book.id, {"Author": [book.author.id]}, typecast=True)
+
+
+def test_single_link_field__raise_if_many():
+    """
+    Test that passing raise_if_many=True to SingleLinkField will cause an exception
+    to be raised if (1) the field receives multiple values and (2) is accessed.
+    """
+
+    class Author(Model):
+        Meta = fake_meta()
+        name = f.TextField("Name")
+
+    class Book(Model):
+        Meta = fake_meta()
+        author = f.SingleLinkField("Author", Author, raise_if_many=True)
+
+    book = Book.from_record(fake_record(Author=[fake_id(), fake_id()]))
+    with pytest.raises(f.MultipleValues):
+        book.author
 
 
 def test_lookup_field():

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -79,12 +79,14 @@ if TYPE_CHECKING:
         rating = orm.fields.RatingField("Star Rating")
         prequels = orm.fields.LinkField["Movie"]("Prequels", "path.to.Movie")
         actors = orm.fields.LinkField("Actors", Actor)
+        prequel = orm.fields.SingleLinkField["Movie"]("Prequels", orm.fields.LinkSelf)
 
     movie = Movie()
     assert_type(movie.name, str)
     assert_type(movie.rating, Optional[int])
     assert_type(movie.actors, List[Actor])
     assert_type(movie.prequels, List[Movie])
+    assert_type(movie.prequel, Optional[Movie])
     assert_type(movie.actors[0].name, str)
 
     class EveryField(orm.Model):


### PR DESCRIPTION
This branch introduces `orm.fields.SingleLinkField`, which wraps (but does not inherit from) `LinkField`. Implementers can use `SingleLinkField` to indicate that they only ever want the first linked record of a particular field (or `None`), to avoid having to deal with lists. It is configurable whether the field will silently ignore 2nd-Nth values in fields that happen to have multiple records linked, or if it will raise an exception in that circumstance.