### PR TITLE
A couple datetime fields missed in #352

### DIFF
--- a/pyairtable/models/comment.py
+++ b/pyairtable/models/comment.py
@@ -54,7 +54,7 @@ class Comment(
     created_time: datetime
 
     #: The ISO 8601 timestamp of when the comment was last edited.
-    last_updated_time: Optional[str]
+    last_updated_time: Optional[datetime]
 
     #: The account which created the comment.
     author: Collaborator

--- a/pyairtable/models/webhook.py
+++ b/pyairtable/models/webhook.py
@@ -56,10 +56,10 @@ class Webhook(CanDeleteModel, url="bases/{base.id}/webhooks/{self.id}"):
     are_notifications_enabled: bool
     cursor_for_next_payload: int
     is_hook_enabled: bool
-    last_successful_notification_time: Optional[str]
+    last_successful_notification_time: Optional[datetime]
     notification_url: Optional[str]
     last_notification_result: Optional["WebhookNotificationResult"]
-    expiration_time: Optional[str]
+    expiration_time: Optional[datetime]
     specification: "WebhookSpecification"
 
     def enable_notifications(self) -> None:


### PR DESCRIPTION
In #352 we changed all models to store `datetime.datetime` instead of `str` for representing timestamps, but we missed a couple places.