### PR TITLE
Add support for grant/revoke admin access

### DIFF
--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -158,3 +158,15 @@ via the following methods.
 `Delete users by email <https://airtable.com/developers/web/api/delete-users-by-email>`__
 
     >>> enterprise.delete_users(["foo@example.com", "bar@example.com"])
+
+`Grant admin access <https://airtable.com/developers/web/api/grant-admin-access>`__
+
+    >>> enterprise.grant_admin("usrUserId")
+    >>> enterprise.grant_admin("user@example.com")
+    >>> enterprise.grant_admin(enterprise.user("usrUserId"))
+
+`Revoke admin access <https://airtable.com/developers/web/api/revoke-admin-access>`__
+
+    >>> enterprise.revoke_admin("usrUserId")
+    >>> enterprise.revoke_admin("user@example.com")
+    >>> enterprise.revoke_admin(enterprise.user("usrUserId"))

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -73,6 +73,18 @@ The 3.0 release has changed the API for retrieving ORM model configuration:
     * - ``Model._get_meta(name)``
       - ``Model.meta.get(name)``
 
+Miscellaneous name changes
+---------------------------------------------
+
+.. list-table::
+    :header-rows: 1
+
+    * - Old name
+      - New name
+    * - :class:`~pyairtable.api.enterprise.ClaimUsersResponse`
+      - :class:`~pyairtable.api.enterprise.ManageUsersResponse`
+
+
 Migrating from 2.2 to 2.3
 ============================
 

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -565,6 +565,8 @@ class UserInfo(
     enterprise_user_type: Optional[str]
     invited_to_airtable_by_user_id: Optional[str]
     is_managed: bool = False
+    is_admin: bool = False
+    is_super_admin: bool = False
     groups: List[NestedId] = _FL()
     collaborations: "Collaborations" = pydantic.Field(default_factory=Collaborations)
 


### PR DESCRIPTION
This branch adds support and tests for `Enterprise.grant_admin()` and `Enterprise.revoke_admin()` to support two new endpoints that were [added in April](https://airtable.com/developers/web/api/changelog).