### PR TITLE
Fix `*args` static type hint in `FunctionCall` constructor

### DIFF
--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -524,7 +524,7 @@ class FunctionCall(Formula):
     for all formula functions known at time of publishing.
     """
 
-    def __init__(self, name: str, *args: List[Any]):
+    def __init__(self, name: str, *args: Any):
         self.name = name
         self.args = args
 


### PR DESCRIPTION
This type hint is unnecessarily wrapped in `List[...]`.

The fact that `args` is a list (in fact, variable length tuple) is implicit.

This typing results in incorrectly typing `args` as `tuple[List[Any], ...]` – i.e. requires _each_ positional argument _itself_ be a `List[Any]`.

See https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values 

### Test Plan

I don't see any static type checking in this project's CI at the moment: https://github.com/gtalarico/pyairtable/blob/132332d5905d5c5b7cc1eb7c01bc2bbffea3b4ff/.github/workflows/test_lint_deploy.yml

Therefore I just tested it manually. Specifically, I updated the `pyairtable` dependency in my personal project and Pyright stopped seeing a type error when calling instantiating `FunctionCall`.

Before:
 
<img width="1146" alt="Screenshot 2025-04-05 at 13 32 38" src="https://github.com/user-attachments/assets/dcdbcd36-467e-4927-bef8-aa235830b63d" />

After:

<img width="1024" alt="Screenshot 2025-04-05 at 13 32 18" src="https://github.com/user-attachments/assets/dcc0b0b3-8cd5-40ac-b104-d7ee18fb8db8" />
