### PR TITLE
Fail `tox -e coverage` if under 100%

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
 [testenv:coverage]
 passenv = COVERAGE_FORMAT
 commands =
-    python -m pytest -m 'not integration' --cov=pyairtable --cov-report={env:COVERAGE_FORMAT:html}
+    python -m pytest -m 'not integration' --cov=pyairtable --cov-report={env:COVERAGE_FORMAT:html} --cov-fail-under=100
 
 [testenv:docs]
 basepython = python3.8


### PR DESCRIPTION
I've noticed that the Codecov integration is failing more often than not (see example run [here](https://github.com/gtalarico/pyairtable/actions/runs/10858385997/job/30136298411?pr=391)). To make it less likely we'll fail on coverage, I'm adding a flag to tox.ini that will fail the `tox -e coverage` part of the test suite if coverage is under 100%.