### PR TITLE
Fix mypy and ensure it runs on GH Actions

### DIFF
--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -186,7 +186,7 @@ class Model:
             )
 
     @classmethod
-    def _get_meta_request_kwargs(cls):
+    def _get_meta_request_kwargs(cls) -> Dict[str, Any]:
         return {
             "user_locale": None,
             "cell_format": "json",

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,11 @@ envlist =
 
 [gh-actions]
 python =
-    3.8: py38, coverage
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
+    3.8: py38, mypy
+    3.9: py39, mypy
+    3.10: py310, mypy
+    3.11: py311, mypy
+    3.12: coverage, mypy
 
 [testenv:pre-commit]
 deps = pre-commit


### PR DESCRIPTION
It looks like #355 was missing a type annotation, and we didn't catch it because GitHub Actions has never been configured to run mypy as part of the test suite. This branch will add that, and fix the missing type annotation. 

@BAPCon FYI