### PR TITLE
Fix for endless loop when requesting records via `POST /listRecords`

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+3.0.1 (2024-12-06)
+------------------------
+
+* Fix for `#415 <https://github.com/gtalarico/pyairtable/issues/415>`_
+  which caused an endless loop when making a request via `POST /listRecords`.
+  - `PR #416 <https://github.com/gtalarico/pyairtable/pull/416>`_,
+    `PR #417 <https://github.com/gtalarico/pyairtable/pull/417>`_
+
 3.0 (2024-11-15)
 ------------------------
 
@@ -57,6 +65,14 @@ Changelog
   - `PR #347 <https://github.com/gtalarico/pyairtable/pull/347>`_
 * Rewrite of :mod:`pyairtable.formulas` module. See :ref:`Building Formulas`.
   - `PR #329 <https://github.com/gtalarico/pyairtable/pull/329>`_
+
+2.3.7 (2024-12-06)
+------------------------
+
+* Fix for `#415 <https://github.com/gtalarico/pyairtable/issues/415>`_
+  which caused an endless loop when making a request via `POST /listRecords`.
+  - `PR #416 <https://github.com/gtalarico/pyairtable/pull/416>`_,
+    `PR #417 <https://github.com/gtalarico/pyairtable/pull/417>`_
 
 2.3.6 (2024-11-11)
 ------------------------

--- a/pyairtable/__init__.py
+++ b/pyairtable/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 from pyairtable.api import Api, Base, Table
 from pyairtable.api.enterprise import Enterprise

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -394,7 +394,7 @@ class Api:
                 return
             if not (offset := _get_offset_field(response)):
                 return
-            params = {**params, offset_field: offset}
+            options = {**options, offset_field: offset}
 
     def chunked(self, iterable: Sequence[T]) -> Iterator[Sequence[T]]:
         """

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -74,6 +74,9 @@ OPTIONS_TO_PARAMETERS = {
     # get webhook payloads
     "limit": "limit",
     "cursor": "cursor",
+    # get audit log events
+    "next": "next",
+    "previous": "previous",
 }
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,20 +10,21 @@ def valid_img_url():
     return "https://github.com/gtalarico/pyairtable/raw/9f243cb0935ad7112859f990434612efdaf49c67/docs/source/_static/logo.png"
 
 
-@pytest.fixture
-def cols():
-    class Columns:
-        # Table should have these Columns
-        TEXT = "text"  # Text
-        TEXT_ID = "fldzbVdWW4xJdZ1em"  # for returnFieldsByFieldId
-        NUM = "number"  # Number, float
-        NUM_ID = "fldFLyuxGuWobyMV2"  # for returnFieldsByFieldId
-        BOOL = "boolean"  # Boolean
-        DATETIME = "datetime"  # Datetime
-        ATTACHMENT = "attachment"  # attachment
-        ATTACHMENT_ID = "fld5VP9oPeCpvIumr"  # for upload_attachment
+class Columns:
+    # Table should have these Columns
+    TEXT = "text"  # Text
+    TEXT_ID = "fldzbVdWW4xJdZ1em"  # for returnFieldsByFieldId
+    NUM = "number"  # Number, float
+    NUM_ID = "fldFLyuxGuWobyMV2"  # for returnFieldsByFieldId
+    BOOL = "boolean"  # Boolean
+    DATETIME = "datetime"  # Datetime
+    ATTACHMENT = "attachment"  # attachment
+    ATTACHMENT_ID = "fld5VP9oPeCpvIumr"  # for upload_attachment
 
-    return Columns
+
+@pytest.fixture
+def cols() -> Columns:
+    return Columns()
 
 
 @pytest.fixture


### PR DESCRIPTION
This fixes #415. The cause was a silly mistake between `params` and `options` within the Api class, and this branch adds both a unit test and an integration test to ensure this behavior is correct.