### PR TITLE
Add `.field_schema()` method to field descriptors on ORM models

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+3.1.0 (TBD)
+------------------------
+
+* Added ``Field.field_schema()`` to type-annotated ORM fields.
+
 3.0.2 (2025-02-25)
 ------------------------
 

--- a/docs/source/orm.rst
+++ b/docs/source/orm.rst
@@ -170,7 +170,7 @@ read `Field types and cell values <https://airtable.com/developers/web/api/field
    * - :class:`~pyairtable.orm.fields.DurationField`
      - `Duration <https://airtable.com/developers/web/api/field-model#durationnumber>`__
    * - :class:`~pyairtable.orm.fields.EmailField`
-     - `Email <https://airtable.com/developers/web/api/field-model#email>`__
+     - `Email <https://airtable.com/developers/web/api/field-model#emailtext>`__
    * - :class:`~pyairtable.orm.fields.ExternalSyncSourceField` 🔒
      - `Sync source <https://airtable.com/developers/web/api/field-model#syncsource>`__
    * - :class:`~pyairtable.orm.fields.FloatField`
@@ -190,7 +190,7 @@ read `Field types and cell values <https://airtable.com/developers/web/api/field
    * - :class:`~pyairtable.orm.fields.MultilineTextField`
      - `Long text <https://airtable.com/developers/web/api/field-model#multilinetext>`__
    * - :class:`~pyairtable.orm.fields.MultipleCollaboratorsField`
-     - `Multiple Collaborators <https://airtable.com/developers/web/api/field-model#multicollaborator>`__
+     - `Multiple collaborators <https://airtable.com/developers/web/api/field-model#multicollaborator>`__
    * - :class:`~pyairtable.orm.fields.MultipleSelectField`
      - `Multiple select <https://airtable.com/developers/web/api/field-model#multiselect>`__
    * - :class:`~pyairtable.orm.fields.NumberField`
@@ -202,7 +202,7 @@ read `Field types and cell values <https://airtable.com/developers/web/api/field
    * - :class:`~pyairtable.orm.fields.RatingField`
      - `Rating <https://airtable.com/developers/web/api/field-model#rating>`__
    * - :class:`~pyairtable.orm.fields.RichTextField`
-     - `Rich text <https://airtable.com/developers/web/api/field-model#rich-text>`__
+     - `Rich text <https://airtable.com/developers/web/api/field-model#richtext>`__
    * - :class:`~pyairtable.orm.fields.SelectField`
      - `Single select <https://airtable.com/developers/web/api/field-model#select>`__
    * - :class:`~pyairtable.orm.fields.SingleLineTextField`
@@ -242,7 +242,7 @@ See :ref:`Required Values` for more details.
    * - :class:`~pyairtable.orm.fields.RequiredDurationField`
      - `Duration <https://airtable.com/developers/web/api/field-model#durationnumber>`__
    * - :class:`~pyairtable.orm.fields.RequiredEmailField`
-     - `Email <https://airtable.com/developers/web/api/field-model#email>`__
+     - `Email <https://airtable.com/developers/web/api/field-model#emailtext>`__
    * - :class:`~pyairtable.orm.fields.RequiredFloatField`
      - `Number <https://airtable.com/developers/web/api/field-model#decimalorintegernumber>`__
    * - :class:`~pyairtable.orm.fields.RequiredIntegerField`
@@ -258,7 +258,7 @@ See :ref:`Required Values` for more details.
    * - :class:`~pyairtable.orm.fields.RequiredRatingField`
      - `Rating <https://airtable.com/developers/web/api/field-model#rating>`__
    * - :class:`~pyairtable.orm.fields.RequiredRichTextField`
-     - `Rich text <https://airtable.com/developers/web/api/field-model#rich-text>`__
+     - `Rich text <https://airtable.com/developers/web/api/field-model#richtext>`__
    * - :class:`~pyairtable.orm.fields.RequiredSelectField`
      - `Single select <https://airtable.com/developers/web/api/field-model#select>`__
    * - :class:`~pyairtable.orm.fields.RequiredSingleLineTextField`
@@ -267,7 +267,7 @@ See :ref:`Required Values` for more details.
      - `Single line text <https://airtable.com/developers/web/api/field-model#simpletext>`__, `Long text <https://airtable.com/developers/web/api/field-model#multilinetext>`__
    * - :class:`~pyairtable.orm.fields.RequiredUrlField`
      - `Url <https://airtable.com/developers/web/api/field-model#urltext>`__
-.. [[[end]]] (checksum: 658b792ee9eb180dc5600d76663c8a7e)
+.. [[[end]]] (checksum: 3ed2090cb24140caa19860a20b0f5a33)
 
 
 Type Annotations

--- a/docs/source/orm.rst
+++ b/docs/source/orm.rst
@@ -666,6 +666,30 @@ directly upload content to Airtable:
 .. automethod:: pyairtable.orm.lists.AttachmentsList.upload
 
 
+ORM Metadata
+------------------
+
+Access to the configuration of a model and the schema of its underlying base/table
+are available through the :attr:`~pyairtable.orm.Model.meta` attribute:
+
+.. code-block:: python
+
+    >>> model = YourModel()
+    >>> model.meta.base_id
+    'appaPqizdsNHDvlEm'
+    >>> model.meta.table_name
+    'YourModel'
+    >>> model.meta.table.schema()
+    TableSchema(id='appaPqizdsNHDvlEm', name='YourModel', ...)
+
+For convenience, the schema of ORM-defined fields can be accessed via those field definitions:
+
+.. code-block:: python
+
+    >>> YourModel.name.field_schema()
+    FieldSchema(id='fldMNxslc6jG0XedV', name='Name', type='singleLineText', ...)
+
+
 ORM Limitations
 ------------------
 

--- a/docs/source/orm.rst
+++ b/docs/source/orm.rst
@@ -187,6 +187,8 @@ read `Field types and cell values <https://airtable.com/developers/web/api/field
      - `Lookup <https://airtable.com/developers/web/api/field-model#lookup>`__
    * - :class:`~pyairtable.orm.fields.ManualSortField` 🔒
      - (undocumented)
+   * - :class:`~pyairtable.orm.fields.MultilineTextField`
+     - `Long text <https://airtable.com/developers/web/api/field-model#multilinetext>`__
    * - :class:`~pyairtable.orm.fields.MultipleCollaboratorsField`
      - `Multiple Collaborators <https://airtable.com/developers/web/api/field-model#multicollaborator>`__
    * - :class:`~pyairtable.orm.fields.MultipleSelectField`
@@ -203,6 +205,8 @@ read `Field types and cell values <https://airtable.com/developers/web/api/field
      - `Rich text <https://airtable.com/developers/web/api/field-model#rich-text>`__
    * - :class:`~pyairtable.orm.fields.SelectField`
      - `Single select <https://airtable.com/developers/web/api/field-model#select>`__
+   * - :class:`~pyairtable.orm.fields.SingleLineTextField`
+     - `Single line text <https://airtable.com/developers/web/api/field-model#simpletext>`__
    * - :class:`~pyairtable.orm.fields.SingleLinkField`
      - `Link to another record <https://airtable.com/developers/web/api/field-model#foreignkey>`__
    * - :class:`~pyairtable.orm.fields.TextField`
@@ -243,6 +247,8 @@ See :ref:`Required Values` for more details.
      - `Number <https://airtable.com/developers/web/api/field-model#decimalorintegernumber>`__
    * - :class:`~pyairtable.orm.fields.RequiredIntegerField`
      - `Number <https://airtable.com/developers/web/api/field-model#decimalorintegernumber>`__
+   * - :class:`~pyairtable.orm.fields.RequiredMultilineTextField`
+     - `Long text <https://airtable.com/developers/web/api/field-model#multilinetext>`__
    * - :class:`~pyairtable.orm.fields.RequiredNumberField`
      - `Number <https://airtable.com/developers/web/api/field-model#decimalorintegernumber>`__
    * - :class:`~pyairtable.orm.fields.RequiredPercentField`
@@ -255,11 +261,41 @@ See :ref:`Required Values` for more details.
      - `Rich text <https://airtable.com/developers/web/api/field-model#rich-text>`__
    * - :class:`~pyairtable.orm.fields.RequiredSelectField`
      - `Single select <https://airtable.com/developers/web/api/field-model#select>`__
+   * - :class:`~pyairtable.orm.fields.RequiredSingleLineTextField`
+     - `Single line text <https://airtable.com/developers/web/api/field-model#simpletext>`__
    * - :class:`~pyairtable.orm.fields.RequiredTextField`
      - `Single line text <https://airtable.com/developers/web/api/field-model#simpletext>`__, `Long text <https://airtable.com/developers/web/api/field-model#multilinetext>`__
    * - :class:`~pyairtable.orm.fields.RequiredUrlField`
      - `Url <https://airtable.com/developers/web/api/field-model#urltext>`__
-.. [[[end]]] (checksum: 43c56200ca513d3a0603bb5a6ddbb1ef)
+.. [[[end]]] (checksum: 658b792ee9eb180dc5600d76663c8a7e)
+
+
+Type Annotations
+------------------
+
+pyAirtable uses type annotations to provide hints to type checkers like mypy.
+Type annotations improve code readability and help catch errors during development.
+
+Basic field types like :class:`~pyairtable.orm.fields.TextField` and :class:`~pyairtable.orm.fields.IntegerField`
+will have their types inferred from the field's configuration. For example:
+
+.. code-block:: python
+
+    from pyairtable.orm import Model, fields as F
+
+    class Person(Model):
+        class Meta: ...
+
+        name = F.TextField("Name")
+        account_id = F.IntegerField("Account ID")
+        edited_by = F.LastModifiedByField("Last Modified By")
+
+    record = Person()
+    reveal_type(record.name)  # Revealed type is 'builtins.str*'
+    reveal_type(record.account_id)  # Revealed type is 'builtins.int*'
+    reveal_type(record.edited_by)  # Revealed type is 'pyairtable.api.types.CollaboratorDict'
+
+You may need to provide type hints to complex fields that involve lists. See below for examples.
 
 
 Formula, Rollup, and Lookup Fields
@@ -363,6 +399,7 @@ One reason to use these fields (sparingly!) might be to avoid adding defensive
 null-handling checks all over your code, if you are confident that the workflows
 around your Airtable base will not produce an empty value (or that an empty value
 is enough of a problem that your code should raise an exception).
+
 
 Linked Records
 ----------------
@@ -508,14 +545,8 @@ This code will perform a series of API calls at the beginning to fetch
 all records from the Books and Authors tables, so that ``author.books``
 does not need to request linked records one at a time during the loop.
 
-.. note::
-    Memoization does not affect whether pyAirtable will make an API call.
-    It only affects whether pyAirtable will reuse a model instance that
-    was already created, or create a new one. For example, calling
-    ``model.all(memoize=True)`` N times will still result in N calls to the API.
-
-You can also set ``memoize = True`` in the ``Meta`` configuration for your model,
-which indicates that you always want to memoize models retrieved from the API:
+If you always want to memoize models retrieved from the API, you can set
+``memoize = True`` in the ``Meta`` configuration for your model:
 
 .. code-block:: python
 
@@ -532,17 +563,38 @@ which indicates that you always want to memoize models retrieved from the API:
     Author.first().books  # this will memoize all books created
     Book.all(memoize=False)  # this will skip memoization
 
-The following methods support the ``memoize=`` keyword argument.
-You can pass ``memoize=False`` to override memoization that is
-enabled on the model configuration.
 
-   * :meth:`Model.all <pyairtable.orm.Model.all>`
-   * :meth:`Model.first <pyairtable.orm.Model.first>`
-   * :meth:`Model.from_record <pyairtable.orm.Model.from_record>`
-   * :meth:`Model.from_id <pyairtable.orm.Model.from_id>`
-   * :meth:`Model.from_ids <pyairtable.orm.Model.from_ids>`
-   * :meth:`LinkField.populate <pyairtable.orm.fields.LinkField.populate>`
-   * :meth:`SingleLinkField.populate <pyairtable.orm.fields.SingleLinkField.populate>`
+The following methods support the ``memoize=`` keyword argument to control
+whether the ORM saves the models it creates for later reuse. If a model is
+configured to memoize by default, pass ``memoize=False`` to override it.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Retrieval function
+     - Will it reuse saved models?
+     - Will it call the API?
+   * - :meth:`Model.all <pyairtable.orm.Model.all>`
+     - Never
+     - Always
+   * - :meth:`Model.first <pyairtable.orm.Model.first>`
+     - Never
+     - Always
+   * - :meth:`Model.from_record <pyairtable.orm.Model.from_record>`
+     - Never
+     - Never
+   * - :meth:`Model.from_id <pyairtable.orm.Model.from_id>`
+     - Yes
+     - Yes, unless ``fetch=True``
+   * - :meth:`Model.from_ids <pyairtable.orm.Model.from_ids>`
+     - Yes
+     - Yes, unless ``fetch=True``
+   * - :meth:`LinkField.populate <pyairtable.orm.fields.LinkField.populate>`
+     - Yes
+     - Yes, unless ``lazy=True``
+   * - :meth:`SingleLinkField.populate <pyairtable.orm.fields.SingleLinkField.populate>`
+     - Yes
+     - Yes, unless ``lazy=True``
 
 
 Comments

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -209,7 +209,9 @@ def _append_docstring_text(obj: Any, text: str, *, skip_empty: bool = True) -> N
 
 def docstring_from(obj: Any, append: str = "") -> Callable[[F], F]:
     def _wrapper(func: F) -> F:
-        func.__doc__ = obj.__doc__ + append
+        func.__doc__ = obj.__doc__
+        if append:
+            _append_docstring_text(func, append)
         return func
 
     return _wrapper

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -442,6 +442,12 @@ class UrlBuilder:
     ...which ensures the URLs are built only once and are accessible via ``.urls``,
     and have the ``SomeObject`` instance available as context, and build
     readable docstrings for the ``SomeObject`` class documentation.
+
+    .. warning::
+
+        This class is intended for use within pyAirtable only, and is tailored
+        to the type of documentation this library produces. Its behavior may
+        change in the future in ways that are not suitable for other projects.
     """
 
     context: Any

--- a/tests/integration/test_integration_orm.py
+++ b/tests/integration/test_integration_orm.py
@@ -202,6 +202,11 @@ def test_every_field(Everything):
             f.AITextField,
             f.RequiredAITextField,
             f.ManualSortField,
+            # These are so similar to TextField we don't need to integration test them
+            f.SingleLineTextField,
+            f.MultilineTextField,
+            f.RequiredSingleLineTextField,
+            f.RequiredMultilineTextField,
         }:
             continue
         assert field_class in classes_used

--- a/tests/test_api_table.py
+++ b/tests/test_api_table.py
@@ -20,7 +20,7 @@ def table_schema(sample_json, api, base) -> TableSchema:
 
 
 @pytest.fixture
-def mock_schema(table, requests_mock, sample_json):
+def mock_table_schema(table, requests_mock, sample_json):
     table_schema = sample_json("TableSchema")
     table_schema["id"] = table.name = fake_id("tbl")
     return requests_mock.get(
@@ -443,7 +443,7 @@ def test_batch_delete(table: Table, container, mock_records):
     assert resp == expected
 
 
-def test_create_field(table, mock_schema, requests_mock, sample_json):
+def test_create_field(table, mock_table_schema, requests_mock, sample_json):
     """
     Tests the API for creating a field (but without actually performing the operation).
     """
@@ -454,7 +454,7 @@ def test_create_field(table, mock_schema, requests_mock, sample_json):
 
     # Ensure we have pre-loaded our schema
     table.schema()
-    assert mock_schema.call_count == 1
+    assert mock_table_schema.call_count == 1
 
     # Create the field
     choices = ["Todo", "In progress", "Done"]
@@ -482,10 +482,10 @@ def test_create_field(table, mock_schema, requests_mock, sample_json):
 
     # Test that the schema has been updated without a second API call
     assert table._schema.field(fld.id).name == "Status"
-    assert mock_schema.call_count == 1
+    assert mock_table_schema.call_count == 1
 
 
-def test_delete_view(table, mock_schema, requests_mock):
+def test_delete_view(table, mock_table_schema, requests_mock):
     view = table.schema().view("Grid view")
     m = requests_mock.delete(view._url)
     view.delete()

--- a/tests/test_orm_fields.py
+++ b/tests/test_orm_fields.py
@@ -413,6 +413,7 @@ def test_writable_fields(test_case):
         f.LastModifiedTimeField,
         f.LookupField,
         f.ManualSortField,
+        f.MultilineTextField,
         f.MultipleCollaboratorsField,
         f.MultipleSelectField,
         f.NumberField,
@@ -422,9 +423,8 @@ def test_writable_fields(test_case):
         f.RatingField,
         f.RichTextField,
         f.SelectField,
-        f.TextField,
         f.SingleLineTextField,
-        f.MultilineTextField,
+        f.TextField,
         f.UrlField,
     ],
 )

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -12,6 +12,7 @@ import pyairtable.api.types as T
 import pyairtable.orm.lists as L
 import pyairtable.utils
 from pyairtable import orm
+from pyairtable.models import schema
 
 if TYPE_CHECKING:
     # This section does not actually get executed; it is only parsed by mypy.
@@ -70,8 +71,9 @@ if TYPE_CHECKING:
 
     # Test type annotations for the ORM
     class Actor(orm.Model):
-        name = orm.fields.TextField("Name")
+        name = orm.fields.SingleLineTextField("Name")
         logins = orm.fields.MultipleCollaboratorsField("Logins")
+        bio = orm.fields.MultilineTextField("Bio")
 
     assert_type(Actor().name, str)
     assert_type(
@@ -147,6 +149,7 @@ if TYPE_CHECKING:
         required_select = orm.fields.RequiredSelectField("Status")
         required_url = orm.fields.RequiredUrlField("URL")
 
+    # Check the types of values returned from these fields
     # fmt: off
     record = EveryField()
     assert_type(record.aitext, Optional[T.AITextDict])
@@ -199,6 +202,58 @@ if TYPE_CHECKING:
     assert_type(record.required_rich_text, str)
     assert_type(record.required_select, str)
     assert_type(record.required_url, str)
+
+    # Check the types of each field schema
+    assert_type(Movie.name.field_schema(), Union[schema.SingleLineTextFieldSchema, schema.MultilineTextFieldSchema])
+    assert_type(Actor.name.field_schema(), schema.SingleLineTextFieldSchema)
+    assert_type(Actor.bio.field_schema(), schema.MultilineTextFieldSchema)
+    assert_type(EveryField.aitext.field_schema(), schema.AITextFieldSchema)
+    assert_type(EveryField.attachments.field_schema(), schema.MultipleAttachmentsFieldSchema)
+    assert_type(EveryField.autonumber.field_schema(), schema.AutoNumberFieldSchema)
+    assert_type(EveryField.barcode.field_schema(), schema.BarcodeFieldSchema)
+    assert_type(EveryField.button.field_schema(), schema.ButtonFieldSchema)
+    assert_type(EveryField.checkbox.field_schema(), schema.CheckboxFieldSchema)
+    assert_type(EveryField.collaborator.field_schema(), schema.SingleCollaboratorFieldSchema)
+    assert_type(EveryField.count.field_schema(), schema.CountFieldSchema)
+    assert_type(EveryField.created_by.field_schema(), schema.CreatedByFieldSchema)
+    assert_type(EveryField.created.field_schema(), schema.CreatedTimeFieldSchema)
+    assert_type(EveryField.currency.field_schema(), schema.CurrencyFieldSchema)
+    assert_type(EveryField.date.field_schema(), schema.DateFieldSchema)
+    assert_type(EveryField.datetime.field_schema(), schema.DateTimeFieldSchema)
+    assert_type(EveryField.duration.field_schema(), schema.DurationFieldSchema)
+    assert_type(EveryField.email.field_schema(), schema.EmailFieldSchema)
+    assert_type(EveryField.float.field_schema(), schema.NumberFieldSchema)
+    assert_type(EveryField.integer.field_schema(), schema.NumberFieldSchema)
+    assert_type(EveryField.last_modified_by.field_schema(), schema.LastModifiedByFieldSchema)
+    assert_type(EveryField.last_modified.field_schema(), schema.LastModifiedTimeFieldSchema)
+    assert_type(EveryField.multi_user.field_schema(), schema.MultipleCollaboratorsFieldSchema)
+    assert_type(EveryField.multi_select.field_schema(), schema.MultipleSelectsFieldSchema)
+    assert_type(EveryField.number.field_schema(), schema.NumberFieldSchema)
+    assert_type(EveryField.percent.field_schema(), schema.PercentFieldSchema)
+    assert_type(EveryField.phone.field_schema(), schema.PhoneNumberFieldSchema)
+    assert_type(EveryField.rating.field_schema(), schema.RatingFieldSchema)
+    assert_type(EveryField.rich_text.field_schema(), schema.RichTextFieldSchema)
+    assert_type(EveryField.select.field_schema(), schema.SingleSelectFieldSchema)
+    assert_type(EveryField.url.field_schema(), schema.UrlFieldSchema)
+    assert_type(EveryField.required_aitext.field_schema(), schema.AITextFieldSchema)
+    assert_type(EveryField.required_barcode.field_schema(), schema.BarcodeFieldSchema)
+    assert_type(EveryField.required_collaborator.field_schema(), schema.SingleCollaboratorFieldSchema)
+    assert_type(EveryField.required_count.field_schema(), schema.CountFieldSchema)
+    assert_type(EveryField.required_currency.field_schema(), schema.CurrencyFieldSchema)
+    assert_type(EveryField.required_date.field_schema(), schema.DateFieldSchema)
+    assert_type(EveryField.required_datetime.field_schema(), schema.DateTimeFieldSchema)
+    assert_type(EveryField.required_duration.field_schema(), schema.DurationFieldSchema)
+    assert_type(EveryField.required_email.field_schema(), schema.EmailFieldSchema)
+    assert_type(EveryField.required_float.field_schema(), schema.NumberFieldSchema)
+    assert_type(EveryField.required_integer.field_schema(), schema.NumberFieldSchema)
+    assert_type(EveryField.required_number.field_schema(), schema.NumberFieldSchema)
+    assert_type(EveryField.required_percent.field_schema(), schema.PercentFieldSchema)
+    assert_type(EveryField.required_phone.field_schema(), schema.PhoneNumberFieldSchema)
+    assert_type(EveryField.required_rating.field_schema(), schema.RatingFieldSchema)
+    assert_type(EveryField.required_rich_text.field_schema(), schema.RichTextFieldSchema)
+    assert_type(EveryField.required_select.field_schema(), schema.SingleSelectFieldSchema)
+    assert_type(EveryField.required_url.field_schema(), schema.UrlFieldSchema)
+    assert_type(EveryField.meta.table.schema().field("Anything"), schema.FieldSchema)
     # fmt: on
 
     # Check that the type system allows create-style dicts in all places


### PR DESCRIPTION
This branch allows implementers easier access to the type-annotated field schemas on ORM models.

What used to be:
```python
schema = MyModel.meta.table.schema().field(MyModel.status.field_name)
assert isinstance(schema, pyairtable.models.schema.SingleSelectFieldSchema)
print(schema.options.choices)
```

...can now be written as:
```python
print(MyModel.status.field_schema().options.choices)
```
