### PR TITLE
Do not use Session.send() as it skips parts of Session.request

### DIFF
--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,9 +1,7 @@
 import posixpath
-from functools import partialmethod
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, TypeVar, Union
 
 import requests
-from requests import PreparedRequest
 from requests.sessions import Session
 from typing_extensions import TypeAlias
 
@@ -274,16 +272,41 @@ class Api:
                 json=json,
             )
 
-        return self._perform_request(prepared)
-
-    get = partialmethod(request, "GET")
-    post = partialmethod(request, "POST")
-    patch = partialmethod(request, "PATCH")
-    delete = partialmethod(request, "DELETE")
-
-    def _perform_request(self, prepared: PreparedRequest) -> Any:
-        response = self.session.send(prepared, timeout=self.timeout)
+        response = self.session.request(
+            method=method,
+            url=url,
+            params=request_params,
+            json=json,
+        )
         return self._process_response(response)
+
+    def get(self, url: str, **kwargs: Any) -> Any:
+        """
+        Make a GET request to the Airtable API.
+        See :meth:`~Api.request` for keyword arguments.
+        """
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> Any:
+        """
+        Make a POST request to the Airtable API.
+        See :meth:`~Api.request` for keyword arguments.
+        """
+        return self.request("POST", url, **kwargs)
+
+    def patch(self, url: str, **kwargs: Any) -> Any:
+        """
+        Make a PATCH request to the Airtable API.
+        See :meth:`~Api.request` for keyword arguments.
+        """
+        return self.request("PATCH", url, **kwargs)
+
+    def delete(self, url: str, **kwargs: Any) -> Any:
+        """
+        Make a DELETE request to the Airtable API.
+        See :meth:`~Api.request` for keyword arguments.
+        """
+        return self.request("DELETE", url, **kwargs)
 
     def _process_response(self, response: requests.Response) -> Any:
         try:

--- a/pyairtable/testing.py
+++ b/pyairtable/testing.py
@@ -259,7 +259,7 @@ class MockAirtable:
 
     # The list of APIs that are mocked by this class.
     mocked = [
-        "Api._perform_request",
+        "Api.request",
         "Table.iterate",
         "Table.get",
         "Table.create",
@@ -294,7 +294,7 @@ class MockAirtable:
     def __enter__(self) -> Self:
         if self._stack:
             raise RuntimeError("MockAirtable is not reentrant")
-        if hasattr(Api._perform_request, "mock"):
+        if hasattr(Api.request, "mock"):
             raise RuntimeError("MockAirtable cannot be nested")
         self._reset()
         self._stack = ExitStack()
@@ -456,11 +456,11 @@ class MockAirtable:
 
     # side effects
 
-    def _api__perform_request(self, method: str, url: str, **kwargs: Any) -> Any:
+    def _api_request(self, api: Api, method: str, url: str, **kwargs: Any) -> Any:
         if not self.passthrough:
             raise RuntimeError("unhandled call to Api.request")
-        mocked = self._mocks["Api._perform_request"]
-        return mocked.temp_original(method, url, **kwargs)
+        mocked = self._mocks["Api.request"]
+        return mocked.temp_original(api, method, url, **kwargs)
 
     def _table_iterate(self, table: Table, **options: Any) -> List[List[RecordDict]]:
         return [list(self.records[(table.base.id, table.name)].values())]


### PR DESCRIPTION
This refactors how `Api.request` operates so that it does not skip some of the other behaviors of `requests.Session.request()`. Once this is merged I'll also cherry-pick it into a 2.x release.

@dortega3000 FYI

Resolves #398

