### PR TITLE
Add `use_field_ids=` param to Api

### DIFF
--- a/docs/source/_substitutions.rst
+++ b/docs/source/_substitutions.rst
@@ -58,7 +58,8 @@
     bet set to null. If ``False``, only provided fields are updated.
 
 .. |kwarg_use_field_ids| replace:: An optional boolean value that lets you return field objects where the
-    key is the field id. This defaults to `false`, which returns field objects where the key is the field name.
+    key is the field id. This defaults to ``False``, which returns field objects where the key is the field name.
+    This behavior can be overridden by passing ``use_field_ids=True`` to :class:`~pyairtable.Api`.
 
 .. |kwarg_force_metadata| replace::
     By default, this method will only fetch information from the API if it has not been cached.

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -41,6 +41,10 @@ class Api:
     # Cached metadata to reduce API calls
     _bases: Optional[Dict[str, "pyairtable.api.base.Base"]] = None
 
+    endpoint_url: str
+    session: Session
+    use_field_ids: bool
+
     def __init__(
         self,
         api_key: str,
@@ -48,6 +52,7 @@ class Api:
         timeout: Optional[TimeoutTuple] = None,
         retry_strategy: Optional[Union[bool, retrying.Retry]] = True,
         endpoint_url: str = "https://api.airtable.com",
+        use_field_ids: bool = False,
     ):
         """
         Args:
@@ -63,6 +68,8 @@ class Api:
                 (see :func:`~pyairtable.retry_strategy` for details).
             endpoint_url: The API endpoint to use. Override this if you are using
                 a debugging or caching proxy.
+            use_field_ids: If ``True``, all API requests will return responses
+                with field IDs instead of field names.
         """
         if retry_strategy is True:
             retry_strategy = retrying.retry_strategy()
@@ -74,6 +81,7 @@ class Api:
         self.endpoint_url = endpoint_url
         self.timeout = timeout
         self.api_key = api_key
+        self.use_field_ids = use_field_ids
 
     @property
     def api_key(self) -> str:

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -230,6 +230,8 @@ class Table:
         """
         if isinstance(formula := options.get("formula"), Formula):
             options["formula"] = to_formula_str(formula)
+        if self.api.use_field_ids:
+            options.setdefault("use_field_ids", self.api.use_field_ids)
         for page in self.api.iterate_requests(
             method="get",
             url=self.url,
@@ -290,7 +292,7 @@ class Table:
         self,
         fields: WritableFields,
         typecast: bool = False,
-        use_field_ids: bool = False,
+        use_field_ids: Optional[bool] = None,
     ) -> RecordDict:
         """
         Create a new record
@@ -304,6 +306,8 @@ class Table:
             typecast: |kwarg_typecast|
             use_field_ids: |kwarg_use_field_ids|
         """
+        if use_field_ids is None:
+            use_field_ids = self.api.use_field_ids
         created = self.api.post(
             url=self.url,
             json={
@@ -318,7 +322,7 @@ class Table:
         self,
         records: Iterable[WritableFields],
         typecast: bool = False,
-        use_field_ids: bool = False,
+        use_field_ids: Optional[bool] = None,
     ) -> List[RecordDict]:
         """
         Create a number of new records in batches.
@@ -343,6 +347,8 @@ class Table:
             use_field_ids: |kwarg_use_field_ids|
         """
         inserted_records = []
+        if use_field_ids is None:
+            use_field_ids = self.api.use_field_ids
 
         # If we got an iterator, exhaust it and collect it into a list.
         records = list(records)
@@ -367,7 +373,7 @@ class Table:
         fields: WritableFields,
         replace: bool = False,
         typecast: bool = False,
-        use_field_ids: bool = False,
+        use_field_ids: Optional[bool] = None,
     ) -> RecordDict:
         """
         Update a particular record ID with the given fields.
@@ -384,6 +390,8 @@ class Table:
             typecast: |kwarg_typecast|
             use_field_ids: |kwarg_use_field_ids|
         """
+        if use_field_ids is None:
+            use_field_ids = self.api.use_field_ids
         method = "put" if replace else "patch"
         updated = self.api.request(
             method=method,
@@ -401,7 +409,7 @@ class Table:
         records: Iterable[UpdateRecordDict],
         replace: bool = False,
         typecast: bool = False,
-        use_field_ids: bool = False,
+        use_field_ids: Optional[bool] = None,
     ) -> List[RecordDict]:
         """
         Update several records in batches.
@@ -417,6 +425,8 @@ class Table:
         """
         updated_records = []
         method = "put" if replace else "patch"
+        if use_field_ids is None:
+            use_field_ids = self.api.use_field_ids
 
         # If we got an iterator, exhaust it and collect it into a list.
         records = list(records)
@@ -442,7 +452,7 @@ class Table:
         key_fields: List[FieldName],
         replace: bool = False,
         typecast: bool = False,
-        use_field_ids: bool = False,
+        use_field_ids: Optional[bool] = None,
     ) -> UpsertResultDict:
         """
         Update or create records in batches, either using ``id`` (if given) or using a set of
@@ -462,6 +472,9 @@ class Table:
         Returns:
             Lists of created/updated record IDs, along with the list of all records affected.
         """
+        if use_field_ids is None:
+            use_field_ids = self.api.use_field_ids
+
         # If we got an iterator, exhaust it and collect it into a list.
         records = list(records)
 

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -197,6 +197,8 @@ class Table:
             user_locale: |kwarg_user_locale|
             use_field_ids: |kwarg_use_field_ids|
         """
+        if self.api.use_field_ids:
+            options.setdefault("use_field_ids", self.api.use_field_ids)
         record = self.api.get(self.record_url(record_id), options=options)
         return assert_typed_dict(RecordDict, record)
 

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -466,7 +466,7 @@ def quoted(value: str) -> str:
     return "'{}'".format(value)
 
 
-def escape_quotes(value: str) -> str:
+def escape_quotes(value: str) -> str:  # pragma: no cover
     r"""
     Ensure any quotes are escaped. Already escaped quotes are ignored.
 

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from posixpath import join as urljoin
 from unittest import mock
 
@@ -10,6 +11,8 @@ from pyairtable.formulas import AND, EQ, Field
 from pyairtable.models.schema import TableSchema
 from pyairtable.testing import fake_id, fake_record
 from pyairtable.utils import chunked
+
+NOW = datetime.now(timezone.utc).isoformat()
 
 
 @pytest.fixture()
@@ -206,29 +209,60 @@ def test_first_none(table: Table, mock_response_single):
         assert rv is None
 
 
-def test_all(table: Table, mock_response_list, mock_records):
-    with Mocker() as mock:
-        mock.get(
-            table.url,
+def test_all(table, requests_mock, mock_response_list, mock_records):
+    requests_mock.get(
+        table.url,
+        status_code=200,
+        json=mock_response_list[0],
+        complete_qs=True,
+    )
+    for n, resp in enumerate(mock_response_list, 1):
+        offset = resp.get("offset", None)
+        if not offset:
+            continue
+        offset_url = table.url + "?offset={}".format(offset)
+        requests_mock.get(
+            offset_url,
             status_code=200,
-            json=mock_response_list[0],
+            json=mock_response_list[1],
             complete_qs=True,
         )
-        for n, resp in enumerate(mock_response_list, 1):
-            offset = resp.get("offset", None)
-            if not offset:
-                continue
-            offset_url = table.url + "?offset={}".format(offset)
-            mock.get(
-                offset_url,
-                status_code=200,
-                json=mock_response_list[1],
-                complete_qs=True,
-            )
-        response = table.all()
+    response = table.all()
 
     for n, resp in enumerate(response):
         assert dict_equals(resp, mock_records[n])
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"view": "Grid view"}, {"view": ["Grid view"]}),
+        ({"page_size": 10}, {"pageSize": ["10"]}),
+        ({"max_records": 10}, {"maxRecords": ["10"]}),
+        ({"fields": ["Name", "Email"]}, {"fields[]": ["Name", "Email"]}),
+        ({"formula": "{Status}='Active'"}, {"filterByFormula": ["{Status}='Active'"]}),
+        ({"cell_format": "json"}, {"cellFormat": ["json"]}),
+        ({"user_locale": "en_US"}, {"userLocale": ["en_US"]}),
+        ({"time_zone": "America/New_York"}, {"timeZone": ["America/New_York"]}),
+        ({"use_field_ids": True}, {"returnFieldsByFieldId": ["1"]}),
+        (
+            {"sort": ["Name", "-Email"]},
+            {
+                "sort[0][direction]": ["asc"],
+                "sort[0][field]": ["Name"],
+                "sort[1][direction]": ["desc"],
+                "sort[1][field]": ["Email"],
+            },
+        ),
+    ],
+)
+def test_all__params(table, requests_mock, kwargs, expected):
+    """
+    Test that parameters to all() get translated to query string correctly.
+    """
+    m = requests_mock.get(table.url, status_code=200, json={"records": []})
+    table.all(**kwargs)
+    assert m.last_request.qs == expected
 
 
 def test_iterate(table: Table, mock_response_list, mock_records):
@@ -458,6 +492,81 @@ def test_delete_view(table, mock_schema, requests_mock):
     m = requests_mock.delete(view._url)
     view.delete()
     assert m.call_count == 1
+
+
+fake_upsert = {"updatedRecords": [], "createdRecords": [], "records": []}
+
+
+@pytest.mark.parametrize("method_name", ("all", "first"))
+def test_use_field_ids__get(table, monkeypatch, requests_mock, method_name):
+    """
+    Test that setting api.use_field_ids=True will change the default behavior
+    (but not the explicit behavior) of the API methods on Table.
+    """
+    m = requests_mock.register_uri("GET", table.url, json={"records": []})
+
+    # by default, we don't pass the param at all
+    method = getattr(table, method_name)
+    method()
+    assert m.called
+    assert "returnFieldsByFieldId" not in m.last_request.qs
+
+    # if use_field_ids=True, we should pass the param...
+    monkeypatch.setattr(table.api, "use_field_ids", True)
+    m.reset()
+    method()
+    assert m.called
+    assert m.last_request.qs["returnFieldsByFieldId"] == ["1"]
+
+    # ...but we can override it
+    m.reset()
+    method(use_field_ids=False)
+    assert m.called
+    assert m.last_request.qs["returnFieldsByFieldId"] == ["0"]
+
+
+@pytest.mark.parametrize(
+    "method_name,method_args,http_method,suffix,response",
+    [
+        ("create", ({"fields": {}}), "POST", "", fake_record()),
+        ("update", ("rec123", {}), "PATCH", "rec123", fake_record()),
+        ("batch_create", ([fake_record()],), "POST", "", {"records": []}),
+        ("batch_update", ([fake_record()],), "PATCH", "", {"records": []}),
+        ("batch_upsert", ([fake_record()], ["Key"]), "PATCH", "", fake_upsert),
+    ],
+)
+def test_use_field_ids__post(
+    table,
+    monkeypatch,
+    requests_mock,
+    method_name,
+    method_args,
+    http_method,
+    suffix,
+    response,
+):
+    url = f"{table.url}/{suffix}".rstrip("/")
+    print(f"{url=}")
+    m = requests_mock.register_uri(http_method, url, json=response)
+
+    # by default, the param is False
+    method = getattr(table, method_name)
+    method(*method_args)
+    assert m.call_count == 1
+    assert m.last_request.json()["returnFieldsByFieldId"] is False
+
+    # if use_field_ids=True, we should pass the param...
+    monkeypatch.setattr(table.api, "use_field_ids", True)
+    m.reset()
+    method(*method_args)
+    assert m.call_count == 1
+    assert m.last_request.json()["returnFieldsByFieldId"] is True
+
+    # ...but we can override it
+    m.reset()
+    method(*method_args, use_field_ids=False)
+    assert m.call_count == 1
+    assert m.last_request.json()["returnFieldsByFieldId"] is False
 
 
 # Helpers


### PR DESCRIPTION
This allows implementers to declare `use_field_ids=True` once, when creating the Api instance, and not have to pass it to each method call thereafter. FYI @jonathanlaniado 

Fixes #365 