### PR TITLE
Only run integration tests once, not in each environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,8 @@ hooks:
 release:
 	@zsh -c "./scripts/release.sh"
 
-.PHONY: test test-e2e coverage lint format docs clean
+.PHONY: test coverage lint format docs clean
 test:
-	tox -- -m 'not integration'
-
-test-e2e:
 	tox
 
 coverage:

--- a/pyairtable/__init__.py
+++ b/pyairtable/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.2"
+__version__ = "3.0.0a1"
 
 from .api import Api, Base, Table
 from .api.enterprise import Enterprise

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     pre-commit
     mypy
     py3{8,9,10,11,12}{,-pydantic1,-requestsmin}
+    integration
     coverage
 
 [gh-actions]
@@ -28,11 +29,15 @@ passenv =
 addopts = -v
 testpaths = tests
 commands =
-    python -m pytest {posargs}
+    python -m pytest {posargs:-m 'not integration'}
 deps =
     -r requirements-test.txt
     requestsmin: requests==2.22.0  # Keep in sync with setup.cfg
     pydantic1: pydantic<2  # Lots of projects still use 1.x
+
+[testenv:integration]
+commands =
+    python -m pytest -m integration
 
 [testenv:coverage]
 passenv = COVERAGE_FORMAT


### PR DESCRIPTION
This will make `tox` a lot faster on local machines and seems very unlikely to miss any regressions.