### PR TITLE
Allow pickling/unpickling of ChangeTrackingLists

### DIFF
--- a/pyairtable/orm/lists.py
+++ b/pyairtable/orm/lists.py
@@ -50,8 +50,13 @@ class ChangeTrackingList(List[T]):
             self._tracking_enabled = prev
 
     def _on_change(self) -> None:
-        if self._tracking_enabled:
-            self._model._changed[self._field.field_name] = True
+        try:
+            if not self._tracking_enabled:
+                return
+        except AttributeError:
+            # This means we're being unpickled and won't call __init__.
+            return
+        self._model._changed[self._field.field_name] = True
 
     @overload
     def __setitem__(self, index: SupportsIndex, value: T, /) -> None: ...

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -632,6 +632,8 @@ def test_link_field():
     collection = [Book(), Book(), Book()]
     author = Author()
     author.books = collection
+    assert isinstance(author._fields["Books"], f.ChangeTrackingList)
+
     assert author.books == collection
 
     with pytest.raises(TypeError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -233,3 +233,25 @@ def test_url_cannot_append_after_params():
         v / "foo"
     with pytest.raises(ValueError):
         v // ["foo", "bar"]
+
+
+@pytest.mark.parametrize(
+    "docstring,expected",
+    [
+        ("", ""),
+        (
+            "This is a\ndocstring.",
+            "|enterprise_only|\n\nThis is a\ndocstring.",
+        ),
+        (
+            "\t  This is a\n\t  docstring.",
+            "\t  |enterprise_only|\n\n\t  This is a\n\t  docstring.",
+        ),
+    ],
+)
+def test_enterprise_docstring(docstring, expected):
+    @utils.enterprise_only
+    class Foo:
+        __doc__ = docstring
+
+    assert Foo.__doc__ == expected


### PR DESCRIPTION
This allows models with link fields to be pickled and unpickled. This is useful, for example, when a model instance is an input to (or a return value from) an instance of [ProcessPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor).

(It also fixes a missing line of coverage in pyairtable.utils.)