### PR TITLE
Add support for 3.13, drop support for 3.8

### DIFF
--- a/.github/workflows/test_lint_deploy.yml
+++ b/.github/workflows/test_lint_deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_lint_deploy.yml
+++ b/.github/workflows/test_lint_deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3
@@ -56,10 +56,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install pypa/build
         run: >-

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -43,10 +43,19 @@ Changelog
 * Changed the return type of :meth:`Model.save <pyairtable.orm.Model.save>`
   from ``bool`` to :class:`~pyairtable.orm.SaveResult`.
   - `PR #387 <https://github.com/gtalarico/pyairtable/pull/387>`_
+* Added :class:`pyairtable.testing.MockAirtable` for easier testing.
+  - `PR #388 <https://github.com/gtalarico/pyairtable/pull/388>`_
 * Added support for `Upload attachment <https://airtable.com/developers/web/api/upload-attachment>`_
   via :meth:`Table.upload_attachment <pyairtable.Table.upload_attachment>`
   or :meth:`AttachmentsList.upload <pyairtable.orm.lists.AttachmentsList.upload>`.
-* Added :class:`pyairtable.testing.MockAirtable` for easier testing.
+  - `PR #389 <https://github.com/gtalarico/pyairtable/pull/389>`_
+
+2.3.4 (2024-10-21)
+------------------------
+
+* Fixed a crash at import time under Python 3.13.
+  - `PR #395 <https://github.com/gtalarico/pyairtable/pull/395>`_,
+    `PR #396 <https://github.com/gtalarico/pyairtable/pull/396>`_.
 
 2.3.3 (2024-03-22)
 ------------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -49,35 +49,36 @@ Changelog
   via :meth:`Table.upload_attachment <pyairtable.Table.upload_attachment>`
   or :meth:`AttachmentsList.upload <pyairtable.orm.lists.AttachmentsList.upload>`.
   - `PR #389 <https://github.com/gtalarico/pyairtable/pull/389>`_
+* Dropped support for Python 3.8.
+  - `PR #395 <https://github.com/gtalarico/pyairtable/pull/395>`_
 
 2.3.4 (2024-10-21)
 ------------------------
 
 * Fixed a crash at import time under Python 3.13.
-  - `PR #395 <https://github.com/gtalarico/pyairtable/pull/395>`_,
-    `PR #396 <https://github.com/gtalarico/pyairtable/pull/396>`_.
+    `PR #396 <https://github.com/gtalarico/pyairtable/pull/396>`_
 
 2.3.3 (2024-03-22)
 ------------------------
 
 * Fixed a bug affecting ORM Meta values which are computed at runtime.
-  - `PR #357 <https://github.com/gtalarico/pyairtable/pull/357>`_.
+  - `PR #357 <https://github.com/gtalarico/pyairtable/pull/357>`_
 * Fixed documentation for the ORM module.
-  - `PR #356 <https://github.com/gtalarico/pyairtable/pull/356>`_.
+  - `PR #356 <https://github.com/gtalarico/pyairtable/pull/356>`_
 
 2.3.2 (2024-03-18)
 ------------------------
 
 * Fixed a bug affecting :func:`pyairtable.metadata.get_table_schema`.
-  - `PR #349 <https://github.com/gtalarico/pyairtable/pull/349>`_.
+  - `PR #349 <https://github.com/gtalarico/pyairtable/pull/349>`_
 
 2.3.1 (2024-03-14)
 ------------------------
 
 * Fixed a bug affecting how timezones are parsed by :class:`~pyairtable.orm.fields.DatetimeField`.
-  - `PR #342 <https://github.com/gtalarico/pyairtable/pull/342>`_.
+  - `PR #342 <https://github.com/gtalarico/pyairtable/pull/342>`_
 * Fixed a bug affecting :meth:`~pyairtable.Base.create_table`.
-  - `PR #345 <https://github.com/gtalarico/pyairtable/pull/345>`_.
+  - `PR #345 <https://github.com/gtalarico/pyairtable/pull/345>`_
 
 2.3.0 (2024-02-25)
 ------------------------
@@ -86,10 +87,10 @@ Changelog
   Read more in :ref:`Migrating from 2.2 to 2.3`.
 * Added support for :ref:`managing permissions and shares`
   and :ref:`managing users`.
-  - `PR #337 <https://github.com/gtalarico/pyairtable/pull/337>`_.
+  - `PR #337 <https://github.com/gtalarico/pyairtable/pull/337>`_
 * Added :meth:`Enterprise.audit_log <pyairtable.Enterprise.audit_log>`
   to iterate page-by-page through `audit log events <https://airtable.com/developers/web/api/audit-logs-overview>`__.
-  - `PR #330 <https://github.com/gtalarico/pyairtable/pull/330>`_.
+  - `PR #330 <https://github.com/gtalarico/pyairtable/pull/330>`_
 * :meth:`Api.base <pyairtable.Api.base>`,
   :meth:`Api.table <pyairtable.Api.table>`,
   and :meth:`Base.table <pyairtable.Base.table>`
@@ -97,7 +98,7 @@ Changelog
   unless the caller passes a new keyword argument ``force=True``.
   This allows callers to validate the IDs/names of many bases or tables at once
   without having to perform expensive network overhead each time.
-  - `PR #336 <https://github.com/gtalarico/pyairtable/pull/336>`_.
+  - `PR #336 <https://github.com/gtalarico/pyairtable/pull/336>`_
 
 2.2.2 (2024-01-28)
 ------------------------
@@ -105,7 +106,7 @@ Changelog
 * Enterprise methods :meth:`~pyairtable.Enterprise.user`,
   :meth:`~pyairtable.Enterprise.users`, and :meth:`~pyairtable.Enterprise.group`
   now return collaborations by default.
-  - `PR #332 <https://github.com/gtalarico/pyairtable/pull/332>`_.
+  - `PR #332 <https://github.com/gtalarico/pyairtable/pull/332>`_
 * Added more helper functions for formulas:
   :func:`~pyairtable.formulas.LESS`,
   :func:`~pyairtable.formulas.LESS_EQUAL`,
@@ -113,36 +114,36 @@ Changelog
   :func:`~pyairtable.formulas.GREATER_EQUAL`,
   and
   :func:`~pyairtable.formulas.NOT_EQUAL`.
-  - `PR #323 <https://github.com/gtalarico/pyairtable/pull/323>`_.
+  - `PR #323 <https://github.com/gtalarico/pyairtable/pull/323>`_
 
 2.2.1 (2023-11-28)
 ------------------------
 
 * :meth:`~pyairtable.Table.update` now accepts ``return_fields_by_field_id=True``
-  - `PR #320 <https://github.com/gtalarico/pyairtable/pull/320>`_.
+  - `PR #320 <https://github.com/gtalarico/pyairtable/pull/320>`_
 
 2.2.0 (2023-11-13)
 ------------------------
 
 * Fixed a bug in how webhook notification signatures are validated
-  - `PR #312 <https://github.com/gtalarico/pyairtable/pull/312>`_.
+  - `PR #312 <https://github.com/gtalarico/pyairtable/pull/312>`_
 * Added support for reading and modifying :doc:`metadata`
-  - `PR #311 <https://github.com/gtalarico/pyairtable/pull/311>`_.
+  - `PR #311 <https://github.com/gtalarico/pyairtable/pull/311>`_
 * Added support for the 'AI Text' field type
-  - `PR #310 <https://github.com/gtalarico/pyairtable/pull/310>`_.
+  - `PR #310 <https://github.com/gtalarico/pyairtable/pull/310>`_
 * Batch methods can now accept generators or iterators, not just lists
-  - `PR #308 <https://github.com/gtalarico/pyairtable/pull/308>`_.
+  - `PR #308 <https://github.com/gtalarico/pyairtable/pull/308>`_
 * Fixed a few documentation errors -
   `PR #301 <https://github.com/gtalarico/pyairtable/pull/301>`_,
-  `PR #306 <https://github.com/gtalarico/pyairtable/pull/306>`_.
+  `PR #306 <https://github.com/gtalarico/pyairtable/pull/306>`_
 
 2.1.0 (2023-08-18)
 ------------------------
 
 * Added classes and methods for managing :ref:`webhooks`.
-  - `PR #291 <https://github.com/gtalarico/pyairtable/pull/291>`_.
+  - `PR #291 <https://github.com/gtalarico/pyairtable/pull/291>`_
 * Added compatibility with Pydantic 2.0.
-  - `PR #288 <https://github.com/gtalarico/pyairtable/pull/288>`_.
+  - `PR #288 <https://github.com/gtalarico/pyairtable/pull/288>`_
 
 2.0.0 (2023-07-31)
 ------------------------
@@ -150,55 +151,55 @@ Changelog
 See :ref:`Migrating from 1.x to 2.0` for detailed migration notes.
 
 * Added :class:`~pyairtable.models.Comment` class; see :ref:`Commenting on Records`.
-  - `PR #282 <https://github.com/gtalarico/pyairtable/pull/282>`_.
+  - `PR #282 <https://github.com/gtalarico/pyairtable/pull/282>`_
 * :meth:`~pyairtable.Table.batch_upsert` now returns the full payload from the Airtable API.
-  - `PR #281 <https://github.com/gtalarico/pyairtable/pull/281>`_.
+  - `PR #281 <https://github.com/gtalarico/pyairtable/pull/281>`_
 * :ref:`ORM` module is no longer experimental and has a stable API.
-  - `PR #277 <https://github.com/gtalarico/pyairtable/pull/277>`_.
+  - `PR #277 <https://github.com/gtalarico/pyairtable/pull/277>`_
 * Added :meth:`Model.batch_save <pyairtable.orm.Model.batch_save>`
   and :meth:`Model.batch_delete <pyairtable.orm.Model.batch_delete>`.
-  - `PR #274 <https://github.com/gtalarico/pyairtable/pull/277>`_.
+  - `PR #274 <https://github.com/gtalarico/pyairtable/pull/277>`_
 * Added :meth:`Api.whoami <pyairtable.Api.whoami>` method.
-  - `PR #273 <https://github.com/gtalarico/pyairtable/pull/273>`_.
+  - `PR #273 <https://github.com/gtalarico/pyairtable/pull/273>`_
 * pyAirtable will automatically retry requests when throttled by Airtable's QPS.
-  - `PR #272 <https://github.com/gtalarico/pyairtable/pull/272>`_.
+  - `PR #272 <https://github.com/gtalarico/pyairtable/pull/272>`_
 * ORM Meta attributes can now be defined as callables.
-  - `PR #268 <https://github.com/gtalarico/pyairtable/pull/268>`_.
+  - `PR #268 <https://github.com/gtalarico/pyairtable/pull/268>`_
 * Removed ``ApiAbstract``.
-  - `PR #267 <https://github.com/gtalarico/pyairtable/pull/267>`_.
+  - `PR #267 <https://github.com/gtalarico/pyairtable/pull/267>`_
 * Implemented strict type annotations on all functions and methods.
-  - `PR #263 <https://github.com/gtalarico/pyairtable/pull/263>`_.
+  - `PR #263 <https://github.com/gtalarico/pyairtable/pull/263>`_
 * Return Model instances, not dicts, from
   :meth:`Model.all <pyairtable.orm.Model.all>` and :meth:`Model.first <pyairtable.orm.Model.first>`.
-  - `PR #262 <https://github.com/gtalarico/pyairtable/pull/262>`_.
+  - `PR #262 <https://github.com/gtalarico/pyairtable/pull/262>`_
 * Dropped support for Python 3.7.
-  - `PR #261 <https://github.com/gtalarico/pyairtable/pull/261>`_.
+  - `PR #261 <https://github.com/gtalarico/pyairtable/pull/261>`_
 * :ref:`ORM` supports all Airtable field types.
-  - `PR #260 <https://github.com/gtalarico/pyairtable/pull/260>`_.
+  - `PR #260 <https://github.com/gtalarico/pyairtable/pull/260>`_
 
 1.5.0 (2023-05-15)
 -------------------------
 
 * Add support for Airtable's upsert operation (see :ref:`Updating Records`).
-  - `PR #255 <https://github.com/gtalarico/pyairtable/pull/255>`_.
+  - `PR #255 <https://github.com/gtalarico/pyairtable/pull/255>`_
 * Fix ``return_fields_by_field_id`` in :meth:`~pyairtable.Api.batch_create` and :meth:`~pyairtable.Api.batch_update`.
-  - `PR #252 <https://github.com/gtalarico/pyairtable/pull/252>`_.
+  - `PR #252 <https://github.com/gtalarico/pyairtable/pull/252>`_
 * Fix ORM crash when Airtable returned additional fields.
-  - `PR #250 <https://github.com/gtalarico/pyairtable/pull/250>`_.
+  - `PR #250 <https://github.com/gtalarico/pyairtable/pull/250>`_
 * Use POST for URLs that are longer than the 16k character limit set by the Airtable API.
-  - `PR #247 <https://github.com/gtalarico/pyairtable/pull/247>`_.
+  - `PR #247 <https://github.com/gtalarico/pyairtable/pull/247>`_
 * Added ``endpoint_url=`` param to :class:`~pyairtable.Table`, :class:`~pyairtable.Base`, :class:`~pyairtable.Api`.
-  - `PR #243 <https://github.com/gtalarico/pyairtable/pull/243>`_.
+  - `PR #243 <https://github.com/gtalarico/pyairtable/pull/243>`_
 * Added ORM :class:`~pyairtable.orm.fields.LookupField`.
-  - `PR #182 <https://github.com/gtalarico/pyairtable/pull/182>`_.
+  - `PR #182 <https://github.com/gtalarico/pyairtable/pull/182>`_
 * Dropped support for Python 3.6 (reached end of life 2021-12-23)
-  - `PR #213 <https://github.com/gtalarico/pyairtable/pull/213>`_.
+  - `PR #213 <https://github.com/gtalarico/pyairtable/pull/213>`_
 
 1.4.0 (2022-12-14)
 -------------------------
 
 * Added :func:`pyairtable.retry_strategy`.
-* Misc fix in sleep for batch requests `PR #180 <https://github.com/gtalarico/pyairtable/pull/180>`_.
+* Misc fix in sleep for batch requests `PR #180 <https://github.com/gtalarico/pyairtable/pull/180>`_
 
 1.3.0 (2022-08-23)
 -------------------------
@@ -210,7 +211,7 @@ See :ref:`Migrating from 1.x to 2.0` for detailed migration notes.
 1.2.0 (2022-07-09)
 -------------------------
 
-* Fixed missing rate limit in :meth:`~pyairtable.Api.batch_update` - `PR #162 <https://github.com/gtalarico/pyairtable/pull/162>`_.
+* Fixed missing rate limit in :meth:`~pyairtable.Api.batch_update` - `PR #162 <https://github.com/gtalarico/pyairtable/pull/162>`_
 * Added support for new parameter `return_fields_by_field_id` - `PR #161 <https://github.com/gtalarico/pyairtable/pull/161>`_. See updated :ref:`Parameters`.
 * Added new ``OR`` formula - `PR #148 <https://github.com/gtalarico/pyairtable/pull/148>`_. See :mod:`pyairtable.formulas`.
 

--- a/pyairtable/models/_base.py
+++ b/pyairtable/models/_base.py
@@ -29,9 +29,6 @@ class AirtableModel(pydantic.BaseModel):
         # Allow both base_invite_links= and baseInviteLinks= in constructor
         allow_population_by_field_name = True
 
-        # We'll assume this in a couple different places
-        underscore_attrs_are_private = True
-
     _raw: Any = pydantic.PrivateAttr()
 
     def __init__(self, **data: Any) -> None:
@@ -138,7 +135,7 @@ class RestfulModel(AirtableModel):
 
     _api: "pyairtable.api.api.Api" = pydantic.PrivateAttr()
     _url: str = pydantic.PrivateAttr(default="")
-    _url_context: Any = None
+    _url_context: Any = pydantic.PrivateAttr(default=None)
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         cls.__url_pattern = kwargs.pop("url", cls.__url_pattern)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,5 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py39']
 include = '\.pyi?$'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,11 @@ sphinxext-opengraph
 revitron-sphinx-theme @ git+https://github.com/gtalarico/revitron-sphinx-theme.git@40f4b09fa5c199e3844153ef973a1155a56981dd
 sphinx-autodoc-typehints
 autodoc-pydantic<2
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
 
 # Packaging
 wheel==0.38.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,11 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     pre-commit
-    mypy-py3{8,9,10,11,12}
-    py3{8,9,10,11,12}{,-pydantic1,-requestsmin}
+    mypy-py3{8,9,10,11,12,13}
+    py3{8,9,10,11,12,13}{,-pydantic1,-requestsmin}
     integration
     coverage
 
@@ -13,20 +13,7 @@ python =
     3.10: py310, mypy-py310
     3.11: py311, mypy-py311
     3.12: coverage, mypy-py312
-
-[testenv:pre-commit]
-deps = pre-commit
-commands = pre-commit run --all-files
-
-[testenv:mypy,mypy-py3{8,9,10,11,12}]
-basepython =
-    py38: python3.8
-    py39: python3.9
-    py310: python3.10
-    py311: python3.11
-    py312: python3.12
-deps = -r requirements-dev.txt
-commands = mypy --strict pyairtable tests/test_typing.py
+    3.13: py313, mypy-py313
 
 [testenv]
 passenv =
@@ -40,6 +27,21 @@ deps =
     -r requirements-test.txt
     requestsmin: requests==2.22.0  # Keep in sync with setup.cfg
     pydantic1: pydantic<2  # Lots of projects still use 1.x
+
+[testenv:pre-commit]
+deps = pre-commit
+commands = pre-commit run --all-files
+
+[testenv:mypy,mypy-py3{8,9,10,11,12,13}]
+basepython =
+    py38: python3.8
+    py39: python3.9
+    py310: python3.10
+    py311: python3.11
+    py312: python3.12
+    py313: python3.13
+deps = -r requirements-dev.txt
+commands = mypy --strict pyairtable tests/test_typing.py
 
 [testenv:integration]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 envlist =
     pre-commit
-    mypy-py3{8,9,10,11,12,13}
-    py3{8,9,10,11,12,13}{,-pydantic1,-requestsmin}
+    mypy-py3{9,10,11,12,13}
+    py3{9,10,11,12,13}{,-pydantic1,-requestsmin}
     integration
     coverage
 
 [gh-actions]
 python =
-    3.8: py38, mypy-py38
     3.9: py39, mypy-py39
     3.10: py310, mypy-py310
     3.11: py311, mypy-py311
@@ -32,9 +31,8 @@ deps =
 deps = pre-commit
 commands = pre-commit run --all-files
 
-[testenv:mypy,mypy-py3{8,9,10,11,12,13}]
+[testenv:mypy,mypy-py3{9,10,11,12,13}]
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
@@ -53,7 +51,7 @@ commands =
     python -m pytest -m 'not integration' --cov=pyairtable --cov-report={env:COVERAGE_FORMAT:html} --cov-fail-under=100
 
 [testenv:docs]
-basepython = python3.8
+basepython = python3.9
 deps =
     -r requirements-dev.txt
 commands =


### PR DESCRIPTION
Python 3.13 appears to have introduced some sort of change to how it handles classes with multiple bases, and that is causing problems with the `pydantic.v1` shim that we use for backwards compatibility. See #394

In 1d225f828f1561e380194f30d7678e33bfdc8b80 I attempted refactoring one of the more complicated base classes to not use multiple inheritance, but it turns out that was a red herring. The real culprit was `underscore_attrs_are_private = True`, which changes pydantic's behavior in some way that causes problems on 3.13. I'm honestly still a bit puzzled why, but I am not sure I care too much. This branch fixes it.