### PR TITLE
Refactored methods/properties for constructing URLs in the API

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -53,12 +53,14 @@ Changelog
   - `PR #395 <https://github.com/gtalarico/pyairtable/pull/395>`_
 * Dropped support for Pydantic 1.x.
   - `PR #397 <https://github.com/gtalarico/pyairtable/pull/397>`_
+* Refactored methods/properties for constructing URLs in the API.
+  - `PR #399 <https://github.com/gtalarico/pyairtable/pull/399>`_
 
 2.3.4 (2024-10-21)
 ------------------------
 
 * Fixed a crash at import time under Python 3.13.
-    `PR #396 <https://github.com/gtalarico/pyairtable/pull/396>`_
+  - `PR #396 <https://github.com/gtalarico/pyairtable/pull/396>`_
 
 2.3.3 (2024-03-22)
 ------------------------

--- a/docs/source/migrations.rst
+++ b/docs/source/migrations.rst
@@ -27,6 +27,37 @@ Deprecated metadata module removed
 The 3.0 release removed the ``pyairtable.metadata`` module. For supported alternatives,
 see :doc:`metadata`.
 
+Changes to generating URLs
+---------------------------------------------
+
+The following properties and methods for constructing URLs have been renamed or removed.
+These methods now return instances of :class:`~pyairtable.utils.Url`, which is a
+subclass of ``str`` that has some overloaded operators. See docs for more details.
+
+.. list-table::
+    :header-rows: 1
+
+    * - Building a URL in 2.x
+      - Building a URL in 3.0
+    * - ``table.url``
+      - ``table.urls.records``
+    * - ``table.record_url(record_id)``
+      - ``table.urls.record(record_id)``
+    * - ``table.meta_url("one", "two")``
+      - ``table.urls.meta / "one" / "two"``
+    * - ``table.meta_url(*parts)``
+      - ``table.urls.meta // parts``
+    * - ``base.url``
+      - (removed; was invalid)
+    * - ``base.meta_url("one", "two")``
+      - ``base.urls.meta / "one" / "two"``
+    * - ``base.webhooks_url()``
+      - ``base.urls.webhooks``
+    * - ``enterprise.url``
+      - ``enterprise.urls.meta``
+    * - ``workspace.url``
+      - ``workspace.urls.meta``
+
 Changes to the formulas module
 ---------------------------------------------
 

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -546,7 +546,7 @@ class Collaborations(AirtableModel):
 class UserInfo(
     CanUpdateModel,
     CanDeleteModel,
-    url="{enterprise.url}/users/{self.id}",
+    url="{enterprise.urls.users}/{self.id}",
     writable=["state", "email", "first_name", "last_name"],
 ):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,12 +191,12 @@ def schema_obj(api, sample_json):
 @pytest.fixture
 def mock_base_metadata(base, sample_json, requests_mock):
     base_json = sample_json("BaseCollaborators")
-    requests_mock.get(base.api.build_url("meta/bases"), json=sample_json("Bases"))
-    requests_mock.get(base.meta_url(), json=base_json)
-    requests_mock.get(base.meta_url("tables"), json=sample_json("BaseSchema"))
-    requests_mock.get(base.meta_url("shares"), json=sample_json("BaseShares"))
+    requests_mock.get(base.api.urls.bases, json=sample_json("Bases"))
+    requests_mock.get(base.urls.meta, json=base_json)
+    requests_mock.get(base.urls.tables, json=sample_json("BaseSchema"))
+    requests_mock.get(base.urls.shares, json=sample_json("BaseShares"))
     for pbd_id, pbd_json in base_json["interfaces"].items():
-        requests_mock.get(base.meta_url("interfaces", pbd_id), json=pbd_json)
+        requests_mock.get(base.urls.interface(pbd_id), json=pbd_json)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,7 +202,7 @@ def mock_base_metadata(base, sample_json, requests_mock):
 @pytest.fixture
 def mock_workspace_metadata(workspace, sample_json, requests_mock):
     workspace_json = sample_json("WorkspaceCollaborators")
-    requests_mock.get(workspace.url, json=workspace_json)
+    requests_mock.get(workspace.urls.meta, json=workspace_json)
 
 
 @pytest.fixture

--- a/tests/test_api_api.py
+++ b/tests/test_api_api.py
@@ -7,7 +7,7 @@ from pyairtable import Api, Base, Table  # noqa
 
 @pytest.fixture
 def mock_bases_endpoint(api, requests_mock, sample_json):
-    return requests_mock.get(api.build_url("meta/bases"), json=sample_json("Bases"))
+    return requests_mock.get(api.urls.bases, json=sample_json("Bases"))
 
 
 def test_repr(api):

--- a/tests/test_api_workspace.py
+++ b/tests/test_api_workspace.py
@@ -16,7 +16,9 @@ def workspace(api, workspace_id):
 
 @pytest.fixture
 def mock_info(workspace, requests_mock, sample_json):
-    return requests_mock.get(workspace.url, json=sample_json("WorkspaceCollaborators"))
+    return requests_mock.get(
+        workspace.urls.meta, json=sample_json("WorkspaceCollaborators")
+    )
 
 
 def test_collaborators(workspace, mock_info):
@@ -39,7 +41,7 @@ def test_bases(workspace, mock_info):
 
 
 def test_create_base(workspace, requests_mock, sample_json):
-    url = workspace.api.build_url("meta/bases")
+    url = workspace.api.urls.bases
     requests_mock.get(url, json=sample_json("Bases"))
     requests_mock.post(url, json={"id": "appLkNDICXNqxSDhG"})
     base = workspace.create_base("Base Name", [])
@@ -48,7 +50,9 @@ def test_create_base(workspace, requests_mock, sample_json):
 
 
 def test_delete(workspace, requests_mock):
-    m = requests_mock.delete(workspace.url, json={"id": workspace.id, "deleted": True})
+    m = requests_mock.delete(
+        workspace.urls.meta, json={"id": workspace.id, "deleted": True}
+    )
     workspace.delete()
     assert m.call_count == 1
 
@@ -73,7 +77,7 @@ def test_move_base(
     expected,
     requests_mock,
 ):
-    m = requests_mock.post(workspace.url + "/moveBase")
+    m = requests_mock.post(workspace.urls.move_base)
     workspace.move_base(locals()[base_param], locals()[workspace_param], **kwargs)
     assert m.call_count == 1
     assert m.request_history[-1].json() == {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,14 +27,12 @@ def mock_metadata(
     user_info = sample_json("UserInfo")
     user_group = sample_json("UserGroup")
     enterprise_info = sample_json("EnterpriseInfo")
-    requests_mock.get(api.build_url("meta/whoami"), json={"id": user_id})
-    requests_mock.get(enterprise.url, json=enterprise_info)
-    requests_mock.get(f"{enterprise.url}/users/{user_id}", json=user_info)
-    requests_mock.get(f"{enterprise.url}/users", json={"users": [user_info]})
+    requests_mock.get(api.urls.whoami, json={"id": user_id})
+    requests_mock.get(enterprise.urls.meta, json=enterprise_info)
+    requests_mock.get(enterprise.urls.users, json={"users": [user_info]})
+    requests_mock.get(enterprise.urls.user(user_id), json=user_info)
     for group_id in enterprise_info["groupIds"]:
-        requests_mock.get(
-            enterprise.api.build_url(f"meta/groups/{group_id}"), json=user_group
-        )
+        requests_mock.get(enterprise.urls.group(group_id), json=user_group)
 
 
 @pytest.fixture

--- a/tests/test_models_comment.py
+++ b/tests/test_models_comment.py
@@ -16,7 +16,7 @@ def comment_json(sample_json):
 
 @pytest.fixture
 def comment(comment_json, table):
-    record_url = table.record_url(RECORD_ID)
+    record_url = table.urls.record(RECORD_ID)
     return Comment.from_api(comment_json, table.api, context={"record_url": record_url})
 
 

--- a/tests/test_models_schema.py
+++ b/tests/test_models_schema.py
@@ -161,9 +161,9 @@ def test_workspace_collaborators__add(api, kind, id, requests_mock, sample_json)
     """
     workspace_json = sample_json("WorkspaceCollaborators")
     workspace = api.workspace(workspace_json["id"])
-    requests_mock.get(workspace.url, json=workspace_json)
-    m = requests_mock.post(f"{workspace.url}/collaborators", body="")
+    requests_mock.get(workspace.urls.meta, json=workspace_json)
     method = getattr(workspace.collaborators(), f"add_{kind}")
+    m = requests_mock.post(workspace.urls.collaborators, body="")
     method(id, "read")
     assert m.call_count == 1
     assert m.last_request.json() == {

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -208,7 +208,7 @@ def test_linked_record():
     assert not contact.address[0].street
 
     with Mocker() as mock:
-        url = Address.meta.table.record_url(address.id)
+        url = Address.meta.table.urls.record(address.id)
         mock.get(url, status_code=200, json=record)
         contact.address[0].fetch()
 
@@ -227,11 +227,11 @@ def test_linked_record_can_be_saved(requests_mock, access_linked_records):
     """
     address_json = fake_record(Number=123, Street="Fake St")
     address_id = address_json["id"]
-    address_url_re = re.escape(Address.meta.table.url + "?filterByFormula=")
+    address_url_re = re.escape(Address.meta.table.urls.records + "?filterByFormula=")
     contact_json = fake_record(Email="alice@example.com", Link=[address_id])
     contact_id = contact_json["id"]
-    contact_url = Contact.meta.table.record_url(contact_id)
-    contact_url_re = re.escape(Contact.meta.table.url + "?filterByFormula=")
+    contact_url = Contact.meta.table.urls.record(contact_id)
+    contact_url_re = re.escape(Contact.meta.table.urls.records + "?filterByFormula=")
     requests_mock.get(re.compile(address_url_re), json={"records": [address_json]})
     requests_mock.get(re.compile(contact_url_re), json={"records": [contact_json]})
     requests_mock.get(contact_url, json=contact_json)
@@ -290,12 +290,12 @@ def test_undeclared_field(requests_mock, test_case):
     )
 
     requests_mock.get(
-        Address.meta.table.url,
+        Address.meta.table.urls.records,
         status_code=200,
         json={"records": [record]},
     )
     requests_mock.get(
-        Address.meta.table.record_url(record["id"]),
+        Address.meta.table.urls.record(record["id"]),
         status_code=200,
         json=record,
     )

--- a/tests/test_orm_model.py
+++ b/tests/test_orm_model.py
@@ -223,8 +223,8 @@ def test_from_ids(mock_api):
     contacts = FakeModel.from_ids(fake_ids)
     mock_api.assert_called_once_with(
         method="get",
-        url=FakeModel.meta.table.url,
-        fallback=("post", FakeModel.meta.table.url + "/listRecords"),
+        url=FakeModel.meta.table.urls.records,
+        fallback=("post", FakeModel.meta.table.urls.records_post),
         options={
             "formula": (
                 "OR(%s)" % ", ".join(f"RECORD_ID()='{id}'" for id in sorted(fake_ids))
@@ -295,7 +295,10 @@ def test_get_fields_by_id(fake_records_by_id):
     """
     with Mocker() as mock:
         mock.get(
-            f"{FakeModelByIds.meta.table.url}?&returnFieldsByFieldId=1&cellFormat=json",
+            FakeModelByIds.meta.table.urls.records.add_qs(
+                returnFieldsByFieldId=1,
+                cellFormat="json",
+            ),
             json=fake_records_by_id,
             complete_qs=True,
             status_code=200,

--- a/tests/test_orm_model__memoization.py
+++ b/tests/test_orm_model__memoization.py
@@ -47,24 +47,24 @@ def record_mocks(requests_mock):
 
     # for Model.all
     mocks.get_authors = requests_mock.get(
-        Author.meta.table.url,
+        Author.meta.table.urls.records,
         json={"records": list(mocks.authors.values())},
     )
     mocks.get_books = requests_mock.get(
-        Book.meta.table.url,
+        Book.meta.table.urls.records,
         json={"records": list(mocks.books.values())},
     )
 
     # for Model.from_id
     mocks.get_author = {
         record_id: requests_mock.get(
-            Author.meta.table.record_url(record_id), json=record_data
+            Author.meta.table.urls.record(record_id), json=record_data
         )
         for record_id, record_data in mocks.authors.items()
     }
     mocks.get_book = {
         record_id: requests_mock.get(
-            Book.meta.table.record_url(record_id), json=record_data
+            Book.meta.table.urls.record(record_id), json=record_data
         )
         for record_id, record_data in mocks.books.items()
     }

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -30,7 +30,7 @@ def test_params_integration(table, mock_records, mock_response_iterator):
             "&returnFieldsByFieldId=1"
             ""
         )
-        mock_url = "{0}?{1}".format(table.url, url_params)
+        mock_url = "{0}?{1}".format(table.urls.records, url_params)
         m.get(mock_url, status_code=200, json=mock_response_iterator)
         response = table.all(**params)
     for n, resp in enumerate(response):

--- a/tests/test_testing__mock_airtable.py
+++ b/tests/test_testing__mock_airtable.py
@@ -246,7 +246,7 @@ def test_passthrough(mock_airtable, requests_mock, base, monkeypatch):
     """
     Test that we can temporarily pass through unhandled methods to the requests library.
     """
-    requests_mock.get(base.meta_url("tables"), json={"tables": []})
+    requests_mock.get(base.urls.tables, json={"tables": []})
 
     with monkeypatch.context() as mctx:
         mctx.setattr(mock_airtable, "passthrough", True)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     # Ensure the type signatures for pyairtable.Base don't change.
     base = pyairtable.Base(api, base_id)
     assert_type(base.table(table_name), pyairtable.Table)
-    assert_type(base.url, str)
+    assert_type(base.id, str)
 
     # Ensure the type signatures for pyairtable.Table don't change.
     table = pyairtable.Table(None, base, table_name)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -10,6 +10,7 @@ from typing_extensions import assert_type
 import pyairtable
 import pyairtable.api.types as T
 import pyairtable.orm.lists as L
+import pyairtable.utils
 from pyairtable import orm
 
 if TYPE_CHECKING:
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 
     # Ensure the type signatures for pyairtable.Api don't change.
     api = pyairtable.Api(access_token)
-    assert_type(api.build_url("foo", "bar"), str)
+    assert_type(api.build_url("foo", "bar"), pyairtable.utils.Url)
     assert_type(api.base(base_id), pyairtable.Base)
     assert_type(api.table(base_id, table_name), pyairtable.Table)
     assert_type(api.whoami(), T.UserAndScopesDict)

--- a/tests/test_url_escape.py
+++ b/tests/test_url_escape.py
@@ -17,4 +17,4 @@ def test_url_escape(base, table_name, escaped):
     table names (which Airtable *will* allow).
     """
     table = base.table(table_name)
-    assert table.url.endswith(escaped)
+    assert table.urls.records.endswith(escaped)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -148,3 +148,88 @@ def test_fieldgetter__required_str():
     assert get_abc_require_b(record) == ("one", "two")
     with pytest.raises(KeyError):
         get_abc_require_b(fake_record(Alpha="one"))
+
+
+def test_url_builder(base):
+    class Example(utils.UrlBuilder):
+        static = "one/two/three"
+        with_attr = "id/{id}"
+        with_self_attr = "self.id/{self.id}"
+        with_property = "self.name/{self.name}"
+        _ignored = "ignored"
+
+    urls = Example(base)
+    assert urls.static == "https://api.airtable.com/v0/one/two/three"
+    assert urls.with_attr == f"https://api.airtable.com/v0/id/{base.id}"
+    assert urls.with_self_attr == f"https://api.airtable.com/v0/self.id/{base.id}"
+    assert urls.with_property == f"https://api.airtable.com/v0/self.name/{base.name}"
+    assert urls._ignored == "ignored"
+
+
+@pytest.mark.parametrize("obj", [None, object(), {"api": object()}])
+def test_url_builder__invalid_context(obj):
+    with pytest.raises(TypeError):
+        utils.UrlBuilder(obj)
+
+
+def test_url_builder__modifies_docstring():
+    """
+    This test is a bit meta, but it ensures that anyone else who wants to use UrlBuilder
+    can skip docstring creation by passing skip_docstring=True
+    """
+
+    class NormalBehavior(utils.UrlBuilder):
+        test = utils.Url("https://example.com")
+
+    class MissingDocstring(utils.UrlBuilder, skip_docstring=True):
+        test = utils.Url("https://example.com")
+
+    class ExistingDocstring(utils.UrlBuilder, skip_docstring=True):
+        """This is the docstring."""
+
+        test = utils.Url("https://example.com")
+
+    assert "URLs associated with :class:" in NormalBehavior.__doc__
+    assert MissingDocstring.__doc__ is None
+    assert ExistingDocstring.__doc__ == "This is the docstring."
+
+
+def test_url():
+    v = utils.Url("https://example.com")
+    assert v == "https://example.com"
+    assert v / "foo/bar" / "baz" == "https://example.com/foo/bar/baz"
+    assert v // [1, 2, "a", "b"] == "https://example.com/1/2/a/b"
+    assert v & {"a": 1, "b": [2, 3, 4]} == "https://example.com?a=1&b=2&b=3&b=4"
+    assert v.add_path(1, 2, "a", "b") == "https://example.com/1/2/a/b"
+    assert v.add_qs({"a": 1}, b=[2, 3, 4]) == "https://example.com?a=1&b=2&b=3&b=4"
+
+    with pytest.raises(TypeError):
+        v.add_path()
+    with pytest.raises(TypeError):
+        v.add_qs()
+
+
+def test_url__parse():
+    v = utils.Url("https://example.com:443/asdf?a=1&b=2&b=3#foo")
+    parsed = v._parse()
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "example.com:443"
+    assert parsed.path == "/asdf"
+    assert parsed.query == "a=1&b=2&b=3"
+    assert parsed.fragment == "foo"
+    assert parsed.hostname == "example.com"
+    assert parsed.port == 443
+
+
+def test_url__replace():
+    v = utils.Url("https://example.com:443/asdf?a=1&b=2&b=3#foo")
+    assert v.replace_url(netloc="foo.com") == "https://foo.com/asdf?a=1&b=2&b=3#foo"
+
+
+def test_url_cannot_append_after_params():
+    # cannot add path segments after params
+    v = utils.Url("https://example.com?a=1&b=2")
+    with pytest.raises(ValueError):
+        v / "foo"
+    with pytest.raises(ValueError):
+        v // ["foo", "bar"]

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,11 @@ commands =
 [testenv:coverage]
 passenv = COVERAGE_FORMAT
 commands =
-    python -m pytest -m 'not integration' --cov=pyairtable --cov-report={env:COVERAGE_FORMAT:html} --cov-fail-under=100
+    python -m pytest -m 'not integration' \
+        --cov=pyairtable \
+        --cov-report={env:COVERAGE_FORMAT:html} \
+        --cov-report=term-missing \
+        --cov-fail-under=100
 
 [testenv:docs]
 basepython = python3.9


### PR DESCRIPTION
This branch replaces the hodgepodge of `something_url()` methods on various classes with a `.urls` property that can contain both 'hardcoded' URLs (which are only calculated once per object) and URL-returning methods. It simplifies the namespace of each containing object and makes it clearer how to add more URLs in the future for any more API endpoints we need.