### PR TITLE
Refactor how we access ORM model configuration

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -26,6 +26,7 @@ Changelog
   - `PR #362 <https://github.com/gtalarico/pyairtable/pull/362>`_.
 * Added ORM fields that :ref:`require a non-null value <Required Values>`.
   - `PR #363 <https://github.com/gtalarico/pyairtable/pull/363>`_.
+* Refactored methods for accessing ORM model configuration.
 
 2.3.3 (2024-03-22)
 ------------------------

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -9,10 +9,15 @@ Migration Guide
 Migrating from 2.x to 3.0
 ============================
 
-In this release we've made breaking changes to the :mod:`pyairtable.formulas` module.
-In general, most functions and methods in this module will return instances of
+In this release we've made a number of breaking changes, summarized below.
+
+Changes to the formulas module
+---------------------------------------------
+
+Most functions and methods in :mod:`pyairtable.formulas` now return instances of
 :class:`~pyairtable.formulas.Formula`, which can be chained, combined, and eventually
 passed to the ``formula=`` keyword argument to methods like :meth:`~pyairtable.Table.all`.
+Read the module documentation for more details.
 
 The full list of breaking changes is below:
 
@@ -49,6 +54,24 @@ The full list of breaking changes is below:
       - These no longer return ``str``, and instead return instances of
         :class:`~pyairtable.formulas.FunctionCall`.
 
+Changes to retrieving ORM model configuration
+---------------------------------------------
+
+The 3.0 release has changed the API for retrieving ORM model configuration:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Method in 2.x
+      - Method in 3.0
+    * - ``Model.get_api()``
+      - ``Model.meta.api``
+    * - ``Model.get_base()``
+      - ``Model.meta.base``
+    * - ``Model.get_table()``
+      - ``Model.meta.table``
+    * - ``Model._get_meta(name)``
+      - ``Model.meta.get(name)``
 
 Migrating from 2.2 to 2.3
 ============================

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -1,10 +1,21 @@
 import datetime
-from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Optional
+from functools import cached_property
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Type,
+    Union,
+)
 
 from typing_extensions import Self as SelfType
 
-from pyairtable.api.api import Api
+from pyairtable.api import retrying
+from pyairtable.api.api import Api, TimeoutTuple
 from pyairtable.api.base import Base
 from pyairtable.api.table import Table
 from pyairtable.api.types import (
@@ -18,6 +29,9 @@ from pyairtable.formulas import EQ, OR, RECORD_ID
 from pyairtable.models import Comment
 from pyairtable.orm.fields import AnyField, Field
 from pyairtable.utils import datetime_from_iso_str, datetime_to_iso_str
+
+if TYPE_CHECKING:
+    from builtins import _ClassInfo
 
 
 class Model:
@@ -71,12 +85,22 @@ class Model:
                     return get_secret("AIRTABLE_API_KEY")
     """
 
+    #: The Airtable record ID for this instance. If empty, the instance
+    #: has never been saved to the API.
     id: str = ""
+
+    #: The time when the Airtable record was created. If empty, the instance
+    #: has never been saved to (or fetched from) the API.
     created_time: Optional[datetime.datetime] = None
+
+    #: A wrapper allowing type-annotated access to ORM configuration.
+    meta: ClassVar["_Meta"]
+
     _deleted: bool = False
     _fields: Dict[FieldName, Any]
 
     def __init_subclass__(cls, **kwargs: Any):
+        cls.meta = _Meta(cls)
         cls._validate_class()
         super().__init_subclass__(**kwargs)
 
@@ -145,36 +169,11 @@ class Model:
             setattr(self, key, value)
 
     @classmethod
-    def _get_meta(
-        cls, name: str, default: Any = None, required: bool = False, call: bool = True
-    ) -> Any:
-        """
-        Retrieves the value of a Meta attribute.
-
-        Args:
-            default: The default value to return if the attribute is not set.
-            required: Raise an exception if the attribute is not set.
-            call: If the value is callable, call it before returning a result.
-        """
-        if not hasattr(cls, "Meta"):
-            raise AttributeError(f"{cls.__name__}.Meta must be defined")
-        if not hasattr(cls.Meta, name):
-            if required:
-                raise ValueError(f"{cls.__name__}.Meta.{name} must be defined")
-            return default
-        value = getattr(cls.Meta, name)
-        if call and callable(value):
-            value = value()
-        if required and value is None:
-            raise ValueError(f"{cls.__name__}.Meta.{name} cannot be None")
-        return value
-
-    @classmethod
     def _validate_class(cls) -> None:
         # Verify required Meta attributes were set (but don't call any callables)
-        assert cls._get_meta("api_key", required=True, call=False)
-        assert cls._get_meta("base_id", required=True, call=False)
-        assert cls._get_meta("table_name", required=True, call=False)
+        assert cls.meta.get("api_key", required=True, call=False)
+        assert cls.meta.get("base_id", required=True, call=False)
+        assert cls.meta.get("table_name", required=True, call=False)
 
         model_attributes = [a for a in cls.__dict__.keys() if not a.startswith("__")]
         overridden = set(model_attributes).intersection(Model.__dict__.keys())
@@ -184,35 +183,6 @@ class Model:
                     cls=cls.__name__, name=overridden
                 )
             )
-
-    @classmethod
-    def _get_meta_request_kwargs(cls) -> Dict[str, Any]:
-        return {
-            "user_locale": None,
-            "cell_format": "json",
-            "time_zone": None,
-            "use_field_ids": cls._get_meta("use_field_ids", default=False),
-        }
-
-    @classmethod
-    @lru_cache
-    def get_api(cls) -> Api:
-        return Api(
-            api_key=cls._get_meta("api_key", required=True),
-            timeout=cls._get_meta("timeout"),
-        )
-
-    @classmethod
-    def get_base(cls) -> Base:
-        return cls.get_api().base(cls._get_meta("base_id", required=True))
-
-    @classmethod
-    def get_table(cls) -> Table:
-        return cls.get_base().table(cls._get_meta("table_name", required=True))
-
-    @classmethod
-    def _typecast(cls) -> bool:
-        return bool(cls._get_meta("typecast", default=True))
 
     def exists(self) -> bool:
         """
@@ -232,14 +202,14 @@ class Model:
         """
         if self._deleted:
             raise RuntimeError(f"{self.id} was deleted")
-        table = self.get_table()
+        table = self.meta.table
         fields = self.to_record(only_writable=True)["fields"]
 
         if not self.id:
-            record = table.create(fields, typecast=self._typecast())
+            record = table.create(fields, typecast=self.meta.typecast)
             did_create = True
         else:
-            record = table.update(self.id, fields, typecast=self._typecast())
+            record = table.update(self.id, fields, typecast=self.meta.typecast)
             did_create = False
 
         self.id = record["id"]
@@ -255,7 +225,7 @@ class Model:
         """
         if not self.id:
             raise ValueError("cannot be deleted because it does not have id")
-        table = self.get_table()
+        table = self.meta.table
         result = table.delete(self.id)
         self._deleted = True
         # Is it even possible to get "deleted" False?
@@ -267,9 +237,8 @@ class Model:
         Retrieve all records for this model. For all supported
         keyword arguments, see :meth:`Table.all <pyairtable.Table.all>`.
         """
-        kwargs.update(cls._get_meta_request_kwargs())
-        table = cls.get_table()
-        return [cls.from_record(record) for record in table.all(**kwargs)]
+        kwargs.update(cls.meta.request_kwargs)
+        return [cls.from_record(record) for record in cls.meta.table.all(**kwargs)]
 
     @classmethod
     def first(cls, **kwargs: Any) -> Optional[SelfType]:
@@ -277,9 +246,8 @@ class Model:
         Retrieve the first record for this model. For all supported
         keyword arguments, see :meth:`Table.first <pyairtable.Table.first>`.
         """
-        kwargs.update(cls._get_meta_request_kwargs())
-        table = cls.get_table()
-        if record := table.first(**kwargs):
+        kwargs.update(cls.meta.request_kwargs)
+        if record := cls.meta.table.first(**kwargs):
             return cls.from_record(record)
         return None
 
@@ -356,7 +324,7 @@ class Model:
         if not self.id:
             raise ValueError("cannot be fetched because instance does not have an id")
 
-        record = self.get_table().get(self.id)
+        record = self.meta.table.get(self.id)
         unused = self.from_record(record)
         self._fields = unused._fields
         self.created_time = unused.created_time
@@ -383,7 +351,7 @@ class Model:
             return [cls.from_id(record_id, fetch=False) for record_id in record_ids]
         # There's no endpoint to query multiple IDs at once, but we can use a formula.
         formula = OR(EQ(RECORD_ID(), record_id) for record_id in record_ids)
-        record_data = cls.get_table().all(formula=formula)
+        record_data = cls.meta.table.all(formula=formula)
         records = [cls.from_record(record) for record in record_data]
         # Ensure we return records in the same order, and raise KeyError if any are missing
         records_by_id = {record.id: record for record in records}
@@ -412,9 +380,9 @@ class Model:
             if (record := model.to_record(only_writable=True))
         ]
 
-        table = cls.get_table()
-        table.batch_update(update_records, typecast=cls._typecast())
-        created_records = table.batch_create(create_records, typecast=cls._typecast())
+        table = cls.meta.table
+        table.batch_update(update_records, typecast=cls.meta.typecast)
+        created_records = table.batch_create(create_records, typecast=cls.meta.typecast)
         for model, record in zip(create_models, created_records):
             model.id = record["id"]
             model.created_time = datetime_from_iso_str(record["createdTime"])
@@ -431,18 +399,122 @@ class Model:
             raise ValueError("cannot delete an unsaved model")
         if not all(isinstance(model, cls) for model in models):
             raise TypeError(set(type(model) for model in models))
-        cls.get_table().batch_delete([model.id for model in models])
+        cls.meta.table.batch_delete([model.id for model in models])
 
     def comments(self) -> List[Comment]:
         """
         Return a list of comments on this record.
         See :meth:`Table.comments <pyairtable.Table.comments>`.
         """
-        return self.get_table().comments(self.id)
+        return self.meta.table.comments(self.id)
 
     def add_comment(self, text: str) -> Comment:
         """
         Add a comment to this record.
         See :meth:`Table.add_comment <pyairtable.Table.add_comment>`.
         """
-        return self.get_table().add_comment(self.id, text)
+        return self.meta.table.add_comment(self.id, text)
+
+
+class _Meta:
+    """
+    Wrapper around a Model.Meta class that provides easier, typed access to
+    configuration values (which may or may not be defined in the original class).
+    """
+
+    def __init__(self, model: Type[Model]) -> None:
+        if not (model_meta := getattr(model, "Meta", None)):
+            raise AttributeError(f"{model.__name__}.Meta must be defined")
+        self.model = model
+        self.model_meta = model_meta
+
+    def get(
+        self,
+        name: str,
+        default: Any = None,
+        required: bool = False,
+        call: bool = True,
+        check_types: Optional["_ClassInfo"] = None,
+    ) -> Any:
+        """
+        Given a name, retrieve the model configuration with that name.
+
+        Args:
+            default: The default value to use if the name is not defined.
+            required: If ``True``, raises ``ValueError`` if the name is undefined or None.
+            call: If ``False``, does not execute any callables to retrieve this value;
+                  it will consider the callable itself as the value.
+            check_types: If set, will raise a ``TypeError`` if the value is not
+                         an instance of the given type(s).
+        """
+        if required and not hasattr(self.model_meta, name):
+            raise ValueError(f"{self.model.__name__}.Meta.{name} must be defined")
+        value = getattr(self.model_meta, name, default)
+        if callable(value) and call:
+            value = value()
+        if required and value is None:
+            raise ValueError(f"{self.model.__name__}.Meta.{name} cannot be None")
+        if check_types is not None and not isinstance(value, check_types):
+            raise TypeError(f"expected {check_types!r}; got {type(value)}")
+        return value
+
+    @property
+    def api_key(self) -> str:
+        return str(self.get("api_key", required=True))
+
+    @property
+    def timeout(self) -> Optional[TimeoutTuple]:
+        return self.get(  # type: ignore[no-any-return]
+            "timeout",
+            default=None,
+            check_types=(type(None), tuple),
+        )
+
+    @property
+    def retry_strategy(self) -> Optional[Union[bool, retrying.Retry]]:
+        return self.get(  # type: ignore[no-any-return]
+            "retry",
+            default=True,
+            check_types=(type(None), bool, retrying.Retry),
+        )
+
+    @cached_property
+    def api(self) -> Api:
+        return Api(
+            self.api_key,
+            timeout=self.timeout,
+            retry_strategy=self.retry_strategy,
+        )
+
+    @property
+    def base_id(self) -> str:
+        return str(self.get("base_id", required=True))
+
+    @property
+    def base(self) -> Base:
+        return self.api.base(self.base_id)
+
+    @property
+    def table_name(self) -> str:
+        return str(self.get("table_name", required=True))
+
+    @property
+    def table(self) -> Table:
+        return self.base.table(self.table_name)
+
+    @property
+    def typecast(self) -> bool:
+        return bool(self.get("typecast", default=True))
+
+    @property
+    def use_field_ids(self) -> bool:
+        return bool(self.get("use_field_ids", default=False))
+
+    @property
+    def request_kwargs(self) -> Dict[str, Any]:
+        return {
+            "user_locale": None,
+            "cell_format": "json",
+            "time_zone": None,
+            "use_field_ids": self.use_field_ids,
+        }

--- a/tests/integration/test_integration_orm.py
+++ b/tests/integration/test_integration_orm.py
@@ -101,11 +101,12 @@ class _Everything(Model):
 
 
 def _model_fixture(cls, monkeypatch, make_meta):
-    monkeypatch.setattr(cls, "Meta", make_meta(cls.__name__.replace("_", "")))
+    monkeypatch.setattr(
+        cls.meta, "model_meta", make_meta(cls.__name__.replace("_", ""))
+    )
     yield cls
-    table = cls.get_table()
-    for page in table.iterate():
-        table.batch_delete([record["id"] for record in page])
+    for page in cls.meta.table.iterate():
+        cls.meta.table.batch_delete([record["id"] for record in page])
 
 
 @pytest.fixture
@@ -171,7 +172,7 @@ def test_undeclared_fields(make_meta):
         first_name = f.TextField("First Name")
         last_name = f.TextField("Last Name")
 
-    table = Contact.get_table()
+    table = Contact.meta.table
     record = table.create(
         {
             "First Name": "Alice",

--- a/tests/integration/test_integration_orm.py
+++ b/tests/integration/test_integration_orm.py
@@ -101,9 +101,7 @@ class _Everything(Model):
 
 
 def _model_fixture(cls, monkeypatch, make_meta):
-    monkeypatch.setattr(
-        cls.meta, "model_meta", make_meta(cls.__name__.replace("_", ""))
-    )
+    monkeypatch.setattr(cls, "Meta", make_meta(cls.__name__.replace("_", "")))
     yield cls
     for page in cls.meta.table.iterate():
         cls.meta.table.batch_delete([record["id"] for record in page])

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -175,7 +175,7 @@ def test_linked_record():
     assert not contact.address[0].street
 
     with Mocker() as mock:
-        url = Address.get_table().record_url(address.id)
+        url = Address.meta.table.record_url(address.id)
         mock.get(url, status_code=200, json=record)
         contact.address[0].fetch()
 
@@ -194,11 +194,11 @@ def test_linked_record_can_be_saved(requests_mock, access_linked_records):
     """
     address_json = fake_record(Number=123, Street="Fake St")
     address_id = address_json["id"]
-    address_url_re = re.escape(Address.get_table().url + "?filterByFormula=")
+    address_url_re = re.escape(Address.meta.table.url + "?filterByFormula=")
     contact_json = fake_record(Email="alice@example.com", Link=[address_id])
     contact_id = contact_json["id"]
-    contact_url = Contact.get_table().record_url(contact_id)
-    contact_url_re = re.escape(Contact.get_table().url + "?filterByFormula=")
+    contact_url = Contact.meta.table.record_url(contact_id)
+    contact_url_re = re.escape(Contact.meta.table.url + "?filterByFormula=")
     requests_mock.get(re.compile(address_url_re), json={"records": [address_json]})
     requests_mock.get(re.compile(contact_url_re), json={"records": [contact_json]})
     requests_mock.get(contact_url, json=contact_json)
@@ -257,12 +257,12 @@ def test_undeclared_field(requests_mock, test_case):
     )
 
     requests_mock.get(
-        Address.get_table().url,
+        Address.meta.table.url,
         status_code=200,
         json={"records": [record]},
     )
     requests_mock.get(
-        Address.get_table().record_url(record["id"]),
+        Address.meta.table.record_url(record["id"]),
         status_code=200,
         json=record,
     )

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -686,14 +686,12 @@ def test_link_field__cycle(requests_mock):
     rec_b = {"id": id_b, "createdTime": DATETIME_S, "fields": {"Friends": [id_c]}}
     rec_c = {"id": id_c, "createdTime": DATETIME_S, "fields": {"Friends": [id_a]}}
 
-    requests_mock.get(Person.get_table().record_url(id_a), json=rec_a)
+    requests_mock.get(Person.meta.table.record_url(id_a), json=rec_a)
     a = Person.from_id(id_a)
 
     for record in (rec_a, rec_b, rec_c):
         url_re = re.compile(
-            re.escape(Person.get_table().url + "?filterByFormula=")
-            + ".*"
-            + record["id"]
+            re.escape(Person.meta.table.url + "?filterByFormula=") + ".*" + record["id"]
         )
         requests_mock.get(url_re, json={"records": [record]})
 
@@ -709,7 +707,7 @@ def test_link_field__load_many(requests_mock):
     """
 
     person_id = fake_id("rec", "A")
-    person_url = Person.get_table().record_url(person_id)
+    person_url = Person.meta.table.record_url(person_id)
     friend_ids = [fake_id("rec", c) for c in "123456789ABCDEF"]
 
     person_json = {
@@ -731,7 +729,7 @@ def test_link_field__load_many(requests_mock):
     # The mocked URL specifically includes every record ID in our test set,
     # to ensure the library isn't somehow dropping records from its query.
     url_regex = ".*".join(
-        [re.escape(Person.get_table().url + "?filterByFormula="), *friend_ids]
+        [re.escape(Person.meta.table.url + "?filterByFormula="), *friend_ids]
     )
     mock_list = requests_mock.get(
         re.compile(url_regex),
@@ -961,7 +959,7 @@ def test_datetime_timezones(requests_mock):
             "fields": request.json()["fields"],
         }
 
-    m = requests_mock.patch(M.get_table().record_url(obj.id), json=patch_callback)
+    m = requests_mock.patch(M.meta.table.record_url(obj.id), json=patch_callback)
 
     # Test that we parse the "Z" into UTC correctly
     assert obj.dt.date() == datetime.date(2024, 2, 29)

--- a/tests/test_orm_model.py
+++ b/tests/test_orm_model.py
@@ -178,8 +178,8 @@ def test_from_ids(mock_api):
     contacts = FakeModel.from_ids(fake_ids)
     mock_api.assert_called_once_with(
         method="get",
-        url=FakeModel.get_table().url,
-        fallback=("post", FakeModel.get_table().url + "/listRecords"),
+        url=FakeModel.meta.table.url,
+        fallback=("post", FakeModel.meta.table.url + "/listRecords"),
         options={
             "formula": "OR(%s)" % ", ".join(f"RECORD_ID()='{id}'" for id in fake_ids)
         },
@@ -248,7 +248,7 @@ def test_get_fields_by_id(fake_records_by_id):
     """
     with Mocker() as mock:
         mock.get(
-            f"{FakeModelByIds.get_table().url}?&returnFieldsByFieldId=1&cellFormat=json",
+            f"{FakeModelByIds.meta.table.url}?&returnFieldsByFieldId=1&cellFormat=json",
             json=fake_records_by_id,
             complete_qs=True,
             status_code=200,
@@ -286,7 +286,7 @@ def test_dynamic_model_meta():
     f = Fake()
     Fake.Meta.table_name.assert_not_called()
 
-    assert f._get_meta("api_key") == data["api_key"]
-    assert f._get_meta("base_id") == data["base_id"]
-    assert f._get_meta("table_name") == data["table_name"]
+    assert f.meta.get("api_key") == data["api_key"]
+    assert f.meta.get("base_id") == data["base_id"]
+    assert f.meta.get("table_name") == data["table_name"]
     Fake.Meta.table_name.assert_called_once()


### PR DESCRIPTION
Right now ORM configuration isn't neatly encapsulated and it's not always type-annotated. This branch refactors things a bit into a `model_class.meta` classvar, which has typed properties and still applies all the features we need (like dynamically determined configuration properties). This also reduces the "autocomplete noise" inside the ORM model itself, especially if we add more configuration options in the future.