### PR TITLE
Add attribute `use_field_ids` to `orm.Model.Meta`

### DIFF
--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -176,7 +176,6 @@ class Model:
     def _get_meta_request_kwargs(cls):
         # Called by modify_kwargs to modify kwargs passed to `all()` & `first()`.
         return {
-            "cell_format": "json",
             "user_locale": None,
             "time_zone": None,
             "return_fields_by_field_id": (

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -31,6 +31,7 @@ class Model:
         * ``table_name`` (required) - Table ID or name.
         * ``timeout`` - A tuple indicating a connect and read timeout. Defaults to no timeout.
         * ``typecast`` - |kwarg_typecast| Defaults to ``True``.
+        * ``use_field_ids`` - |kwarg_use_field_ids| Defaults to ``False``.
 
     .. code-block:: python
 
@@ -46,6 +47,7 @@ class Model:
                 api_key = "keyapikey"
                 timeout = (5, 5)
                 typecast = True
+                use_field_ids = True
 
     You can implement meta attributes as callables if certain values
     need to be dynamically provided or are unavailable at import time:

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -276,20 +276,11 @@ class Model:
 
     @classmethod
     def _kwargs_union(cls, request_args: dict):
-        meta_keys = [
-            "view",
-            "fields",
-            "sort",
-            "formula",
+        disallowed_args = (
             "cell_format",
-            "user_locale",
-            "time_zone",
             "return_fields_by_field_id",
-        ]
-        args_union = {
-            attr: cls._get_meta(attr) for attr in meta_keys if cls._get_meta(attr)
-        }
-        args_union.update(request_args)
+        )
+        args_union = {k: v for k, v in request_args.items() if k not in disallowed_args}
         return args_union
 
     def to_record(self, only_writable: bool = False) -> RecordDict:

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -177,6 +177,7 @@ class Model:
         # Called by modify_kwargs to modify kwargs passed to `all()` & `first()`.
         return {
             "user_locale": None,
+            "cell_format": "json",
             "time_zone": None,
             "return_fields_by_field_id": (
                 cls._get_meta("use_field_ids")

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -173,16 +173,18 @@ class Model:
             )
 
     @classmethod
-    def _get_meta_request_kwargs(cls, request_args: dict):
+    def _get_meta_request_kwargs(cls):
         # Called by modify_kwargs to modify kwargs passed to `all()` & `first()`.
-        disallowed_args = (
-            "cell_format",
-            "return_fields_by_field_id",
-        )
-        args_union = {k: v for k, v in request_args.items() if k not in disallowed_args}
-        if cls._get_meta("use_field_ids"):
-            args_union["return_fields_by_field_id"] = True
-        return args_union
+        return {
+            "cell_format": "json",
+            "user_locale": None,
+            "time_zone": None,
+            "return_fields_by_field_id": (
+                cls._get_meta("use_field_ids")
+                if cls._get_meta("use_field_ids")
+                else False
+            ),
+        }
 
     @classmethod
     @lru_cache
@@ -258,7 +260,7 @@ class Model:
         Retrieve all records for this model. For all supported
         keyword arguments, see :meth:`Table.all <pyairtable.Table.all>`.
         """
-        kwargs.update(cls._get_meta_request_kwargs(kwargs))
+        kwargs.update(cls._get_meta_request_kwargs())
         table = cls.get_table()
         return [cls.from_record(record) for record in table.all(**kwargs)]
 
@@ -268,7 +270,7 @@ class Model:
         Retrieve the first record for this model. For all supported
         keyword arguments, see :meth:`Table.first <pyairtable.Table.first>`.
         """
-        kwargs.update(cls._get_meta_request_kwargs(kwargs))
+        kwargs.update(cls._get_meta_request_kwargs())
         table = cls.get_table()
         if record := table.first(**kwargs):
             return cls.from_record(record)

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -47,7 +47,6 @@ class Model:
                 api_key = "keyapikey"
                 timeout = (5, 5)
                 typecast = True
-                use_field_ids = True
 
     You can implement meta attributes as callables if certain values
     need to be dynamically provided or are unavailable at import time:
@@ -174,16 +173,11 @@ class Model:
 
     @classmethod
     def _get_meta_request_kwargs(cls):
-        # Called by modify_kwargs to modify kwargs passed to `all()` & `first()`.
         return {
             "user_locale": None,
             "cell_format": "json",
             "time_zone": None,
-            "return_fields_by_field_id": (
-                cls._get_meta("use_field_ids")
-                if cls._get_meta("use_field_ids")
-                else False
-            ),
+            "return_fields_by_field_id": cls._get_meta("use_field_ids", default=False),
         }
 
     @classmethod
@@ -204,8 +198,7 @@ class Model:
 
     @classmethod
     def _typecast(cls) -> bool:
-        _ = bool(cls._get_meta("typecast", default=True))
-        return _
+        return bool(cls._get_meta("typecast", default=True))
 
     def exists(self) -> bool:
         """

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -201,7 +201,9 @@ class Model:
 
     @classmethod
     def _typecast(cls) -> bool:
-        return bool(cls._get_meta("typecast", default=True))
+        _ = bool(cls._get_meta("typecast", default=True))
+        print(f"Typecast: {_}")
+        return _
 
     def exists(self) -> bool:
         """
@@ -261,6 +263,7 @@ class Model:
         return [cls.from_record(record) for record in table.all(**kwargs)]
 
     @classmethod
+    @modify_kwargs
     def first(cls, **kwargs: Any) -> Optional[SelfType]:
         """
         Retrieve the first record for this model. For all supported
@@ -283,7 +286,6 @@ class Model:
             "time_zone",
             "return_fields_by_field_id",
         ]
-        print("running union")
         args_union = {
             attr: cls._get_meta(attr) for attr in meta_keys if cls._get_meta(attr)
         }

--- a/pyairtable/testing.py
+++ b/pyairtable/testing.py
@@ -34,19 +34,7 @@ def fake_meta(
     base_id: str = "appFakeTestingApp",
     table_name: str = "tblFakeTestingTbl",
     api_key: str = "patFakePersonalAccessToken",
-) -> type:
-    """
-    Generate a ``Meta`` class for inclusion in a ``Model`` subclass.
-    """
-    attrs = {"base_id": base_id, "table_name": table_name, "api_key": api_key}
-    return type("Meta", (), attrs)
-
-
-def fake_meta_from_ids(
-    base_id: str = "appFakeTestingApp",
-    table_name: str = "Apartments",
-    api_key: str = "patFakePersonalAccessToken",
-    use_field_ids: bool = True,
+    use_field_ids: bool = False,
 ) -> type:
     """
     Generate a ``Meta`` class for inclusion in a ``Model`` subclass.

--- a/pyairtable/testing.py
+++ b/pyairtable/testing.py
@@ -42,6 +42,24 @@ def fake_meta(
     return type("Meta", (), attrs)
 
 
+def fake_meta_from_ids(
+    base_id: str = "appFakeTestingApp",
+    table_name: str = "Apartments",
+    api_key: str = "patFakePersonalAccessToken",
+    use_field_ids: bool = True,
+) -> type:
+    """
+    Generate a ``Meta`` class for inclusion in a ``Model`` subclass.
+    """
+    attrs = {
+        "base_id": base_id,
+        "table_name": table_name,
+        "api_key": api_key,
+        "use_field_ids": use_field_ids,
+    }
+    return type("Meta", (), attrs)
+
+
 def fake_record(
     fields: Optional[Fields] = None,
     id: Optional[str] = None,

--- a/tests/test_orm_model.py
+++ b/tests/test_orm_model.py
@@ -6,7 +6,7 @@ from requests_mock import Mocker
 
 from pyairtable.orm import Model
 from pyairtable.orm import fields as f
-from pyairtable.testing import fake_id, fake_meta, fake_meta_from_ids, fake_record
+from pyairtable.testing import fake_id, fake_meta, fake_record
 
 
 @pytest.fixture(autouse=True)
@@ -76,7 +76,7 @@ class FakeModel(Model):
 
 
 class FakeModelByIds(Model):
-    Meta = fake_meta_from_ids()
+    Meta = fake_meta(use_field_ids=True, table_name="Apartments")
     Name = f.TextField("fld1VnoyuotSTyxW1")
     Age = f.NumberField("fld2VnoyuotSTy4g6")
 
@@ -254,9 +254,7 @@ def test_dynamic_model_meta():
 
     class Fake(Model):
         class Meta:
-            def api_key():
-                return data["api_key"]  # noqa
-
+            api_key = lambda: data["api_key"]  # noqa
             base_id = partial(data.get, "base_id")
 
             @staticmethod

--- a/tests/test_orm_model.py
+++ b/tests/test_orm_model.py
@@ -173,6 +173,27 @@ def test_from_ids__no_fetch(mock_all):
     assert set(contact.id for contact in contacts) == set(fake_ids)
 
 
+def test_disallowed_args():
+    """
+    Test the argument sanitizer, `use_field_ids` attribute, and disallowed kwargs
+    """
+    obj = FakeModel()
+
+    FakeModel.Meta.use_field_ids = True
+    with mock.patch("pyairtable.Table.all") as mock_all:
+        obj.all(fields=["one", "two"])
+    assert obj._get_meta("use_field_ids")
+    assert "return_fields_by_field_id" in mock_all.call_args.kwargs
+    assert "fields" in mock_all.call_args.kwargs
+
+    FakeModel.Meta.use_field_ids = False
+    with mock.patch("pyairtable.Table.all") as mock_all:
+        obj.all(fields=["one", "two"], return_fields_by_field_id=True)
+    assert not obj._get_meta("use_field_ids")
+    assert "return_fields_by_field_id" not in mock_all.call_args.kwargs
+    assert "fields" in mock_all.call_args.kwargs
+
+
 def test_dynamic_model_meta():
     """
     Test that we can provide callables in our Meta class to provide

--- a/tests/test_orm_model.py
+++ b/tests/test_orm_model.py
@@ -197,15 +197,14 @@ def test_passthrough(methodname):
     with mock.patch(f"pyairtable.Table.{methodname}") as mock_endpoint:
         method = getattr(FakeModel, methodname)
         method(a=1, b=2, c=3)
-
     mock_endpoint.assert_called_once_with(
         a=1,
         b=2,
         c=3,
-        time_zone=None,
+        return_fields_by_field_id=getattr(FakeModel.Meta, "use_field_ids", False),
         user_locale=None,
+        time_zone=None,
         cell_format="json",
-        return_fields_by_field_id=False,
     )
 
 
@@ -225,7 +224,7 @@ def test_get_fields_by_id(fake_records_by_id):
     """
     with Mocker() as mock:
         mock.get(
-            f"{FakeModelByIds.get_table().url}?&returnFieldsByFieldId=1",
+            f"{FakeModelByIds.get_table().url}?&returnFieldsByFieldId=1&cellFormat=json",
             json=fake_records_by_id,
             complete_qs=True,
             status_code=200,


### PR DESCRIPTION
Resolves #351
Resolves #187 

Adds wrapper `@modify_kwargs` that handles kwarg sanitization for:
- `Model.all()`
- `Model.first()`

`cell_format` and `return_fields_by_field_id` are removed.

If `Model.Meta.use_field_ids=True`, adds `return_fields_by_field_id=True` to above function calls.

I figure adding a dedicated wrapper is easier to read and is easier to manage if more sanitization is needed in the future.