### PR TITLE
Fix enterprise.info and enterprise.users after new API params

### DIFF
--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -440,10 +440,17 @@ class EnterpriseInfo(AirtableModel):
     email_domains: List["EnterpriseInfo.EmailDomain"]
     root_enterprise_id: str = pydantic.Field(alias="rootEnterpriseAccountId")
     descendant_enterprise_ids: List[str] = _FL(alias="descendantEnterpriseAccountIds")
+    aggregated: Optional["EnterpriseInfo.AggregatedIds"] = None
+    descendants: Dict[str, "EnterpriseInfo.AggregatedIds"] = _FD()
 
     class EmailDomain(AirtableModel):
         email_domain: str
         is_sso_required: bool
+
+    class AggregatedIds(AirtableModel):
+        group_ids: List[str] = _FL()
+        user_ids: List[str] = _FL()
+        workspace_ids: List[str] = _FL()
 
 
 class WorkspaceCollaborators(_Collaborators, url="meta/workspaces/{self.id}"):
@@ -577,9 +584,24 @@ class UserInfo(
     is_super_admin: bool = False
     groups: List[NestedId] = _FL()
     collaborations: "Collaborations" = _F("Collaborations")
+    descendants: Dict[str, "UserInfo.DescendantIds"] = _FD()
+    aggregated: Optional["UserInfo.AggregatedIds"] = None
 
     def logout(self) -> None:
         self._api.post(self._url + "/logout")
+
+    class DescendantIds(AirtableModel):
+        last_activity_time: Optional[datetime] = None
+        collaborations: Optional["Collaborations"] = None
+        is_admin: bool = False
+        is_managed: bool = False
+        groups: List[NestedId] = _FL()
+
+    class AggregatedIds(AirtableModel):
+        last_activity_time: Optional[datetime] = None
+        collaborations: Optional["Collaborations"] = None
+        is_admin: bool = False
+        groups: List[NestedId] = _FL()
 
 
 class UserGroup(AirtableModel):

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -233,9 +233,9 @@ def cache_unless_forced(func: Callable[[C], R]) -> _FetchMethod[C, R]:
         attr = "_cached_" + attr.lstrip("_")
 
     @wraps(func)
-    def _inner(self: C, *, force: bool = False) -> R:
+    def _inner(self: C, *, force: bool = False, **kwargs: Any) -> R:
         if force or getattr(self, attr, None) is None:
-            setattr(self, attr, func(self))
+            setattr(self, attr, func(self, **kwargs))
         return cast(R, getattr(self, attr))
 
     _inner.__annotations__["force"] = bool

--- a/tests/sample_data/EnterpriseInfo.json
+++ b/tests/sample_data/EnterpriseInfo.json
@@ -1,5 +1,8 @@
 {
   "createdTime": "2019-01-03T12:33:12.421Z",
+  "descendantEnterpriseAccountIds": [
+    "entJ9ZQ5vz9ZQ5vz9"
+  ],
   "emailDomains": [
     {
       "emailDomain": "foobar.com",

--- a/tests/sample_data/UserInfo.json
+++ b/tests/sample_data/UserInfo.json
@@ -12,7 +12,7 @@
       {
         "baseId": "appLkNDICXNqxSDhG",
         "createdTime": "2019-01-03T12:33:12.421Z",
-        "grantedByUserId": "usrqccqnMB2eHylqB",
+        "grantedByUserId": "usrogvSbotRtzdtZW",
         "interfaceId": "pbdyGA3PsOziEHPDE",
         "permissionLevel": "edit"
       }
@@ -38,6 +38,7 @@
   ],
   "id": "usrL2PNC5o3H4lBEi",
   "invitedToAirtableByUserId": "usrsOEchC9xuwRgKk",
+  "isAdmin": true,
   "isManaged": true,
   "isServiceAccount": false,
   "isSsoRequired": true,


### PR DESCRIPTION
This adds support for the new `include=` params [announced today](https://airtable.com/developers/web/api/changelog#anchor-2024-11-11) for [Get Enterprise](https://airtable.com/developers/web/api/get-enterprise) and also fixes a bug where we were sending unsupported params to that same endpoint.

Fixes #404 