### PR TITLE
Add missing schema fields

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -36,9 +36,11 @@ You'll find more detail in the API reference for :mod:`pyairtable.models.schema`
 Modifying existing schema
 -----------------------------
 
-To modify a table or field, you can modify its schema object directly and
-call ``save()``, as shown below. You can only change names and descriptions;
-the Airtable API does not permit changing any other options.
+To modify a table or field, you can modify portions of its schema object directly
+and call ``save()``, as shown below. The Airtable API only allows changing certain
+properties; these are enumerated in the API reference for each schema class.
+For example, :class:`~pyairtable.models.schema.TableSchema` allows changing the name,
+description, and date dependency configuration.
 
 .. code-block:: python
 
@@ -49,6 +51,9 @@ the Airtable API does not permit changing any other options.
     >>> field.name = "Label"
     >>> field.description = "The primary field on the table"
     >>> field.save()
+
+To add or replace the date dependency configuration on a table, you can use the shortcut method
+:meth:`TableSchema.set_date_dependency <pyairtable.models.schema.TableSchema.set_date_dependency>`.
 
 
 Creating schema elements

--- a/pyairtable/models/_base.py
+++ b/pyairtable/models/_base.py
@@ -235,16 +235,16 @@ class CanUpdateModel(RestfulModel):
             kwargs.pop("reload_after_save", cls.__reload_after_save)
         )
         if cls.__writable:
-            _append_docstring_text(
+            _append_docstring_refs(
                 cls,
-                "The following fields can be modified and saved: "
-                + ", ".join(f"``{field}``" for field in cls.__writable),
+                "The following fields can be modified and saved",
+                cls.__writable,
             )
         if cls.__readonly:
-            _append_docstring_text(
+            _append_docstring_refs(
                 cls,
-                "The following fields are read-only and cannot be modified:\n"
-                + ", ".join(f"``{field}``" for field in cls.__readonly),
+                "The following fields are read-only and cannot be modified",
+                cls.__readonly,
             )
         super().__init_subclass__(**kwargs)
 
@@ -284,6 +284,24 @@ class CanUpdateModel(RestfulModel):
                 raise AttributeError(name)
 
         super().__setattr__(name, value)
+
+
+def _append_docstring_refs(
+    cls: Type[CanUpdateModel],
+    explanation: str,
+    field_names: Iterable[str],
+) -> None:
+    """
+    Used by CanUpdateModel to append a list of field names to the class docstring.
+    """
+    field_refs = [
+        f":attr:`~{cls.__module__}.{cls.__qualname__}.{field}`" for field in field_names
+    ]
+    _append_docstring_text(
+        cls,
+        f"{explanation}: " + ", ".join(field_refs),
+        before_re=r"^\s+Usage:",
+    )
 
 
 def rebuild_models(

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -225,6 +225,7 @@ class BaseShares(AirtableModel):
         is_password_protected: bool
         block_installation_id: Optional[str] = None
         restricted_to_email_domains: List[str] = _FL()
+        restricted_to_enterprise_members: bool
         view_id: Optional[str] = None
         effective_email_domain_allow_list: List[str] = _FL()
 
@@ -617,6 +618,7 @@ class UserGroup(AirtableModel):
     updated_time: datetime
     members: List["UserGroup.Member"]
     collaborations: "Collaborations" = _F("Collaborations")
+    mapped_user_license_type: Optional[str] = None
 
     class Member(AirtableModel):
         user_id: str

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -191,6 +191,7 @@ class BaseCollaborators(_Collaborators, url="meta/bases/{base.id}"):
     group_collaborators: "BaseCollaborators.GroupCollaborators" = _F("BaseCollaborators.GroupCollaborators")  # fmt: skip
     individual_collaborators: "BaseCollaborators.IndividualCollaborators" = _F("BaseCollaborators.IndividualCollaborators")  # fmt: skip
     invite_links: "BaseCollaborators.InviteLinks" = _F("BaseCollaborators.InviteLinks")  # fmt: skip
+    sensitivity_label: Optional["BaseCollaborators.SensitivityLabel"] = None
 
     class InterfaceCollaborators(
         _Collaborators,
@@ -215,6 +216,11 @@ class BaseCollaborators(_Collaborators, url="meta/bases/{base.id}"):
     class InviteLinks(RestfulModel, url="{base_collaborators._url}/invites"):
         via_base: List["InviteLink"] = _FL(alias="baseInviteLinks")
         via_workspace: List["WorkspaceInviteLink"] = _FL(alias="workspaceInviteLinks")  # fmt: skip
+
+    class SensitivityLabel(AirtableModel):
+        id: str
+        description: str
+        name: str
 
 
 class BaseShares(AirtableModel):
@@ -681,6 +687,7 @@ class UserInfo(
     is_two_factor_auth_enabled: bool
     last_activity_time: Optional[datetime] = None
     created_time: Optional[datetime] = None
+    license_type: Optional[str] = None
     enterprise_user_type: Optional[str] = None
     invited_to_airtable_by_user_id: Optional[str] = None
     is_managed: bool = False
@@ -695,6 +702,7 @@ class UserInfo(
         self._api.post(self._url + "/logout")
 
     class DescendantIds(AirtableModel):
+        license_type: Optional[str] = None
         last_activity_time: Optional[datetime] = None
         collaborations: Optional["Collaborations"] = None
         is_admin: bool = False
@@ -702,6 +710,7 @@ class UserInfo(
         groups: List[NestedId] = _FL()
 
     class AggregatedIds(AirtableModel):
+        license_type: Optional[str] = None
         last_activity_time: Optional[datetime] = None
         collaborations: Optional["Collaborations"] = None
         is_admin: bool = False

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -741,7 +741,7 @@ class _ListFieldBase(
         # and persist it later when they call .save(), we need to
         # set the list as the field's value.
         instance._fields[self.field_name] = value
-        return cast(T_ORM_List, value)
+        return cast(T_ORM_List, value)  # type: ignore[redundant-cast]
 
     def valid_or_raise(self, value: Any) -> None:
         super().valid_or_raise(value)

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -197,13 +197,18 @@ def _prepend_docstring_text(obj: Any, text: str, *, skip_empty: bool = True) -> 
     obj.__doc__ = f"{text}\n\n{doc}"
 
 
-def _append_docstring_text(obj: Any, text: str, *, skip_empty: bool = True) -> None:
+def _append_docstring_text(
+    obj: Any, text: str, *, skip_empty: bool = True, before_re: str = ""
+) -> None:
     doc = obj.__doc__ or ""
     if skip_empty and not doc:
         return
     doc = doc.rstrip("\n")
     if has_leading_spaces := re.match(r"^\s+", doc):
         text = textwrap.indent(text, has_leading_spaces[0])
+    if before_re and (match := re.search(before_re, doc, re.MULTILINE)):
+        text = text + "\n\n" + doc[match.start() :]
+        doc = doc[: match.start()].rstrip()
     obj.__doc__ = f"{doc}\n\n{text}"
 
 

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -170,7 +170,7 @@ def enterprise_only(wrapped: F, /, modify_docstring: bool = True) -> F:
         for name, obj in vars(wrapped).items():
             if inspect.isfunction(obj):
                 setattr(wrapped, name, enterprise_only(obj))
-        return cast(F, wrapped)
+        return cast(F, wrapped)  # type: ignore[redundant-cast]
 
     @wraps(wrapped)
     def _decorated(*args: Any, **kwargs: Any) -> Any:

--- a/scripts/find_model_changes.py
+++ b/scripts/find_model_changes.py
@@ -107,6 +107,7 @@ SCAN_MODELS = {
     "pyairtable.models.webhook:WebhookSpecification.SourceOptions": "schemas:webhooks-specification:@filters:@sourceOptions",
     "pyairtable.models.webhook:WebhookSpecification.SourceOptions.FormSubmission": "schemas:webhooks-specification:@filters:@sourceOptions:@formSubmission",
     "pyairtable.models.webhook:WebhookSpecification.SourceOptions.FormPageSubmission": "schemas:webhooks-specification:@filters:@sourceOptions:@formPageSubmission",
+    "pyairtable.models.schema:TableSchema.DateDependency": "schemas:date-dependency-settings",
 }
 
 IGNORED = [
@@ -125,6 +126,11 @@ IGNORED = [
 
 def main() -> None:
     initdata = get_api_data()
+    identify_missing_fields(initdata)
+    identify_unscanned_classes(initdata)
+
+
+def identify_missing_fields(initdata: "ApiData") -> None:
     issues: List[str] = []
 
     # Find missing/extra fields
@@ -142,8 +148,11 @@ def main() -> None:
         for issue in issues:
             print(issue)
 
+
+def identify_unscanned_classes(initdata: "ApiData") -> None:
+    issues: List[str] = []
+
     # Find unscanned model classes
-    issues.clear()
     modules = sorted({model_path.split(":")[0] for model_path in SCAN_MODELS})
     for modname in modules:
         if not ignore_name(modname):

--- a/scripts/find_model_changes.py
+++ b/scripts/find_model_changes.py
@@ -8,7 +8,7 @@ import json
 import re
 from functools import cached_property
 from operator import attrgetter
-from typing import Any, Dict, Iterator, List, Type
+from typing import Any, Dict, Iterator, List, Optional, Type
 
 import click
 import requests
@@ -133,7 +133,7 @@ IGNORED = [
     help="Save API schema information to a file.",
     type=click.Path(writable=True),
 )
-def main(save_apidata: str | None) -> None:
+def main(save_apidata: Optional[str]) -> None:
     api_data = get_api_data()
     if save_apidata:
         with open(save_apidata, "w") as f:

--- a/tests/sample_data/BaseShares.json
+++ b/tests/sample_data/BaseShares.json
@@ -7,6 +7,7 @@
         "foobar.com"
       ],
       "isPasswordProtected": true,
+      "restrictedToEnterpriseMembers": false,
       "restrictedToEmailDomains": [
         "foobar.com"
       ],
@@ -19,6 +20,7 @@
       "createdByUserId": "usrL2PNC5o3H4lBEi",
       "createdTime": "2019-01-01T00:00:00.000Z",
       "isPasswordProtected": false,
+      "restrictedToEnterpriseMembers": false,
       "restrictedToEmailDomains": [],
       "shareId": "shrMg5vs9SpczJvQp",
       "shareTokenPrefix": "shrMg5vs",
@@ -31,6 +33,7 @@
       "createdByUserId": "usrL2PNC5o3H4lBEi",
       "createdTime": "2019-01-01T00:00:00.000Z",
       "isPasswordProtected": false,
+      "restrictedToEnterpriseMembers": false,
       "restrictedToEmailDomains": [],
       "shareId": "shrjjKdhMg5vs9Spc",
       "shareTokenPrefix": "shrjjKdh",

--- a/tests/sample_data/UserGroup.json
+++ b/tests/sample_data/UserGroup.json
@@ -29,6 +29,7 @@
   "createdTime": "2021-06-02T07:37:19.000Z",
   "enterpriseAccountId": "entUBq2RGdihxl3vU",
   "id": "ugp1mKGb3KXUyQfOZ",
+  "mappedUserLicenseType": "contributor",
   "members": [
     {
       "createdTime": "2021-06-02T07:37:19.000Z",


### PR DESCRIPTION
I ran `python -m scripts.find_model_changes` and found a few new model entries that weren't explicitly called out as changes in the changelog. I've added those here. One of those fields is [date dependency settings](https://airtable.com/developers/web/api/model/date-dependency-settings), which was a bit complex so I added a convenience method for creating it.