### PR TITLE
Fix failing integration test for manualSort field

### DIFF
--- a/tests/integration/test_integration_orm.py
+++ b/tests/integration/test_integration_orm.py
@@ -201,6 +201,7 @@ def test_every_field(Everything):
             f.ExternalSyncSourceField,
             f.AITextField,
             f.RequiredAITextField,
+            f.ManualSortField,
         }:
             continue
         assert field_class in classes_used


### PR DESCRIPTION
I neglected to run the integration test suite on #380 and one of the tests fails. The license on the test base does not allow for this field type to be created, so I'm simply skipping it for now.