### PR TITLE
Enhance `Model.save` Method to Allow Field-specific Updates

### DIFF
--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -230,7 +230,9 @@ class Model:
 
         Args:
             fields: A list of field names to save. If provided, only these
-                fields will be updated. Otherwise, all fields will be updated.
+            fields will be updated. Otherwise, all fields will be updated.
+            The field names should be in the form the user declared them
+            in the ORM class.
 
         Returns:
             ``True`` if a record was created, ``False`` if it was updated.

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -246,7 +246,11 @@ class Model:
         if fields:
             # Convert ORM attribute names to Airtable field names
             update_fields = {
-                attribute_map[field].field_name: None if self._fields.get(attribute_map[field].field_name) is None else attribute_map[field].to_record_value(self._fields.get(attribute_map[field].field_name))
+                attribute_map[field].field_name: None
+                    if self._fields.get(attribute_map[field].field_name) is None 
+                    else attribute_map[field].to_record_value(
+                        self._fields.get(attribute_map[field].field_name)
+                    )
                 for field in fields
                 if field in attribute_map and not attribute_map[field].readonly
             }

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -345,9 +345,9 @@ class Model:
         ct = datetime_to_iso_str(self.created_time) if self.created_time else ""
         return {"id": self.id, "createdTime": ct, "fields": fields}
     
-    def to_update_record(self, fields: Optional[List[str]] = None) -> UpdateRecordDict:
+    def to_update_record(self, fields: Optional[List[str]] = None) -> RecordDict:
         """
-        Build an :class:`~pyairtable.api.types.UpdateRecordDict` to represent this instance.
+        Build an :class:`~pyairtable.api.types.RecordDict` to represent this instance.
 
         This method generates a field update dictionary for the instance.
 

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -362,7 +362,6 @@ class Model:
         """
         attribute_map = self._attribute_descriptor_map()
         if fields:
-            # Convert ORM attribute names to Airtable field names
             update_fields = {
                 attribute_map[field].field_name: None
                     if self._fields.get(attribute_map[field].field_name) is None 

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -228,6 +228,10 @@ class Model:
         If the instance does not exist already, it will be created;
         otherwise, the existing record will be updated.
 
+        Args:
+            fields: A list of field names to save. If provided, only these
+                fields will be updated. Otherwise, all fields will be updated.
+
         Returns:
             ``True`` if a record was created, ``False`` if it was updated.
         """
@@ -385,7 +389,7 @@ class Model:
             memoize: |kwarg_orm_memoize|
         """
         try:
-            instance = cast(SelfType, cls._memoized[record_id])
+            instance = cls._memoized[record_id]
         except KeyError:
             instance = cls(id=record_id)
         if fetch and not instance._fetched:
@@ -433,7 +437,7 @@ class Model:
         if cls._memoized:
             for record_id in record_ids:
                 try:
-                    by_id[record_id] = cast(SelfType, cls._memoized[record_id])
+                    by_id[record_id] = cls._memoized[record_id]
                 except KeyError:
                     pass
 

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -345,9 +345,9 @@ class Model:
         ct = datetime_to_iso_str(self.created_time) if self.created_time else ""
         return {"id": self.id, "createdTime": ct, "fields": fields}
     
-    def to_update_record(self, fields: Optional[List[str]] = None) -> RecordDict:
+    def to_update_record(self, fields: Optional[List[str]] = None) -> UpdateRecordDict:
         """
-        Build an :class:`~pyairtable.api.types.RecordDict` to represent this instance.
+        Build an :class:`~pyairtable.api.types.UpdateRecordDict` to represent this instance.
 
         This method generates a field update dictionary for the instance.
 
@@ -508,9 +508,9 @@ class Model:
             if (record := model.to_record(only_writable=True))
         ]
         update_records: List[UpdateRecordDict] = [
-            {"id": record["id"], "fields": record["fields"]}
+            {"id": update["id"], "fields": update["fields"]}
             for model in update_models
-            if (record := model.to_update_record(fields=fields))
+            if (update := model.to_update_record(fields=fields))
         ]
 
         table = cls.meta.table

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -103,15 +103,15 @@ def test_model_save_specific_fields():
         update_fields = args[1]
 
         assert "id" in args  # Ensure it is updating an existing record
-        assert "email" in update_fields
-        assert "is_registered" in update_fields
-        assert "first_name" not in update_fields
-        assert "last_name" not in update_fields
-        assert "birthday" not in update_fields
+        assert "Email" in update_fields
+        assert "Registered" in update_fields
+        assert "First Name" not in update_fields
+        assert "Last Name" not in update_fields
+        assert "Birthday" not in update_fields
 
         # Ensure the new values are correctly assigned
-        assert update_fields["email"] == "new_mail@gui.com"
-        assert update_fields["is_registered"] is False
+        assert update_fields["Email"] == "new_mail@gui.com"
+        assert update_fields["Registered"] is False
 
 
 def test_unsupplied_fields():


### PR DESCRIPTION
Introduces enhancements requested in #378 to the `Model.save` method, allowing specific field updates to a record rather than the entire record.

```python

contact = Contact(
    first_name="Benjamin",
    last_name="Perkins"
)

# Specify fields to save
contact.save(fields=['first_name'])

Contact.from_id(contact.id)._fields
>>> {'First Name': 'Benjamin'}
```

### ORM attribute name vs Airtable field name
I think the fields should be specified via their ORM attribute name: `first_name`, `last_name`. This would maintain consistency and be more Pythonic.
