### PR TITLE
Release 3.0.0a1

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -25,6 +25,15 @@ Changelog
 * Renamed ``return_fields_by_field_id=`` to ``use_field_ids=``.
   - `PR #362 <https://github.com/gtalarico/pyairtable/pull/362>`_.
 * Added ORM fields that :ref:`require a non-null value <Required Values>`.
+  - `PR #363 <https://github.com/gtalarico/pyairtable/pull/363>`_.
+
+2.3.3 (2024-03-22)
+------------------------
+
+* Fixed a bug affecting ORM Meta values which are computed at runtime.
+  - `PR #357 <https://github.com/gtalarico/pyairtable/pull/357>`_.
+* Fixed documentation for the ORM module.
+  - `PR #356 <https://github.com/gtalarico/pyairtable/pull/356>`_.
 
 2.3.2 (2024-03-18)
 ------------------------

--- a/tests/integration/test_integration_api.py
+++ b/tests/integration/test_integration_api.py
@@ -279,7 +279,7 @@ def test_integration_formula_composition(table: Table, cols):
 def test_integration_attachment(table, cols, valid_img_url):
     rec = table.create({cols.ATTACHMENT: [attachment(valid_img_url)]})
     rv_get = table.get(rec["id"])
-    assert rv_get["fields"]["attachment"][0]["filename"] == "logo.png"
+    assert rv_get["fields"]["attachment"][0]["url"].endswith("logo.png")
 
 
 def test_integration_attachment_multiple(table, cols, valid_img_url):

--- a/tests/integration/test_integration_orm.py
+++ b/tests/integration/test_integration_orm.py
@@ -67,7 +67,7 @@ class _Everything(Model):
     formula_nan = f.TextField("Formula NaN", readonly=True)
     addresses = f.LinkField("Address", _Address)
     link_count = f.CountField("Link to Self (Count)")
-    link_self = f.LinkField["_Everything"](
+    link_self = f.SingleLinkField["_Everything"](
         "Link to Self",
         model="test_integration_orm._Everything",
         lazy=False,
@@ -80,6 +80,24 @@ class _Everything(Model):
     created_by = f.CreatedByField("Created By")
     last_modified = f.LastModifiedTimeField("Last Modified")
     last_modified_by = f.LastModifiedByField("Last Modified By")
+    required_barcode = f.RequiredBarcodeField("Barcode")
+    required_collaborator = f.RequiredCollaboratorField("Assignee")
+    required_count = f.RequiredCountField("Count")
+    required_currency = f.RequiredCurrencyField("Dollars")
+    required_date = f.RequiredDateField("Date")
+    required_datetime = f.RequiredDatetimeField("DateTime")
+    required_duration = f.RequiredDurationField("Duration (h:mm)")
+    required_email = f.RequiredEmailField("Email")
+    required_float = f.RequiredFloatField("Decimal 1")
+    required_integer = f.RequiredIntegerField("Integer")
+    required_number = f.RequiredNumberField("Number")
+    required_percent = f.RequiredPercentField("Percent")
+    required_phone = f.RequiredPhoneNumberField("Phone")
+    required_rating = f.RequiredRatingField("Stars")
+    required_rich_text = f.RequiredRichTextField("Notes")
+    required_select = f.RequiredSelectField("Status")
+    required_text = f.RequiredTextField("Name")
+    required_url = f.RequiredUrlField("URL")
 
 
 def _model_fixture(cls, monkeypatch, make_meta):
@@ -180,7 +198,11 @@ def test_every_field(Everything):
         type(field) for field in vars(Everything).values() if isinstance(field, f.Field)
     }
     for field_class in f.ALL_FIELDS:
-        if field_class in {f.ExternalSyncSourceField, f.AITextField}:
+        if field_class in {
+            f.ExternalSyncSourceField,
+            f.AITextField,
+            f.RequiredAITextField,
+        }:
             continue
         assert field_class in classes_used
 
@@ -213,8 +235,8 @@ def test_every_field(Everything):
     record.save()
     assert record.id
     assert record.addresses == []
-    assert record.link_self == []
-    record.link_self = [record]
+    assert record.link_self is None
+    record.link_self = record
     record.save()
 
     # The ORM won't refresh the model's field values after save()

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -823,7 +823,7 @@ def test_single_link_field__multiple_values():
     assert book.author.name == "Author 1"
     assert book._fields["Author"][1:] == [a2, a3]  # not converted to models
 
-    # if no modifications made, the entire list will be sent back to the API
+    # if book.author.__set__ not called, the entire list will be sent back to the API
     with mock.patch("pyairtable.Table.update", return_value=book.to_record()) as m:
         book.save()
         m.assert_called_once_with(book.id, {"Author": [a1, a2, a3]}, typecast=True)


### PR DESCRIPTION
Fixed a couple last minute issues with docs and integration tests from #358 and #363

This will be marked as a pre-release on PyPI, so it won't be installed for anyone who isn't explicitly depending on this version number (or using `pip install --pre`, `poetry --allow-prereleases`, etc.)