### PR TITLE
Documentation and API cleanup ahead of 3.0 release

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -78,9 +78,6 @@ API: pyairtable.models.schema
 
 .. automodule:: pyairtable.models.schema
     :members:
-    :inherited-members: AirtableModel
-
-.. automethod:: pyairtable.models.schema.parse_field_schema
 
 
 API: pyairtable.models.webhook

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -27,10 +27,25 @@ API: pyairtable
 .. autofunction:: pyairtable.retry_strategy
 
 
+API: pyairtable.api.enterprise
+*******************************
+
+.. automodule:: pyairtable.api.enterprise
+    :members:
+    :exclude-members: Enterprise
+
+
 API: pyairtable.api.types
 *******************************
 
 .. automodule:: pyairtable.api.types
+    :members:
+
+
+API: pyairtable.exceptions
+*******************************
+
+.. automodule:: pyairtable.exceptions
     :members:
 
 
@@ -49,19 +64,31 @@ API: pyairtable.models
     :inherited-members: AirtableModel
 
 
-API: pyairtable.models.audit
-********************************
+API: pyairtable.models.comment
+-------------------------------
 
-.. automodule:: pyairtable.models.audit
+.. automodule:: pyairtable.models.comment
     :members:
+    :exclude-members: Comment
     :inherited-members: AirtableModel
 
 
 API: pyairtable.models.schema
-********************************
+-------------------------------
 
 .. automodule:: pyairtable.models.schema
     :members:
+    :inherited-members: AirtableModel
+
+.. automethod:: pyairtable.models.schema.parse_field_schema
+
+
+API: pyairtable.models.webhook
+-------------------------------
+
+.. automodule:: pyairtable.models.webhook
+    :members:
+    :exclude-members: Webhook, WebhookNotification, WebhookPayload
     :inherited-members: AirtableModel
 
 
@@ -79,6 +106,13 @@ API: pyairtable.orm.fields
     :members:
     :exclude-members: valid_types, contains_type
     :no-inherited-members:
+
+
+API: pyairtable.testing
+*******************************
+
+.. automodule:: pyairtable.testing
+    :members:
 
 
 API: pyairtable.utils

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -76,13 +76,16 @@ The 3.0 release has changed the API for retrieving ORM model configuration:
 Miscellaneous name changes
 ---------------------------------------------
 
-.. list-table::
-    :header-rows: 1
-
-    * - Old name
-      - New name
-    * - :class:`~pyairtable.api.enterprise.ClaimUsersResponse`
-      - :class:`~pyairtable.api.enterprise.ManageUsersResponse`
+    * - | ``pyairtable.api.enterprise.ClaimUsersResponse``
+        | has become :class:`pyairtable.api.enterprise.ManageUsersResponse`
+    * - | ``pyairtable.formulas.CircularDependency``
+        | has become :class:`pyairtable.exceptions.CircularFormulaError`
+    * - | ``pyairtable.params.InvalidParamException``
+        | has become :class:`pyairtable.exceptions.InvalidParameterError`
+    * - | ``pyairtable.orm.fields.MissingValue``
+        | has become :class:`pyairtable.exceptions.MissingValueError`
+    * - | ``pyairtable.orm.fields.MultipleValues``
+        | has become :class:`pyairtable.exceptions.MultipleValuesError`
 
 
 Migrating from 2.2 to 2.3

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -1,10 +1,6 @@
 from typing import Any, Dict, List, Tuple
 
-
-class InvalidParamException(ValueError):
-    """
-    Raised when invalid parameters are passed to ``all()``, ``first()``, etc.
-    """
+from pyairtable.exceptions import InvalidParameterError
 
 
 def dict_list_to_request_params(
@@ -85,7 +81,7 @@ def _option_to_param(name: str) -> str:
     try:
         return OPTIONS_TO_PARAMETERS[name]
     except KeyError:
-        raise InvalidParamException(name)
+        raise InvalidParameterError(name)
 
 
 #: List of option names that cannot be passed via POST, only GET

--- a/pyairtable/api/retrying.py
+++ b/pyairtable/api/retrying.py
@@ -74,5 +74,5 @@ class _RetryingSession(Session):
 
 __all__ = [
     "Retry",
-    "_RetryingSession",
+    "retry_strategy",
 ]

--- a/pyairtable/api/workspace.py
+++ b/pyairtable/api/workspace.py
@@ -104,9 +104,9 @@ class Workspace:
         See https://airtable.com/developers/web/api/move-base
 
         Usage:
+            >>> base = api.base("appCwFmhESAta6clC")
             >>> ws = api.workspace("wspmhESAta6clCCwF")
-            >>> base = api.workspace("appCwFmhESAta6clC")
-            >>> workspace.move_base(base, "wspSomeOtherPlace", index=0)
+            >>> ws.move_base(base, "wspSomeOtherPlace", index=0)
         """
         base_id = base if isinstance(base, str) else base.id
         target_id = target if isinstance(target, str) else target.id

--- a/pyairtable/exceptions.py
+++ b/pyairtable/exceptions.py
@@ -1,0 +1,28 @@
+class PyAirtableError(Exception):
+    """
+    Base class for all exceptions raised by PyAirtable.
+    """
+
+
+class CircularFormulaError(PyAirtableError, RecursionError):
+    """
+    A circular dependency was encountered when flattening nested conditions.
+    """
+
+
+class InvalidParameterError(PyAirtableError, ValueError):
+    """
+    Raised when invalid parameters are passed to ``all()``, ``first()``, etc.
+    """
+
+
+class MissingValueError(PyAirtableError, ValueError):
+    """
+    A required field received an empty value, either from Airtable or other code.
+    """
+
+
+class MultipleValuesError(PyAirtableError, ValueError):
+    """
+    SingleLinkField received more than one value from either Airtable or calling code.
+    """

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -14,6 +14,7 @@ from typing import Any, ClassVar, Iterable, List, Optional, Set, Union
 from typing_extensions import Self as SelfType
 
 from pyairtable.api.types import Fields
+from pyairtable.exceptions import CircularFormulaError
 from pyairtable.utils import date_to_iso_str, datetime_to_iso_str
 
 
@@ -235,7 +236,7 @@ class Compound(Formula):
         flattened: List[Formula] = []
         for item in self.components:
             if id(item) in memo:
-                raise CircularDependency(item)
+                raise CircularFormulaError(item)
             if isinstance(item, Compound) and item.operator == self.operator:
                 flattened.extend(item.flatten(memo=memo).components)
             else:
@@ -313,12 +314,6 @@ def NOT(component: Optional[Formula] = None, /, **fields: Any) -> Compound:
     if (count := len(items)) != 1:
         raise ValueError(f"NOT() requires exactly one condition; got {count}")
     return Compound.build("NOT", items)
-
-
-class CircularDependency(RecursionError):
-    """
-    A circular dependency was encountered when flattening nested conditions.
-    """
 
 
 def match(field_values: Fields, *, match_any: bool = False) -> Formula:

--- a/pyairtable/models/__init__.py
+++ b/pyairtable/models/__init__.py
@@ -6,13 +6,20 @@
 pyAirtable will wrap certain API responses in type-annotated models,
 some of which will be deeply nested within each other. Models which
 implementers can interact with directly are documented below.
+Nested or internal models are documented in each submodule.
+
+Due to its complexity, the :mod:`pyairtable.models.schema` module is
+documented separately, and none of its classes are exposed here.
 """
 
+from .audit import AuditLogEvent, AuditLogResponse
 from .collaborator import Collaborator
 from .comment import Comment
 from .webhook import Webhook, WebhookNotification, WebhookPayload
 
 __all__ = [
+    "AuditLogResponse",
+    "AuditLogEvent",
     "Collaborator",
     "Comment",
     "Webhook",

--- a/pyairtable/models/comment.py
+++ b/pyairtable/models/comment.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Dict, Optional
 
+from pyairtable._compat import pydantic
+
 from ._base import AirtableModel, CanDeleteModel, CanUpdateModel, update_forward_refs
 from .collaborator import Collaborator
 
@@ -58,7 +60,7 @@ class Comment(
     author: Collaborator
 
     #: Users or groups that were mentioned in the text.
-    mentioned: Optional[Dict[str, "Mentioned"]]
+    mentioned: Dict[str, "Mentioned"] = pydantic.Field(default_factory=dict)
 
 
 class Mentioned(AirtableModel):

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -1345,7 +1345,11 @@ class _HasFieldSchema(AirtableModel):
     field_schema: FieldSchema
 
 
-def parse_field_schema(obj: Any) -> FieldSchema:
+def parse_field_schema(obj: Dict[str, Any]) -> FieldSchema:
+    """
+    Given a ``dict`` representing a field schema,
+    parse it into the appropriate FieldSchema subclass.
+    """
     return _HasFieldSchema.parse_obj({"field_schema": obj}).field_schema
 
 

--- a/tests/integration/test_integration_api.py
+++ b/tests/integration/test_integration_api.py
@@ -313,7 +313,7 @@ def test_integration_comments(api, table: Table, cols):
     comments[0].text = "Never mind!"
     comments[0].save()
     assert whoami not in comments[0].text
-    assert comments[0].mentioned is None
+    assert not comments[0].mentioned
 
     # Test that we can delete the comment
     comments[0].delete()

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -5,6 +5,7 @@ from fractions import Fraction
 import pytest
 from mock import call
 
+import pyairtable.exceptions
 from pyairtable import formulas as F
 from pyairtable import orm
 from pyairtable.formulas import AND, EQ, GT, GTE, LT, LTE, NE, NOT, OR
@@ -181,7 +182,7 @@ def test_compound_flatten():
 def test_compound_flatten_circular_dependency():
     circular = NOT(F.Formula("x"))
     circular.components = [circular]
-    with pytest.raises(F.CircularDependency):
+    with pytest.raises(pyairtable.exceptions.CircularFormulaError):
         circular.flatten()
 
 

--- a/tests/test_models_comment.py
+++ b/tests/test_models_comment.py
@@ -45,14 +45,15 @@ def test_parse(comment_json):
     Comment.parse_obj(comment_json)
 
 
-@pytest.mark.parametrize("attr", ["mentioned", "last_updated_time"])
-def test_missing_attributes(comment_json, attr):
+def test_missing_attributes(comment_json):
     """
     Test that we can parse the payload when missing optional values.
     """
-    del comment_json[Comment.__fields__[attr].alias]
+    del comment_json["lastUpdatedTime"]
+    del comment_json["mentioned"]
     comment = Comment.parse_obj(comment_json)
-    assert getattr(comment, attr) is None
+    assert comment.mentioned == {}
+    assert comment.last_updated_time is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 from requests_mock import NoMockAddress
 
+import pyairtable.exceptions
 from pyairtable.formulas import OR, RECORD_ID
 from pyairtable.orm import fields as f
 from pyairtable.orm.model import Model
@@ -465,11 +466,11 @@ def test_rejects_null(field_type):
         the_field = field_type("Field Name")
 
     obj = T()
-    with pytest.raises(f.MissingValue):
+    with pytest.raises(pyairtable.exceptions.MissingValueError):
         obj.the_field
-    with pytest.raises(f.MissingValue):
+    with pytest.raises(pyairtable.exceptions.MissingValueError):
         obj.the_field = None
-    with pytest.raises(f.MissingValue):
+    with pytest.raises(pyairtable.exceptions.MissingValueError):
         T(the_field=None)
 
 
@@ -855,7 +856,7 @@ def test_single_link_field__raise_if_many():
         author = f.SingleLinkField("Author", Author, raise_if_many=True)
 
     book = Book.from_record(fake_record(Author=[fake_id(), fake_id()]))
-    with pytest.raises(f.MultipleValues):
+    with pytest.raises(pyairtable.exceptions.MultipleValuesError):
         book.author
 
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -3,12 +3,12 @@ import requests
 from requests_mock import Mocker
 
 from pyairtable.api.params import (
-    InvalidParamException,
     dict_list_to_request_params,
     field_names_to_sorting_dict,
     options_to_json_and_params,
     options_to_params,
 )
+from pyairtable.exceptions import InvalidParameterError
 
 
 def test_params_integration(table, mock_records, mock_response_iterator):
@@ -178,7 +178,7 @@ def test_convert_options_to_json(option, value, expected):
 
 
 def test_process_params_invalid():
-    with pytest.raises(InvalidParamException):
+    with pytest.raises(InvalidParameterError):
         options_to_params({"ffields": "x"})
 
 


### PR DESCRIPTION
There are a couple breaking name changes here (like moving exceptions into `pyairtable.exceptions`) along with some cleanups on the API documentation itself.