### PR TITLE
Track changes to ORM fields and only save modified fields (unless forced)

### DIFF
--- a/pyairtable/orm/changes.py
+++ b/pyairtable/orm/changes.py
@@ -1,0 +1,48 @@
+from typing import Callable, Iterable, List, SupportsIndex, Union
+
+from typing_extensions import TypeVar
+
+T = TypeVar("T")
+
+
+class ChangeNotifyingList(List[T]):
+    """
+    A list that calls a callback any time it is changed. This allows us to know
+    if any mutations happened to the lists returned from linked record fields.
+    """
+
+    def __init__(self, *args: Iterable[T], on_change: Callable[[], None]) -> None:
+        super().__init__(*args)
+        self._on_change = on_change
+
+    def __setitem__(self, index: SupportsIndex, value: T) -> None:  # type: ignore[override]
+        self._on_change()
+        return super().__setitem__(index, value)
+
+    def __delitem__(self, key: Union[SupportsIndex, slice]) -> None:
+        self._on_change()
+        return super().__delitem__(key)
+
+    def append(self, object: T) -> None:
+        self._on_change()
+        return super().append(object)
+
+    def insert(self, index: SupportsIndex, object: T) -> None:
+        self._on_change()
+        return super().insert(index, object)
+
+    def remove(self, value: T) -> None:
+        self._on_change()
+        return super().remove(value)
+
+    def clear(self) -> None:
+        self._on_change()
+        return super().clear()
+
+    def extend(self, iterable: Iterable[T]) -> None:
+        self._on_change()
+        return super().extend(iterable)
+
+    def pop(self, index: SupportsIndex = -1) -> T:
+        self._on_change()
+        return super().pop(index)

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -176,11 +176,13 @@ class Field(Generic[T_API, T_ORM, T_Missing], metaclass=abc.ABCMeta):
 
     def __set__(self, instance: "Model", value: Optional[T_ORM]) -> None:
         self._raise_if_readonly()
-        if not hasattr(instance, "_fields"):
-            instance._fields = {}
         if self.validate_type and value is not None:
             self.valid_or_raise(value)
+        if not hasattr(instance, "_fields"):
+            instance._fields = {}
         instance._fields[self.field_name] = value
+        if hasattr(instance, "_changed"):
+            instance._changed[self.field_name] = True
 
     def __delete__(self, instance: "Model") -> None:
         raise AttributeError(f"cannot delete {self._description}")

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -29,6 +29,7 @@ import abc
 import importlib
 from datetime import date, datetime, timedelta
 from enum import Enum
+from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -58,6 +59,7 @@ from pyairtable.api.types import (
     RecordId,
 )
 from pyairtable.exceptions import MissingValueError, MultipleValuesError
+from pyairtable.orm.changes import ChangeNotifyingList
 
 if TYPE_CHECKING:
     from pyairtable.orm import Model  # noqa
@@ -488,15 +490,23 @@ class _ListField(Generic[T_API, T_ORM], Field[List[T_API], List[T_ORM], List[T_O
         return self._get_list_value(instance)
 
     def _get_list_value(self, instance: "Model") -> List[T_ORM]:
-        value = cast(List[T_ORM], instance._fields.get(self.field_name))
+        value = instance._fields.get(self.field_name)
         # If Airtable returns no value, substitute an empty list.
         if value is None:
             value = []
-            # For implementers to be able to modify this list in place
-            # and persist it later when they call .save(), we need to
-            # set this empty list as the field's value.
-            if not self.readonly:
-                instance._fields[self.field_name] = value
+        if self.readonly:
+            return value
+
+        # We need to keep track of any mutations to this list, so we know
+        # whether to write the field back to the API when the model is saved.
+        if not isinstance(value, ChangeNotifyingList):
+            on_change = partial(instance._changed.__setitem__, self.field_name, True)
+            value = ChangeNotifyingList[T_ORM](value, on_change=on_change)
+
+        # For implementers to be able to modify this list in place
+        # and persist it later when they call .save(), we need to
+        # set the list as the field's value.
+        instance._fields[self.field_name] = value
         return value
 
 

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -833,7 +833,7 @@ def test_single_link_field__multiple_values():
 
     # if book.author.__set__ not called, the entire list will be sent back to the API
     with mock.patch("pyairtable.Table.update", return_value=book.to_record()) as m:
-        book.save()
+        book.save(force=True)
         m.assert_called_once_with(book.id, {"Author": [a1, a2, a3]}, typecast=True)
 
     # if we modify the field value, it will drop items 2-N
@@ -974,7 +974,7 @@ def test_datetime_timezones(requests_mock):
     # Test that we parse the "Z" into UTC correctly
     assert obj.dt.date() == datetime.date(2024, 2, 29)
     assert obj.dt.tzinfo is datetime.timezone.utc
-    obj.save()
+    obj.save(force=True)
     assert m.last_request.json()["fields"]["dt"] == "2024-02-29T12:34:56.000Z"
 
     # Test that we can set a UTC timezone and it will be saved as-is.
@@ -1018,5 +1018,5 @@ def test_select_field(fields, expected):
     assert obj.the_field == expected
 
     with mock.patch("pyairtable.Table.update", return_value=obj.to_record()) as m:
-        obj.save()
+        obj.save(force=True)
         m.assert_called_once_with(obj.id, fields, typecast=True)


### PR DESCRIPTION
This branch adds change tracking to the ORM Model and Field classes, so that we can avoid sending field values to the API if they haven't been modified. This is the default behavior now; implementers can override this behavior by calling `obj.save(force=True)` on a model instance.

Fixes #378 

FYI @gildastone @bapcon