### PR TITLE
enh: Add PyAirtable Caching Layer

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,6 +18,9 @@ API: pyairtable
 .. autoclass:: pyairtable.Table
     :members:
 
+.. autoclass:: pyairtable.TableTTLConfig
+    :members:
+
 .. autoclass:: pyairtable.Workspace
     :members:
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,9 @@ Changelog
 3.3.0 (2025-11-05)
 ------------------------
 
+* Added opt-in TTL caching for ``Table.all`` and ``Table.first`` via
+  :meth:`Api.enable_caching <pyairtable.Api.enable_caching>` and
+  :class:`~pyairtable.TableTTLConfig`.
 * Added ``count_comments=`` parameter to ``Table.all`` and ``Table.first``.
   - `PR #441 <https://github.com/gtalarico/pyairtable/pull/441>`_
 * Added support for `Create Workspace <https://airtable.com/developers/web/api/create-workspace>`_

--- a/docs/source/tables.rst
+++ b/docs/source/tables.rst
@@ -77,6 +77,53 @@ multiple requests.
   [{'id': 'rec123asa23', 'fields': {'Last Name': 'Alfred', 'Age': 84}, ...}, ...]
 
 
+Record Caching
+**************
+
+You can enable TTL-based caching for calls to :meth:`~pyairtable.Table.all`
+and :meth:`~pyairtable.Table.first` when your application repeatedly reads the
+same record lists. Caching is disabled by default and is configured on the
+:class:`~pyairtable.Api` instance, so all tables created from that API will share
+the same cache.
+
+.. code-block:: python
+
+  >>> from pyairtable import Api, TableTTLConfig
+  >>> api = Api("pat...")
+  >>> api.enable_caching(
+  ...     TableTTLConfig(
+  ...         default_ttl_seconds=300,
+  ...         overrides={"Projects": 60},
+  ...         max_entries=512,
+  ...     )
+  ... )
+  >>> table = api.table("app123...", "Projects")
+  >>> table.all(view="Open")  # Fetches records from Airtable
+  [{'id': 'rec123...', 'fields': {'Name': 'Launch'}, ...}]
+  >>> table.all(view="Open")  # Returns the cached records
+  [{'id': 'rec123...', 'fields': {'Name': 'Launch'}, ...}]
+
+Cache entries are keyed by the base, table, and query options that affect the
+returned records, such as ``view``, ``formula``, ``fields``, ``sort``,
+``max_records``, and ``count_comments``. The ``page_size`` option is ignored
+because it only controls pagination while fetching the same result set.
+:meth:`~pyairtable.Table.iterate` and :meth:`~pyairtable.Table.get` are not
+cached.
+
+Writes made through the same :class:`~pyairtable.Api` instance automatically
+invalidate cached record lists for that table. This includes
+:meth:`~pyairtable.Table.create`, :meth:`~pyairtable.Table.batch_create`,
+:meth:`~pyairtable.Table.update`, :meth:`~pyairtable.Table.batch_update`,
+:meth:`~pyairtable.Table.batch_upsert`, :meth:`~pyairtable.Table.delete`,
+:meth:`~pyairtable.Table.batch_delete`, and
+:meth:`~pyairtable.Table.upload_attachment`.
+
+Changes made outside that API instance, such as writes from another process or
+another Airtable client, are not visible until the matching cache entry expires.
+You can call :meth:`~pyairtable.Api.disable_caching` to discard the cache, or
+:meth:`~pyairtable.Api.cache_stats` to inspect cache entries while debugging.
+
+
 Parameters
 **********
 

--- a/pyairtable/__init__.py
+++ b/pyairtable/__init__.py
@@ -1,6 +1,7 @@
 __version__ = "3.3.0"
 
 from pyairtable.api import Api, Base, Table
+from pyairtable.api.caching import TableTTLConfig
 from pyairtable.api.enterprise import Enterprise
 from pyairtable.api.retrying import retry_strategy
 from pyairtable.api.workspace import Workspace
@@ -10,6 +11,7 @@ __all__ = [
     "Base",
     "Enterprise",
     "Table",
+    "TableTTLConfig",
     "Workspace",
     "retry_strategy",
 ]

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,5 +1,16 @@
 from functools import cached_property
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import requests
 from requests.sessions import Session
@@ -188,15 +199,12 @@ class Api:
             self._base_from_info(info) for info in self._base_info(force=force).bases
         ]
 
-    def enable_caching(
-        self, ttl_config: Optional[TableTTLConfig] = None
-    ) -> None:
+    def enable_caching(self, ttl_config: Optional[TableTTLConfig] = None) -> None:
         """
         Enable TTL-based caching for table record fetches.
 
-        When enabled, calls to :meth:`Table.all() <pyairtable.Table.all>`,
-        :meth:`Table.iterate() <pyairtable.Table.iterate>`, and
-        :meth:`Table.first() <pyairtable.Table.first>` will return
+        When enabled, calls to :meth:`Table.all() <pyairtable.Table.all>`
+        and :meth:`Table.first() <pyairtable.Table.first>` will return
         cached results if a fresh entry exists for the same query parameters.
         Cached entries are automatically invalidated when records are created,
         updated, or deleted through this :class:`Api` instance.
@@ -234,9 +242,13 @@ class Api:
             return None
         return self._record_cache.stats()
 
-    def _invalidate_cache_for_table(self, base_id: str, table_name: str) -> None:
+    def _invalidate_cache_for_table(
+        self,
+        base_id: str,
+        table_id_or_names: Iterable[str],
+    ) -> None:
         if self._record_cache is not None:
-            self._record_cache.invalidate_table(base_id, table_name)
+            self._record_cache.invalidate_table(base_id, table_id_or_names)
 
     def create_base(
         self,

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -7,7 +7,7 @@ from typing_extensions import TypeAlias
 
 from pyairtable.api import retrying
 from pyairtable.api.base import Base
-from pyairtable.api.caching import RequestCache, TableTTLConfig
+from pyairtable.api.caching import RecordCache, TableTTLConfig
 from pyairtable.api.enterprise import Enterprise
 from pyairtable.api.params import options_to_json_and_params, options_to_params
 from pyairtable.api.table import Table
@@ -52,7 +52,7 @@ class Api:
     endpoint_url: Url
     session: Session
     use_field_ids: bool
-    _request_cache: Optional[RequestCache] = None
+    _record_cache: Optional[RecordCache] = None
 
     class _urls(UrlBuilder):
         whoami = Url("meta/whoami")
@@ -192,15 +192,18 @@ class Api:
         self, ttl_config: Optional[TableTTLConfig] = None
     ) -> None:
         """
-        Enable request-level caching for table record fetches.
+        Enable TTL-based caching for table record fetches.
 
-        When enabled, calls to ``table.all()``, ``table.iterate()``, and ``table.get()``
-        will cache results based on the query parameters. Cached results are automatically
-        invalidated when records are created, updated, or deleted.
+        When enabled, calls to :meth:`Table.all() <pyairtable.Table.all>`,
+        :meth:`Table.iterate() <pyairtable.Table.iterate>`, and
+        :meth:`Table.first() <pyairtable.Table.first>` will return
+        cached results if a fresh entry exists for the same query parameters.
+        Cached entries are automatically invalidated when records are created,
+        updated, or deleted through this :class:`Api` instance.
 
         Args:
-            ttl_config: Configuration for cache TTLs. If not provided, uses a default
-                configuration with a 300-second TTL for all tables.
+            ttl_config: Configuration for cache TTLs. If not provided, uses a
+                default configuration with a 300-second TTL for all tables.
 
         Usage:
             >>> api = Api(token)
@@ -210,34 +213,30 @@ class Api:
             >>> table.all()  # Returns cached result
         """
         if ttl_config is None:
-            ttl_config = TableTTLConfig(default_ttl_seconds=300)
-        self._request_cache = RequestCache(ttl_config)
+            ttl_config = TableTTLConfig()
+        self._record_cache = RecordCache(ttl_config)
 
     def disable_caching(self) -> None:
-        """Disable request-level caching."""
-        self._request_cache = None
+        """Disable caching and discard all cached data."""
+        self._record_cache = None
 
     def cache_stats(self) -> Optional[Dict[str, Any]]:
         """
-        Return cache statistics for debugging.
-
-        Returns None if caching is not enabled.
+        Return cache statistics for debugging, or ``None`` if caching is disabled.
 
         Usage:
             >>> api.enable_caching()
             >>> api.table(base_id, table_name).all()
-            >>> stats = api.cache_stats()
-            >>> stats['total_entries']
-            1
+            >>> api.cache_stats()
+            {'total_entries': 1, 'entries': [...]}
         """
-        if self._request_cache is None:
+        if self._record_cache is None:
             return None
-        return self._request_cache.stats()
+        return self._record_cache.stats()
 
     def _invalidate_cache_for_table(self, base_id: str, table_name: str) -> None:
-        """Invalidate cache entries for a specific table (called on mutations)."""
-        if self._request_cache is not None:
-            self._request_cache.invalidate_table(base_id, table_name)
+        if self._record_cache is not None:
+            self._record_cache.invalidate_table(base_id, table_name)
 
     def create_base(
         self,
@@ -307,14 +306,6 @@ class Api:
             params: Additional query params to append to the URL as-is.
             json: The JSON payload for a POST/PUT/PATCH/DELETE request.
         """
-        # Check cache for GET requests to list records
-        if method.upper() == "GET" and self._request_cache is not None:
-            cache_key = self._make_cache_key(url, options)
-            if cache_key is not None:
-                cached = self._request_cache.get_entry(cache_key)
-                if cached is not None:
-                    return {"records": cached}
-
         # Convert Airtable-specific options to query params, but give priority to query params
         # that are explicitly passed via `params=`. This is to preserve backwards-compatibility for
         # any library users who might be calling `self._request` directly.
@@ -353,17 +344,7 @@ class Api:
             params=request_params,
             json=json,
         )
-        result = self._process_response(response)
-
-        # Store in cache if this was a list records call
-        if method.upper() == "GET" and self._request_cache is not None:
-            cache_key = self._make_cache_key(url, options)
-            if cache_key is not None and isinstance(result, dict):
-                records = result.get("records", [])
-                if isinstance(records, list):
-                    self._request_cache.put_entry(cache_key, records)
-
-        return result
+        return self._process_response(response)
 
     def get(self, url: str, **kwargs: Any) -> Any:
         """
@@ -392,48 +373,6 @@ class Api:
         See :meth:`~Api.request` for keyword arguments.
         """
         return self.request("DELETE", url, **kwargs)
-
-    def _make_cache_key(
-        self, url: str, options: Optional[Dict[str, Any]] = None
-    ) -> Optional[Tuple[str, str, str, str, Tuple[str, ...], str, Tuple[str, ...], bool]]:
-        """
-        Generate a cache key from URL and options.
-
-        Returns None if this URL should not be cached (e.g., not a list records call).
-        Cache key includes: base_id, table_id_or_name, formula, cell_format, fields, view, sort, use_field_ids.
-        """
-        from pyairtable.api.caching import CacheKey
-
-        # URL format: /v0/{base_id}/{table_id_or_name} for list records
-        # Parse from URL path
-        parts = url.rstrip("/").split("/")
-        if len(parts) < 2:
-            return None
-
-        base_id = parts[-2]
-        table_id_or_name = parts[-1]
-
-        if not base_id or not table_id_or_name:
-            return None
-
-        options = options or {}
-
-        # Extract cache-relevant options
-        formula = str(options.get("formula", "")) if options.get("formula") else ""
-        cell_format = str(options.get("cell_format", "")) if options.get("cell_format") else ""
-        view = str(options.get("view", "")) if options.get("view") else ""
-        use_field_ids = bool(options.get("use_field_ids", False))
-
-        # Sort fields and sort params for deterministic keys
-        fields = options.get("fields", ())
-        if fields:
-            fields = tuple(sorted(fields))
-
-        sort = options.get("sort", ())
-        if sort:
-            sort = tuple(sorted(str(s) for s in sort))
-
-        return (base_id, table_id_or_name, formula, cell_format, fields, view, sort, use_field_ids)
 
     def _process_response(self, response: requests.Response) -> Any:
         try:

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -7,6 +7,7 @@ from typing_extensions import TypeAlias
 
 from pyairtable.api import retrying
 from pyairtable.api.base import Base
+from pyairtable.api.caching import RequestCache, TableTTLConfig
 from pyairtable.api.enterprise import Enterprise
 from pyairtable.api.params import options_to_json_and_params, options_to_params
 from pyairtable.api.table import Table
@@ -51,6 +52,7 @@ class Api:
     endpoint_url: Url
     session: Session
     use_field_ids: bool
+    _request_cache: Optional[RequestCache] = None
 
     class _urls(UrlBuilder):
         whoami = Url("meta/whoami")
@@ -186,6 +188,57 @@ class Api:
             self._base_from_info(info) for info in self._base_info(force=force).bases
         ]
 
+    def enable_caching(
+        self, ttl_config: Optional[TableTTLConfig] = None
+    ) -> None:
+        """
+        Enable request-level caching for table record fetches.
+
+        When enabled, calls to ``table.all()``, ``table.iterate()``, and ``table.get()``
+        will cache results based on the query parameters. Cached results are automatically
+        invalidated when records are created, updated, or deleted.
+
+        Args:
+            ttl_config: Configuration for cache TTLs. If not provided, uses a default
+                configuration with a 300-second TTL for all tables.
+
+        Usage:
+            >>> api = Api(token)
+            >>> api.enable_caching()
+            >>> table = api.table(base_id, table_name)
+            >>> table.all()  # Makes API call
+            >>> table.all()  # Returns cached result
+        """
+        if ttl_config is None:
+            ttl_config = TableTTLConfig(default_ttl_seconds=300)
+        self._request_cache = RequestCache(ttl_config)
+
+    def disable_caching(self) -> None:
+        """Disable request-level caching."""
+        self._request_cache = None
+
+    def cache_stats(self) -> Optional[Dict[str, Any]]:
+        """
+        Return cache statistics for debugging.
+
+        Returns None if caching is not enabled.
+
+        Usage:
+            >>> api.enable_caching()
+            >>> api.table(base_id, table_name).all()
+            >>> stats = api.cache_stats()
+            >>> stats['total_entries']
+            1
+        """
+        if self._request_cache is None:
+            return None
+        return self._request_cache.stats()
+
+    def _invalidate_cache_for_table(self, base_id: str, table_name: str) -> None:
+        """Invalidate cache entries for a specific table (called on mutations)."""
+        if self._request_cache is not None:
+            self._request_cache.invalidate_table(base_id, table_name)
+
     def create_base(
         self,
         workspace_id: str,
@@ -254,6 +307,14 @@ class Api:
             params: Additional query params to append to the URL as-is.
             json: The JSON payload for a POST/PUT/PATCH/DELETE request.
         """
+        # Check cache for GET requests to list records
+        if method.upper() == "GET" and self._request_cache is not None:
+            cache_key = self._make_cache_key(url, options)
+            if cache_key is not None:
+                cached = self._request_cache.get_entry(cache_key)
+                if cached is not None:
+                    return {"records": cached}
+
         # Convert Airtable-specific options to query params, but give priority to query params
         # that are explicitly passed via `params=`. This is to preserve backwards-compatibility for
         # any library users who might be calling `self._request` directly.
@@ -292,7 +353,17 @@ class Api:
             params=request_params,
             json=json,
         )
-        return self._process_response(response)
+        result = self._process_response(response)
+
+        # Store in cache if this was a list records call
+        if method.upper() == "GET" and self._request_cache is not None:
+            cache_key = self._make_cache_key(url, options)
+            if cache_key is not None and isinstance(result, dict):
+                records = result.get("records", [])
+                if isinstance(records, list):
+                    self._request_cache.put_entry(cache_key, records)
+
+        return result
 
     def get(self, url: str, **kwargs: Any) -> Any:
         """
@@ -321,6 +392,48 @@ class Api:
         See :meth:`~Api.request` for keyword arguments.
         """
         return self.request("DELETE", url, **kwargs)
+
+    def _make_cache_key(
+        self, url: str, options: Optional[Dict[str, Any]] = None
+    ) -> Optional[Tuple[str, str, str, str, Tuple[str, ...], str, Tuple[str, ...], bool]]:
+        """
+        Generate a cache key from URL and options.
+
+        Returns None if this URL should not be cached (e.g., not a list records call).
+        Cache key includes: base_id, table_id_or_name, formula, cell_format, fields, view, sort, use_field_ids.
+        """
+        from pyairtable.api.caching import CacheKey
+
+        # URL format: /v0/{base_id}/{table_id_or_name} for list records
+        # Parse from URL path
+        parts = url.rstrip("/").split("/")
+        if len(parts) < 2:
+            return None
+
+        base_id = parts[-2]
+        table_id_or_name = parts[-1]
+
+        if not base_id or not table_id_or_name:
+            return None
+
+        options = options or {}
+
+        # Extract cache-relevant options
+        formula = str(options.get("formula", "")) if options.get("formula") else ""
+        cell_format = str(options.get("cell_format", "")) if options.get("cell_format") else ""
+        view = str(options.get("view", "")) if options.get("view") else ""
+        use_field_ids = bool(options.get("use_field_ids", False))
+
+        # Sort fields and sort params for deterministic keys
+        fields = options.get("fields", ())
+        if fields:
+            fields = tuple(sorted(fields))
+
+        sort = options.get("sort", ())
+        if sort:
+            sort = tuple(sorted(str(s) for s in sort))
+
+        return (base_id, table_id_or_name, formula, cell_format, fields, view, sort, use_field_ids)
 
     def _process_response(self, response: requests.Response) -> Any:
         try:

--- a/pyairtable/api/caching.py
+++ b/pyairtable/api/caching.py
@@ -1,0 +1,124 @@
+"""
+Request-level caching for Airtable API calls.
+
+This module provides configurable, TTL-based caching of record fetch operations.
+Caching is opt-in and is disabled by default.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+from pyairtable.api.types import RecordDict
+
+if TYPE_CHECKING:
+    pass
+
+__all__ = ["CacheEntry", "TableTTLConfig", "RequestCache"]
+
+
+@dataclass
+class CacheEntry:
+    """A single cached record set with metadata."""
+
+    records: List[RecordDict]
+    stored_at_seconds: float
+    hit_count: int = 0
+
+
+@dataclass(frozen=True)
+class TableTTLConfig:
+    """Configuration for per-table TTL (time-to-live) values."""
+
+    default_ttl_seconds: int = 300
+    overrides: Dict[str, int] = field(default_factory=dict)
+
+    def ttl_for_table(self, table_name: str) -> int:
+        """Get the TTL for a specific table."""
+        return self.overrides.get(table_name, self.default_ttl_seconds)
+
+
+CacheKey = Tuple[str, str, str, str, Tuple[str, ...], str, Tuple[str, ...], bool]
+
+
+class RequestCache:
+    """
+    Thread-safe, TTL-based cache for table record fetches.
+
+    Cache keys are tuples of (base_id, table_id_or_name, formula, cell_format,
+    fields, view, sort, use_field_ids).
+    """
+
+    def __init__(self, ttl_config: TableTTLConfig) -> None:
+        """Initialize the cache with a TTL configuration."""
+        self._store: Dict[CacheKey, CacheEntry] = {}
+        self._lock = threading.Lock()
+        self._ttl_config = ttl_config
+
+    def get_entry(self, key: CacheKey) -> Optional[List[RecordDict]]:
+        """
+        Retrieve a cached entry if it exists and has not expired.
+
+        Returns None if the entry doesn't exist or has expired.
+        """
+        table_name = key[1]
+        ttl = self._ttl_config.ttl_for_table(table_name)
+
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+
+            age = time.monotonic() - entry.stored_at_seconds
+            if age > ttl:
+                del self._store[key]
+                return None
+
+            entry.hit_count += 1
+            return entry.records
+
+    def put_entry(self, key: CacheKey, records: List[RecordDict]) -> None:
+        """Store a cache entry."""
+        entry = CacheEntry(records=records, stored_at_seconds=time.monotonic())
+        with self._lock:
+            self._store[key] = entry
+
+    def invalidate_table(self, base_id: str, table_name: str) -> None:
+        """Remove all cache entries for a specific table."""
+        with self._lock:
+            keys_to_remove = [
+                k for k in self._store if k[0] == base_id and k[1] == table_name
+            ]
+            for k in keys_to_remove:
+                del self._store[k]
+
+    def invalidate_all(self) -> None:
+        """Clear all cache entries."""
+        with self._lock:
+            self._store.clear()
+
+    def stats(self) -> Dict[str, Any]:
+        """Return cache statistics for debugging."""
+        with self._lock:
+            now = time.monotonic()
+            entries = []
+            for key, entry in self._store.items():
+                entries.append(
+                    {
+                        "base_id": key[0],
+                        "table": key[1],
+                        "formula": key[2] or "(all)",
+                        "cell_format": key[3] or "json",
+                        "fields": key[4] or "(all)",
+                        "view": key[5] or "(default)",
+                        "sort": key[6] or "(none)",
+                        "use_field_ids": key[7],
+                        "age_seconds": round(now - entry.stored_at_seconds, 1),
+                        "hit_count": entry.hit_count,
+                        "record_count": len(entry.records),
+                    }
+                )
+            return {"total_entries": len(entries), "entries": entries}

--- a/pyairtable/api/caching.py
+++ b/pyairtable/api/caching.py
@@ -2,9 +2,9 @@
 TTL-based caching for Airtable record fetches.
 
 Caching is opt-in via :meth:`Api.enable_caching() <pyairtable.Api.enable_caching>`
-and disabled by default. When enabled, calls to :meth:`~pyairtable.Table.all`,
-:meth:`~pyairtable.Table.iterate`, and :meth:`~pyairtable.Table.first` will
-return cached results if a fresh entry exists for the same query parameters.
+and disabled by default. When enabled, calls to :meth:`~pyairtable.Table.all`
+and :meth:`~pyairtable.Table.first` will return cached results if a fresh
+entry exists for the same query parameters.
 
 Cached entries are automatically invalidated when records are created, updated,
 or deleted through the same :class:`~pyairtable.Api` instance. Mutations made
@@ -17,7 +17,7 @@ import copy
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Hashable, Iterable, List, Optional, Tuple
 
 from pyairtable.api.types import RecordDict
 
@@ -30,22 +30,15 @@ class CacheKey:
     Immutable, hashable representation of a record-list query.
 
     Two queries that would return the same logical result set produce
-    equal ``CacheKey`` instances. Pagination internals (``offset``,
-    ``page_size``) are excluded; ``max_records`` is included because
-    it limits the total result set.
+    equal ``CacheKey`` instances. ``page_size`` is excluded because it
+    only controls request pagination; options like ``offset``,
+    ``max_records``, and ``count_comments`` are included because they
+    change the result set or response shape.
     """
 
     base_id: str
     table_id_or_name: str
-    formula: str = ""
-    cell_format: str = ""
-    fields: Tuple[str, ...] = ()
-    view: str = ""
-    sort: Tuple[str, ...] = ()
-    time_zone: str = ""
-    user_locale: str = ""
-    use_field_ids: bool = False
-    max_records: Optional[int] = None
+    options: Tuple[Tuple[str, Hashable], ...] = ()
 
     @classmethod
     def from_query(
@@ -54,31 +47,56 @@ class CacheKey:
         table_id_or_name: str,
         options: Dict[str, Any],
     ) -> "CacheKey":
-        fields = options.get("fields", ())
-        if isinstance(fields, (list, tuple)):
-            fields = tuple(sorted(fields))
-
-        sort = options.get("sort", ())
-        if isinstance(sort, (list, tuple)):
-            sort = tuple(sort)
-
-        max_records = options.get("max_records")
-        if max_records is not None:
-            max_records = int(max_records)
-
+        cache_options = []
+        for name, value in options.items():
+            if name == "page_size":
+                continue
+            if value is None or value is False:
+                continue
+            if name == "fields":
+                value = cls._freeze_unordered(value)
+            elif name in ("count_comments", "use_field_ids"):
+                value = bool(value)
+            elif name == "max_records":
+                value = int(value)
+            else:
+                value = cls._freeze(value)
+            cache_options.append((name, value))
         return cls(
             base_id=base_id,
             table_id_or_name=table_id_or_name,
-            formula=str(options.get("formula", "") or ""),
-            cell_format=str(options.get("cell_format", "") or ""),
-            fields=fields,
-            view=str(options.get("view", "") or ""),
-            sort=sort,
-            time_zone=str(options.get("time_zone", "") or ""),
-            user_locale=str(options.get("user_locale", "") or ""),
-            use_field_ids=bool(options.get("use_field_ids", False)),
-            max_records=max_records,
+            options=tuple(sorted(cache_options)),
         )
+
+    @staticmethod
+    def _freeze(value: Any) -> Hashable:
+        if isinstance(value, dict):
+            return tuple(
+                sorted(
+                    (str(key), CacheKey._freeze(item)) for key, item in value.items()
+                )
+            )
+        if isinstance(value, (list, tuple)):
+            return tuple(CacheKey._freeze(item) for item in value)
+        if isinstance(value, (set, frozenset)):
+            return tuple(sorted(CacheKey._freeze(item) for item in value))
+        try:
+            hash(value)
+        except TypeError:
+            return repr(value)
+        return value
+
+    @staticmethod
+    def _freeze_unordered(value: Any) -> Hashable:
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, set, frozenset)):
+            return tuple(sorted(str(item) for item in value))
+        return CacheKey._freeze(value)
+
+    def option(self, name: str, default: Any = None) -> Any:
+        """Return the normalized value for a cached option."""
+        return dict(self.options).get(name, default)
 
 
 @dataclass
@@ -146,19 +164,21 @@ class RecordCache:
         with self._lock:
             self._store[key] = entry
             if len(self._store) > self._config.max_entries:
-                oldest_key = min(
-                    self._store, key=lambda k: self._store[k].stored_at
-                )
+                oldest_key = min(self._store, key=lambda k: self._store[k].stored_at)
                 del self._store[oldest_key]
 
-    def invalidate_table(self, base_id: str, table_id_or_name: str) -> None:
+    def invalidate_table(
+        self,
+        base_id: str,
+        table_id_or_names: Iterable[str],
+    ) -> None:
         """Remove every entry whose key matches the given base + table."""
+        table_id_or_names = set(table_id_or_names)
         with self._lock:
             to_remove = [
                 k
                 for k in self._store
-                if k.base_id == base_id
-                and k.table_id_or_name == table_id_or_name
+                if k.base_id == base_id and k.table_id_or_name in table_id_or_names
             ]
             for k in to_remove:
                 del self._store[k]
@@ -177,8 +197,9 @@ class RecordCache:
                     {
                         "base_id": key.base_id,
                         "table": key.table_id_or_name,
-                        "formula": key.formula or "(all)",
-                        "view": key.view or "(default)",
+                        "formula": key.option("formula", "(all)"),
+                        "view": key.option("view", "(default)"),
+                        "options": dict(key.options),
                         "age_seconds": round(now - entry.stored_at, 1),
                         "hit_count": entry.hit_count,
                         "record_count": len(entry.records),

--- a/pyairtable/api/caching.py
+++ b/pyairtable/api/caching.py
@@ -1,122 +1,185 @@
 """
-Request-level caching for Airtable API calls.
+TTL-based caching for Airtable record fetches.
 
-This module provides configurable, TTL-based caching of record fetch operations.
-Caching is opt-in and is disabled by default.
+Caching is opt-in via :meth:`Api.enable_caching() <pyairtable.Api.enable_caching>`
+and disabled by default. When enabled, calls to :meth:`~pyairtable.Table.all`,
+:meth:`~pyairtable.Table.iterate`, and :meth:`~pyairtable.Table.first` will
+return cached results if a fresh entry exists for the same query parameters.
+
+Cached entries are automatically invalidated when records are created, updated,
+or deleted through the same :class:`~pyairtable.Api` instance. Mutations made
+by other clients or API tokens are *not* visible until the TTL expires.
 """
 
 from __future__ import annotations
 
+import copy
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from pyairtable.api.types import RecordDict
 
-if TYPE_CHECKING:
-    pass
+__all__ = ["CacheKey", "TableTTLConfig", "RecordCache"]
 
-__all__ = ["CacheEntry", "TableTTLConfig", "RequestCache"]
+
+@dataclass(frozen=True)
+class CacheKey:
+    """
+    Immutable, hashable representation of a record-list query.
+
+    Two queries that would return the same logical result set produce
+    equal ``CacheKey`` instances. Pagination internals (``offset``,
+    ``page_size``) are excluded; ``max_records`` is included because
+    it limits the total result set.
+    """
+
+    base_id: str
+    table_id_or_name: str
+    formula: str = ""
+    cell_format: str = ""
+    fields: Tuple[str, ...] = ()
+    view: str = ""
+    sort: Tuple[str, ...] = ()
+    time_zone: str = ""
+    user_locale: str = ""
+    use_field_ids: bool = False
+    max_records: Optional[int] = None
+
+    @classmethod
+    def from_query(
+        cls,
+        base_id: str,
+        table_id_or_name: str,
+        options: Dict[str, Any],
+    ) -> "CacheKey":
+        fields = options.get("fields", ())
+        if isinstance(fields, (list, tuple)):
+            fields = tuple(sorted(fields))
+
+        sort = options.get("sort", ())
+        if isinstance(sort, (list, tuple)):
+            sort = tuple(sort)
+
+        max_records = options.get("max_records")
+        if max_records is not None:
+            max_records = int(max_records)
+
+        return cls(
+            base_id=base_id,
+            table_id_or_name=table_id_or_name,
+            formula=str(options.get("formula", "") or ""),
+            cell_format=str(options.get("cell_format", "") or ""),
+            fields=fields,
+            view=str(options.get("view", "") or ""),
+            sort=sort,
+            time_zone=str(options.get("time_zone", "") or ""),
+            user_locale=str(options.get("user_locale", "") or ""),
+            use_field_ids=bool(options.get("use_field_ids", False)),
+            max_records=max_records,
+        )
 
 
 @dataclass
-class CacheEntry:
-    """A single cached record set with metadata."""
+class _CacheEntry:
+    """A cached record set with bookkeeping metadata."""
 
     records: List[RecordDict]
-    stored_at_seconds: float
+    stored_at: float
     hit_count: int = 0
 
 
 @dataclass(frozen=True)
 class TableTTLConfig:
-    """Configuration for per-table TTL (time-to-live) values."""
+    """
+    Per-table TTL configuration for the record cache.
+
+    Args:
+        default_ttl_seconds: Fallback TTL applied to any table without an override.
+        overrides: Mapping of table name/ID to TTL in seconds.
+        max_entries: Maximum number of cache entries before the oldest is evicted.
+    """
 
     default_ttl_seconds: int = 300
     overrides: Dict[str, int] = field(default_factory=dict)
+    max_entries: int = 1024
 
     def ttl_for_table(self, table_name: str) -> int:
-        """Get the TTL for a specific table."""
         return self.overrides.get(table_name, self.default_ttl_seconds)
 
 
-CacheKey = Tuple[str, str, str, str, Tuple[str, ...], str, Tuple[str, ...], bool]
-
-
-class RequestCache:
+class RecordCache:
     """
-    Thread-safe, TTL-based cache for table record fetches.
+    Thread-safe, TTL-based cache for complete record-list results.
 
-    Cache keys are tuples of (base_id, table_id_or_name, formula, cell_format,
-    fields, view, sort, use_field_ids).
+    Entries are keyed by :class:`CacheKey` and store the fully-assembled
+    list of records (all pages merged). Expired entries are lazily evicted
+    on read; a hard cap (``max_entries``) provides a safety net against
+    unbounded growth.
     """
 
-    def __init__(self, ttl_config: TableTTLConfig) -> None:
-        """Initialize the cache with a TTL configuration."""
-        self._store: Dict[CacheKey, CacheEntry] = {}
+    def __init__(self, config: TableTTLConfig) -> None:
+        self._store: Dict[CacheKey, _CacheEntry] = {}
         self._lock = threading.Lock()
-        self._ttl_config = ttl_config
+        self._config = config
 
-    def get_entry(self, key: CacheKey) -> Optional[List[RecordDict]]:
-        """
-        Retrieve a cached entry if it exists and has not expired.
-
-        Returns None if the entry doesn't exist or has expired.
-        """
-        table_name = key[1]
-        ttl = self._ttl_config.ttl_for_table(table_name)
-
+    def get(self, key: CacheKey) -> Optional[List[RecordDict]]:
+        """Return a deep copy of cached records, or ``None`` on miss/expiry."""
+        ttl = self._config.ttl_for_table(key.table_id_or_name)
         with self._lock:
             entry = self._store.get(key)
             if entry is None:
                 return None
-
-            age = time.monotonic() - entry.stored_at_seconds
-            if age > ttl:
+            if time.monotonic() - entry.stored_at > ttl:
                 del self._store[key]
                 return None
-
             entry.hit_count += 1
-            return entry.records
+            return copy.deepcopy(entry.records)
 
-    def put_entry(self, key: CacheKey, records: List[RecordDict]) -> None:
-        """Store a cache entry."""
-        entry = CacheEntry(records=records, stored_at_seconds=time.monotonic())
+    def put(self, key: CacheKey, records: List[RecordDict]) -> None:
+        """Store a deep copy of *records*, evicting the oldest entry if full."""
+        entry = _CacheEntry(
+            records=copy.deepcopy(records),
+            stored_at=time.monotonic(),
+        )
         with self._lock:
             self._store[key] = entry
+            if len(self._store) > self._config.max_entries:
+                oldest_key = min(
+                    self._store, key=lambda k: self._store[k].stored_at
+                )
+                del self._store[oldest_key]
 
-    def invalidate_table(self, base_id: str, table_name: str) -> None:
-        """Remove all cache entries for a specific table."""
+    def invalidate_table(self, base_id: str, table_id_or_name: str) -> None:
+        """Remove every entry whose key matches the given base + table."""
         with self._lock:
-            keys_to_remove = [
-                k for k in self._store if k[0] == base_id and k[1] == table_name
+            to_remove = [
+                k
+                for k in self._store
+                if k.base_id == base_id
+                and k.table_id_or_name == table_id_or_name
             ]
-            for k in keys_to_remove:
+            for k in to_remove:
                 del self._store[k]
 
     def invalidate_all(self) -> None:
-        """Clear all cache entries."""
         with self._lock:
             self._store.clear()
 
     def stats(self) -> Dict[str, Any]:
-        """Return cache statistics for debugging."""
+        """Snapshot of cache contents for debugging."""
         with self._lock:
             now = time.monotonic()
             entries = []
             for key, entry in self._store.items():
                 entries.append(
                     {
-                        "base_id": key[0],
-                        "table": key[1],
-                        "formula": key[2] or "(all)",
-                        "cell_format": key[3] or "json",
-                        "fields": key[4] or "(all)",
-                        "view": key[5] or "(default)",
-                        "sort": key[6] or "(none)",
-                        "use_field_ids": key[7],
-                        "age_seconds": round(now - entry.stored_at_seconds, 1),
+                        "base_id": key.base_id,
+                        "table": key.table_id_or_name,
+                        "formula": key.formula or "(all)",
+                        "view": key.view or "(default)",
+                        "age_seconds": round(now - entry.stored_at, 1),
                         "hit_count": entry.hit_count,
                         "record_count": len(entry.records),
                     }

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -370,7 +370,9 @@ class Table:
                 "returnFieldsByFieldId": use_field_ids,
             },
         )
-        return assert_typed_dict(RecordDict, created)
+        result = assert_typed_dict(RecordDict, created)
+        self.api._invalidate_cache_for_table(self.base.id, self.name)
+        return result
 
     def batch_create(
         self,
@@ -419,6 +421,7 @@ class Table:
             )
             inserted_records += assert_typed_dicts(RecordDict, response["records"])
 
+        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return inserted_records
 
     def update(
@@ -456,7 +459,9 @@ class Table:
                 "returnFieldsByFieldId": use_field_ids,
             },
         )
-        return assert_typed_dict(RecordDict, updated)
+        result = assert_typed_dict(RecordDict, updated)
+        self.api._invalidate_cache_for_table(self.base.id, self.name)
+        return result
 
     def batch_update(
         self,
@@ -498,6 +503,7 @@ class Table:
             )
             updated_records += assert_typed_dicts(RecordDict, response["records"])
 
+        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return updated_records
 
     def batch_upsert(
@@ -571,6 +577,7 @@ class Table:
                 assert_typed_dicts(RecordDict, response["records"])
             )
 
+        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return result
 
     def delete(self, record_id: RecordId) -> RecordDeletedDict:
@@ -586,10 +593,12 @@ class Table:
         Returns:
             Confirmation that the record was deleted.
         """
-        return assert_typed_dict(
+        result = assert_typed_dict(
             RecordDeletedDict,
             self.api.delete(self.urls.record(record_id)),
         )
+        self.api._invalidate_cache_for_table(self.base.id, self.name)
+        return result
 
     def batch_delete(self, record_ids: Iterable[RecordId]) -> List[RecordDeletedDict]:
         """
@@ -616,6 +625,7 @@ class Table:
             result = self.api.delete(self.urls.records, params={"records[]": chunk})
             deleted_records += assert_typed_dicts(RecordDeletedDict, result["records"])
 
+        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return deleted_records
 
     def comments(self, record_id: RecordId) -> List["pyairtable.models.Comment"]:

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import pyairtable.models
+from pyairtable.api.caching import CacheKey
 from pyairtable.api.types import (
     FieldName,
     RecordDeletedDict,
@@ -230,6 +231,34 @@ class Table:
         """
         return self.base.api
 
+    def _list_records_options(self, options: Dict[str, Any]) -> Dict[str, Any]:
+        options = dict(options)
+        if isinstance(formula := options.get("formula"), Formula):
+            options["formula"] = to_formula_str(formula)
+        if self.api.use_field_ids:
+            options.setdefault("use_field_ids", self.api.use_field_ids)
+        return options
+
+    def _cache_table_id_or_name(self) -> str:
+        return self._schema.id if self._schema else self.name
+
+    def _cache_table_identifiers(self) -> List[str]:
+        identifiers = [self.name, self._cache_table_id_or_name()]
+        return list(dict.fromkeys(identifiers))
+
+    def _cache_key(self, options: Dict[str, Any]) -> CacheKey:
+        return CacheKey.from_query(
+            self.base.id,
+            self._cache_table_id_or_name(),
+            options,
+        )
+
+    def _invalidate_record_cache(self) -> None:
+        self.api._invalidate_cache_for_table(
+            self.base.id,
+            self._cache_table_identifiers(),
+        )
+
     def get(self, record_id: RecordId, **options: Any) -> RecordDict:
         """
         Retrieve a record by its ID.
@@ -280,38 +309,14 @@ class Table:
             use_field_ids: |kwarg_use_field_ids|
             count_comments: |kwarg_count_comments|
         """
-        if isinstance(formula := options.get("formula"), Formula):
-            options["formula"] = to_formula_str(formula)
-        if self.api.use_field_ids:
-            options.setdefault("use_field_ids", self.api.use_field_ids)
-
-        cache = self.api._record_cache
-        cache_key = None
-        if cache is not None:
-            from pyairtable.api.caching import CacheKey
-
-            cache_key = CacheKey.from_query(
-                self.base.id, self.id_or_name, options
-            )
-            cached = cache.get(cache_key)
-            if cached is not None:
-                yield cached
-                return
-
-        all_records: List[RecordDict] = []
+        options = self._list_records_options(options)
         for page in self.api.iterate_requests(
             method="get",
             url=self.urls.records,
             fallback=("post", self.urls.records_post),
             options=options,
         ):
-            records = assert_typed_dicts(RecordDict, page.get("records", []))
-            if cache_key is not None:
-                all_records.extend(records)
-            yield records
-
-        if cache is not None and cache_key is not None:
-            cache.put(cache_key, all_records)
+            yield assert_typed_dicts(RecordDict, page.get("records", []))
 
     def all(self, **options: Any) -> List[RecordDict]:
         """
@@ -336,7 +341,18 @@ class Table:
             use_field_ids: |kwarg_use_field_ids|
             count_comments: |kwarg_count_comments|
         """
-        return [record for page in self.iterate(**options) for record in page]
+        options = self._list_records_options(options)
+        cache = self.api._record_cache
+        cache_key = self._cache_key(options) if cache is not None else None
+        if cache is not None and cache_key is not None:
+            cached = cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        records = [record for page in self.iterate(**options) for record in page]
+        if cache is not None and cache_key is not None:
+            cache.put(cache_key, records)
+        return records
 
     def first(self, **options: Any) -> Optional[RecordDict]:
         """
@@ -358,10 +374,8 @@ class Table:
             count_comments: |kwarg_count_comments|
         """
         options.update(dict(page_size=1, max_records=1))
-        for page in self.iterate(**options):
-            for record in page:
-                return record
-        return None
+        records = self.all(**options)
+        return records[0] if records else None
 
     def create(
         self,
@@ -383,6 +397,7 @@ class Table:
         """
         if use_field_ids is None:
             use_field_ids = self.api.use_field_ids
+        self._invalidate_record_cache()
         created = self.api.post(
             url=self.urls.records,
             json={
@@ -392,7 +407,6 @@ class Table:
             },
         )
         result = assert_typed_dict(RecordDict, created)
-        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return result
 
     def batch_create(
@@ -429,6 +443,7 @@ class Table:
 
         # If we got an iterator, exhaust it and collect it into a list.
         records = list(records)
+        self._invalidate_record_cache()
 
         for chunk in self.api.chunked(records):
             new_records = [{"fields": fields} for fields in chunk]
@@ -442,7 +457,6 @@ class Table:
             )
             inserted_records += assert_typed_dicts(RecordDict, response["records"])
 
-        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return inserted_records
 
     def update(
@@ -471,6 +485,7 @@ class Table:
         if use_field_ids is None:
             use_field_ids = self.api.use_field_ids
         method = "put" if replace else "patch"
+        self._invalidate_record_cache()
         updated = self.api.request(
             method=method,
             url=self.urls.record(record_id),
@@ -481,7 +496,6 @@ class Table:
             },
         )
         result = assert_typed_dict(RecordDict, updated)
-        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return result
 
     def batch_update(
@@ -510,6 +524,7 @@ class Table:
 
         # If we got an iterator, exhaust it and collect it into a list.
         records = list(records)
+        self._invalidate_record_cache()
 
         for chunk in self.api.chunked(records):
             chunk_records = [{"id": x["id"], "fields": x["fields"]} for x in chunk]
@@ -524,7 +539,6 @@ class Table:
             )
             updated_records += assert_typed_dicts(RecordDict, response["records"])
 
-        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return updated_records
 
     def batch_upsert(
@@ -576,6 +590,7 @@ class Table:
             "createdRecords": [],
             "records": [],
         }
+        self._invalidate_record_cache()
 
         for chunk in self.api.chunked(records):
             formatted_records = [
@@ -598,7 +613,6 @@ class Table:
                 assert_typed_dicts(RecordDict, response["records"])
             )
 
-        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return result
 
     def delete(self, record_id: RecordId) -> RecordDeletedDict:
@@ -614,11 +628,11 @@ class Table:
         Returns:
             Confirmation that the record was deleted.
         """
+        self._invalidate_record_cache()
         result = assert_typed_dict(
             RecordDeletedDict,
             self.api.delete(self.urls.record(record_id)),
         )
-        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return result
 
     def batch_delete(self, record_ids: Iterable[RecordId]) -> List[RecordDeletedDict]:
@@ -641,12 +655,12 @@ class Table:
 
         # If we got an iterator, exhaust it and collect it into a list.
         record_ids = list(record_ids)
+        self._invalidate_record_cache()
 
         for chunk in self.api.chunked(record_ids):
             result = self.api.delete(self.urls.records, params={"records[]": chunk})
             deleted_records += assert_typed_dicts(RecordDeletedDict, result["records"])
 
-        self.api._invalidate_cache_for_table(self.base.id, self.name)
         return deleted_records
 
     def comments(self, record_id: RecordId) -> List["pyairtable.models.Comment"]:
@@ -847,5 +861,6 @@ class Table:
             "filename": filename,
             "file": base64.encodebytes(content).decode("utf8"),  # API needs Unicode
         }
+        self._invalidate_record_cache()
         response = self.api.post(url, json=payload)
         return assert_typed_dict(UploadAttachmentResultDict, response)

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -284,13 +284,34 @@ class Table:
             options["formula"] = to_formula_str(formula)
         if self.api.use_field_ids:
             options.setdefault("use_field_ids", self.api.use_field_ids)
+
+        cache = self.api._record_cache
+        cache_key = None
+        if cache is not None:
+            from pyairtable.api.caching import CacheKey
+
+            cache_key = CacheKey.from_query(
+                self.base.id, self.id_or_name, options
+            )
+            cached = cache.get(cache_key)
+            if cached is not None:
+                yield cached
+                return
+
+        all_records: List[RecordDict] = []
         for page in self.api.iterate_requests(
             method="get",
             url=self.urls.records,
             fallback=("post", self.urls.records_post),
             options=options,
         ):
-            yield assert_typed_dicts(RecordDict, page.get("records", []))
+            records = assert_typed_dicts(RecordDict, page.get("records", []))
+            if cache_key is not None:
+                all_records.extend(records)
+            yield records
+
+        if cache is not None and cache_key is not None:
+            cache.put(cache_key, all_records)
 
     def all(self, **options: Any) -> List[RecordDict]:
         """

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -1154,5 +1154,5 @@ def YEAR(date: FunctionArg, /) -> FunctionCall:
     return FunctionCall('YEAR', date)
 
 
-# [[[end]]] (sum: 6J+3KYcsIL)
+# [[[end]]] (checksum: e89fb729872c20bdff0bf57c061dae96) (sum: 6J+3KYcsIL)
 # fmt: on

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -1545,7 +1545,7 @@ FieldSchema: TypeAlias = Union[
     UrlFieldSchema,
     UnknownFieldSchema,
 ]
-# [[[end]]] (sum: yhWbyMdrHR)
+# [[[end]]] (checksum: ca159bc8c76b1d15a2a57f0e76fb8911) (sum: yhWbyMdrHR)
 # fmt: on
 
 

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -1551,4 +1551,4 @@ __all__ = [
     "TextField",
     "UrlField",
 ]
-# [[[end]]] (sum: Wo7K0mAxiV)
+# [[[end]]] (checksum: 5a8ecad26031895bfaac551e751b7278) (sum: Wo7K0mAxiV)

--- a/tests/test_api_caching.py
+++ b/tests/test_api_caching.py
@@ -1,23 +1,28 @@
 from __future__ import annotations
 
-import copy
 import threading
-import time
 from unittest.mock import patch
 
 import pytest
 from requests_mock import Mocker
 
 from pyairtable import Api, Table, TableTTLConfig
-from pyairtable.api.caching import CacheKey, RecordCache, _CacheEntry
-
+from pyairtable.api.caching import CacheKey, RecordCache
 
 FAKE_BASE_ID = "appFAKEBASE123"
 FAKE_TABLE = "TestTable"
 
 SAMPLE_RECORDS = [
-    {"id": "rec1", "createdTime": "2024-01-01T00:00:00.000Z", "fields": {"Name": "Alpha"}},
-    {"id": "rec2", "createdTime": "2024-01-01T00:00:00.000Z", "fields": {"Name": "Beta"}},
+    {
+        "id": "rec1",
+        "createdTime": "2024-01-01T00:00:00.000Z",
+        "fields": {"Name": "Alpha"},
+    },
+    {
+        "id": "rec2",
+        "createdTime": "2024-01-01T00:00:00.000Z",
+        "fields": {"Name": "Beta"},
+    },
 ]
 
 
@@ -44,10 +49,7 @@ class TestCacheKey:
         key = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
         assert key.base_id == FAKE_BASE_ID
         assert key.table_id_or_name == FAKE_TABLE
-        assert key.formula == ""
-        assert key.fields == ()
-        assert key.sort == ()
-        assert key.use_field_ids is False
+        assert key.options == ()
 
     def test_from_query_with_options(self) -> None:
         key = CacheKey.from_query(
@@ -61,11 +63,11 @@ class TestCacheKey:
                 "use_field_ids": True,
             },
         )
-        assert key.formula == "{Name}='Alpha'"
-        assert key.view == "Grid view"
-        assert key.fields == ("A", "B")
-        assert key.sort == ("Name", "-Age")
-        assert key.use_field_ids is True
+        assert key.option("formula") == "{Name}='Alpha'"
+        assert key.option("view") == "Grid view"
+        assert key.option("fields") == ("A", "B")
+        assert key.option("sort") == ("Name", "-Age")
+        assert key.option("use_field_ids") is True
 
     def test_fields_sorted_for_equality(self) -> None:
         k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"fields": ["B", "A"]})
@@ -77,20 +79,36 @@ class TestCacheKey:
         k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"sort": ["-Age", "Name"]})
         assert k1 != k2
 
-    def test_pagination_internals_ignored(self) -> None:
-        """offset and page_size don't affect the result set, so they're excluded."""
+    def test_page_size_ignored(self) -> None:
+        """page_size changes pagination, but not Table.all() results."""
         base = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
         with_pagination = CacheKey.from_query(
             FAKE_BASE_ID,
             FAKE_TABLE,
-            {"offset": "itr123", "page_size": 100},
+            {"page_size": 100},
         )
         assert base == with_pagination
+
+    def test_offset_included_in_key(self) -> None:
+        """offset changes the returned result set, so it's part of the key."""
+        k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"offset": "itr123"})
+        assert k1 != k2
 
     def test_max_records_included_in_key(self) -> None:
         """max_records limits the result set, so it's part of the key."""
         k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
         k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"max_records": 50})
+        assert k1 != k2
+
+    def test_count_comments_included_in_key(self) -> None:
+        """count_comments changes response metadata, so it's part of the key."""
+        k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        k2 = CacheKey.from_query(
+            FAKE_BASE_ID,
+            FAKE_TABLE,
+            {"count_comments": True},
+        )
         assert k1 != k2
 
     def test_hashable(self) -> None:
@@ -102,6 +120,52 @@ class TestCacheKey:
         k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"formula": None})
         k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
         assert k1 == k2
+
+    def test_false_values_treated_as_empty(self) -> None:
+        k1 = CacheKey.from_query(
+            FAKE_BASE_ID,
+            FAKE_TABLE,
+            {"count_comments": False},
+        )
+        k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        assert k1 == k2
+
+    def test_freezes_nested_option_values(self) -> None:
+        k1 = CacheKey.from_query(
+            FAKE_BASE_ID,
+            FAKE_TABLE,
+            {"future": {"b": [2, 1], "a": {"x": "y"}}},
+        )
+        k2 = CacheKey.from_query(
+            FAKE_BASE_ID,
+            FAKE_TABLE,
+            {"future": {"a": {"x": "y"}, "b": [2, 1]}},
+        )
+        assert k1 == k2
+
+    def test_freezes_sets(self) -> None:
+        k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"future": {2, 1}})
+        k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"future": {1, 2}})
+        assert k1 == k2
+
+    def test_freezes_unhashable_objects(self) -> None:
+        class Unhashable:
+            __hash__ = None  # type: ignore
+
+        key = CacheKey.from_query(
+            FAKE_BASE_ID,
+            FAKE_TABLE,
+            {"future": Unhashable()},
+        )
+        assert "Unhashable" in key.option("future")
+
+    def test_field_name_string_is_not_split(self) -> None:
+        key = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"fields": "Name"})
+        assert key.option("fields") == "Name"
+
+    def test_unusual_fields_value_falls_back_to_freeze(self) -> None:
+        key = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"fields": 123})
+        assert key.option("fields") == 123
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +246,7 @@ class TestRecordCache:
         cache.put(k2, SAMPLE_RECORDS)
         cache.put(k3, SAMPLE_RECORDS)
 
-        cache.invalidate_table(FAKE_BASE_ID, FAKE_TABLE)
+        cache.invalidate_table(FAKE_BASE_ID, [FAKE_TABLE])
 
         assert cache.get(k1) is None
         assert cache.get(k2) is None
@@ -279,7 +343,7 @@ class TestRecordCache:
 
 
 class TestCachingIntegration:
-    """Test that caching works end-to-end through Table.all / iterate / first."""
+    """Test that caching works end-to-end through Table.all / first."""
 
     @pytest.fixture()
     def api(self) -> Api:
@@ -300,9 +364,7 @@ class TestCachingIntegration:
         responses = [{"json": page, "status_code": 200} for page in pages]
         requests_mock.get(table.urls.records, responses)
 
-    def test_all_caches_across_pages(
-        self, table: Table, requests_mock: Mocker
-    ) -> None:
+    def test_all_caches_across_pages(self, table: Table, requests_mock: Mocker) -> None:
         """table.all() assembles all pages, and the second call is a cache hit."""
         page1_records = [
             {"id": "rec1", "createdTime": "t", "fields": {"X": 1}},
@@ -328,38 +390,39 @@ class TestCachingIntegration:
         assert second_call == first_call
         assert requests_mock.call_count == 2
 
-    def test_iterate_caches(
+    def test_iterate_not_cached_and_preserves_pages(
         self, table: Table, requests_mock: Mocker
     ) -> None:
-        records = [{"id": "rec1", "createdTime": "t", "fields": {}}]
-        self._mock_list_records(
-            requests_mock, table, [{"records": records}]
-        )
+        page1_records = [{"id": "rec1", "createdTime": "t", "fields": {}}]
+        page2_records = [{"id": "rec2", "createdTime": "t", "fields": {}}]
+        pages = [
+            {"records": page1_records, "offset": "off1"},
+            {"records": page2_records},
+            {"records": page1_records, "offset": "off1"},
+            {"records": page2_records},
+        ]
+        self._mock_list_records(requests_mock, table, pages)
 
         pages1 = list(table.iterate())
-        assert len(pages1) == 1
-        assert requests_mock.call_count == 1
-
         pages2 = list(table.iterate())
-        assert pages2[0] == pages1[0]
-        assert requests_mock.call_count == 1
+        assert pages1 == [page1_records, page2_records]
+        assert pages2 == [page1_records, page2_records]
+        assert requests_mock.call_count == 4
 
-    def test_first_does_not_cache_partial_iteration(
-        self, table: Table, requests_mock: Mocker
-    ) -> None:
-        """first() short-circuits the iterator, so the cache is never populated.
-        This is correct: first() uses max_records=1, which generates a distinct
-        cache key, and the generator exits before cache.put() is reached."""
+    def test_first_caches(self, table: Table, requests_mock: Mocker) -> None:
         records = [{"id": "rec1", "createdTime": "t", "fields": {"A": 1}}]
-        requests_mock.get(table.urls.records, [
-            {"json": {"records": records}, "status_code": 200},
-            {"json": {"records": records}, "status_code": 200},
-        ])
+        requests_mock.get(
+            table.urls.records,
+            [
+                {"json": {"records": records}, "status_code": 200},
+                {"json": {"records": records}, "status_code": 200},
+            ],
+        )
 
         r1 = table.first()
         r2 = table.first()
         assert r1 == r2
-        assert requests_mock.call_count == 2
+        assert requests_mock.call_count == 1
 
     def test_different_formulas_cached_separately(
         self, table: Table, requests_mock: Mocker
@@ -368,10 +431,13 @@ class TestCachingIntegration:
         rec_b = [{"id": "rec2", "createdTime": "t", "fields": {"X": "B"}}]
 
         # Two different formulas, each served once.
-        requests_mock.get(table.urls.records, [
-            {"json": {"records": rec_a}, "status_code": 200},
-            {"json": {"records": rec_b}, "status_code": 200},
-        ])
+        requests_mock.get(
+            table.urls.records,
+            [
+                {"json": {"records": rec_a}, "status_code": 200},
+                {"json": {"records": rec_b}, "status_code": 200},
+            ],
+        )
 
         result_a = table.all(formula="{X}='A'")
         result_b = table.all(formula="{X}='B'")
@@ -382,13 +448,37 @@ class TestCachingIntegration:
         assert result_a2 == result_a
         assert requests_mock.call_count == 2
 
+    def test_count_comments_cached_separately(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        without_comments = [{"id": "rec1", "createdTime": "t", "fields": {"X": 1}}]
+        with_comments = [
+            {
+                "id": "rec1",
+                "createdTime": "t",
+                "fields": {"X": 1},
+                "commentCount": 2,
+            }
+        ]
+        requests_mock.get(
+            table.urls.records,
+            [
+                {"json": {"records": without_comments}, "status_code": 200},
+                {"json": {"records": with_comments}, "status_code": 200},
+            ],
+        )
+
+        assert table.all() == without_comments
+        assert table.all(count_comments=True) == with_comments
+        assert table.all() == without_comments
+        assert table.all(count_comments=True) == with_comments
+        assert requests_mock.call_count == 2
+
     def test_mutation_invalidates_cache(
         self, table: Table, requests_mock: Mocker
     ) -> None:
         records = [{"id": "rec1", "createdTime": "t", "fields": {"X": 1}}]
-        self._mock_list_records(
-            requests_mock, table, [{"records": records}]
-        )
+        self._mock_list_records(requests_mock, table, [{"records": records}])
         table.all()
         assert requests_mock.call_count == 1
 
@@ -397,18 +487,64 @@ class TestCachingIntegration:
         assert requests_mock.call_count == 1
 
         # Mutation invalidates cache.
-        requests_mock.post(table.urls.records, json={
-            "id": "rec2",
-            "createdTime": "t",
-            "fields": {"X": 2},
-        })
+        requests_mock.post(
+            table.urls.records,
+            json={
+                "id": "rec2",
+                "createdTime": "t",
+                "fields": {"X": 2},
+            },
+        )
         table.create({"X": 2})
         assert requests_mock.call_count == 2
 
         # Re-register GET response for the post-invalidation fetch.
-        self._mock_list_records(
-            requests_mock, table, [{"records": records}]
+        self._mock_list_records(requests_mock, table, [{"records": records}])
+        table.all()
+        assert requests_mock.call_count == 3
+
+    def test_mutation_invalidates_cache_for_quoted_table_name(
+        self, api: Api, requests_mock: Mocker
+    ) -> None:
+        api.enable_caching()
+        table = api.table("appTEST123", "My Table")
+        records = [{"id": "rec1", "createdTime": "t", "fields": {"X": 1}}]
+        self._mock_list_records(requests_mock, table, [{"records": records}])
+        table.all()
+        table.all()
+        assert requests_mock.call_count == 1
+
+        requests_mock.post(
+            table.urls.records,
+            json={
+                "id": "rec2",
+                "createdTime": "t",
+                "fields": {"X": 2},
+            },
         )
+        table.create({"X": 2})
+        self._mock_list_records(requests_mock, table, [{"records": records}])
+        table.all()
+        assert requests_mock.call_count == 3
+
+    def test_mutation_invalidates_cache_after_schema_load(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        records = [{"id": "rec1", "createdTime": "t", "fields": {"X": 1}}]
+        self._mock_list_records(requests_mock, table, [{"records": records}])
+        table.all()
+        table._schema = type("Schema", (), {"id": "tblSchema"})()  # type: ignore
+
+        requests_mock.post(
+            table.urls.records,
+            json={
+                "id": "rec2",
+                "createdTime": "t",
+                "fields": {"X": 2},
+            },
+        )
+        table.create({"X": 2})
+        self._mock_list_records(requests_mock, table, [{"records": records}])
         table.all()
         assert requests_mock.call_count == 3
 
@@ -416,9 +552,7 @@ class TestCachingIntegration:
         self, table: Table, requests_mock: Mocker
     ) -> None:
         records = [{"id": "rec1", "createdTime": "t", "fields": {"X": 1}}]
-        self._mock_list_records(
-            requests_mock, table, [{"records": records}]
-        )
+        self._mock_list_records(requests_mock, table, [{"records": records}])
         table.all()
         assert requests_mock.call_count == 1
 
@@ -429,9 +563,34 @@ class TestCachingIntegration:
         table.delete("rec1")
         assert requests_mock.call_count == 2
 
-        self._mock_list_records(
-            requests_mock, table, [{"records": []}]
+        self._mock_list_records(requests_mock, table, [{"records": []}])
+        table.all()
+        assert requests_mock.call_count == 3
+
+    def test_upload_attachment_invalidates_cache(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        records = [{"id": "rec1", "createdTime": "t", "fields": {"X": 1}}]
+        self._mock_list_records(requests_mock, table, [{"records": records}])
+        table.all()
+        table.all()
+        assert requests_mock.call_count == 1
+
+        requests_mock.post(
+            table.urls.upload_attachment("rec1", "Attachments"),
+            json={
+                "id": "rec1",
+                "createdTime": "t",
+                "fields": {"Attachments": []},
+            },
         )
+        table.upload_attachment(
+            "rec1",
+            "Attachments",
+            "example.txt",
+            content="hello",
+        )
+        self._mock_list_records(requests_mock, table, [{"records": records}])
         table.all()
         assert requests_mock.call_count == 3
 
@@ -440,23 +599,27 @@ class TestCachingIntegration:
         tbl = api.table("appTEST123", "MyTable")
 
         records = [{"id": "rec1", "createdTime": "t", "fields": {}}]
-        requests_mock.get(tbl.urls.records, [
-            {"json": {"records": records}, "status_code": 200},
-            {"json": {"records": records}, "status_code": 200},
-        ])
+        requests_mock.get(
+            tbl.urls.records,
+            [
+                {"json": {"records": records}, "status_code": 200},
+                {"json": {"records": records}, "status_code": 200},
+            ],
+        )
 
         tbl.all()
         tbl.all()
         assert requests_mock.call_count == 2
 
-    def test_disable_caching(
-        self, table: Table, requests_mock: Mocker
-    ) -> None:
+    def test_disable_caching(self, table: Table, requests_mock: Mocker) -> None:
         records = [{"id": "rec1", "createdTime": "t", "fields": {}}]
-        requests_mock.get(table.urls.records, [
-            {"json": {"records": records}, "status_code": 200},
-            {"json": {"records": records}, "status_code": 200},
-        ])
+        requests_mock.get(
+            table.urls.records,
+            [
+                {"json": {"records": records}, "status_code": 200},
+                {"json": {"records": records}, "status_code": 200},
+            ],
+        )
 
         table.all()
         assert requests_mock.call_count == 1
@@ -466,13 +629,9 @@ class TestCachingIntegration:
         table.all()
         assert requests_mock.call_count == 2
 
-    def test_cache_stats(
-        self, table: Table, requests_mock: Mocker
-    ) -> None:
+    def test_cache_stats(self, table: Table, requests_mock: Mocker) -> None:
         records = [{"id": "rec1", "createdTime": "t", "fields": {}}]
-        self._mock_list_records(
-            requests_mock, table, [{"records": records}]
-        )
+        self._mock_list_records(requests_mock, table, [{"records": records}])
         table.all()
         table.all()
 

--- a/tests/test_api_caching.py
+++ b/tests/test_api_caching.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyairtable.api.caching import CacheEntry, RequestCache, TableTTLConfig
+
+
+FAKE_BASE_ID = "appFAKEBASE123"
+FAKE_TABLE = "TestTable"
+
+SAMPLE_RECORDS = [
+    {"id": "rec1", "fields": {"Name": "Alpha"}},
+    {"id": "rec2", "fields": {"Name": "Beta"}},
+]
+
+
+def _make_cache(
+    default_ttl: int = 300, overrides: dict[str, int] | None = None
+) -> RequestCache:
+    config = TableTTLConfig(
+        default_ttl_seconds=default_ttl,
+        overrides=overrides or {},
+    )
+    return RequestCache(config)
+
+
+class TestTableTTLConfig:
+    def test_default_ttl(self) -> None:
+        config = TableTTLConfig(default_ttl_seconds=300)
+        assert config.ttl_for_table("Anything") == 300
+
+    def test_override_ttl(self) -> None:
+        config = TableTTLConfig(
+            default_ttl_seconds=300,
+            overrides={"Workstreams": 900},
+        )
+        assert config.ttl_for_table("Workstreams") == 900
+        assert config.ttl_for_table("Initiatives") == 300
+
+    def test_frozen_config(self) -> None:
+        config = TableTTLConfig(default_ttl_seconds=300)
+        with pytest.raises(AttributeError):
+            config.default_ttl_seconds = 100  # type: ignore
+
+
+class TestCacheEntry:
+    def test_cache_entry_creation(self) -> None:
+        entry = CacheEntry(records=SAMPLE_RECORDS, stored_at_seconds=time.monotonic())
+        assert entry.records == SAMPLE_RECORDS
+        assert entry.hit_count == 0
+
+    def test_cache_entry_hit_count(self) -> None:
+        entry = CacheEntry(records=SAMPLE_RECORDS, stored_at_seconds=time.monotonic())
+        entry.hit_count += 1
+        entry.hit_count += 1
+        assert entry.hit_count == 2
+
+
+class TestRequestCache:
+    def test_put_and_get_entry(self) -> None:
+        cache = _make_cache()
+        key = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
+        cache.put_entry(key, SAMPLE_RECORDS)
+
+        result = cache.get_entry(key)
+        assert result == SAMPLE_RECORDS
+
+    def test_miss_returns_none(self) -> None:
+        cache = _make_cache()
+        result = cache.get_entry((FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False))
+        assert result is None
+
+    def test_ttl_expiry(self) -> None:
+        cache = _make_cache(default_ttl=10)
+        key = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
+
+        with patch("pyairtable.api.caching.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            cache.put_entry(key, SAMPLE_RECORDS)
+
+            mock_time.monotonic.return_value = 1005.0
+            assert cache.get_entry(key) == SAMPLE_RECORDS
+
+            mock_time.monotonic.return_value = 1011.0
+            assert cache.get_entry(key) is None
+
+    def test_per_table_ttl_override(self) -> None:
+        cache = _make_cache(default_ttl=300, overrides={"ShortLived": 5})
+        key_short = (FAKE_BASE_ID, "ShortLived", "", "", (), "", (), False)
+        key_long = (FAKE_BASE_ID, "LongLived", "", "", (), "", (), False)
+
+        with patch("pyairtable.api.caching.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            cache.put_entry(key_short, SAMPLE_RECORDS)
+            cache.put_entry(key_long, SAMPLE_RECORDS)
+
+            mock_time.monotonic.return_value = 1006.0
+            assert cache.get_entry(key_short) is None
+            assert cache.get_entry(key_long) == SAMPLE_RECORDS
+
+    def test_invalidate_table_removes_all_formulas(self) -> None:
+        cache = _make_cache()
+        key_no_formula = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
+        key_with_formula = (FAKE_BASE_ID, FAKE_TABLE, "{Quarter}='Q3'", "", (), "", (), False)
+        other_table_key = (FAKE_BASE_ID, "OtherTable", "", "", (), "", (), False)
+
+        cache.put_entry(key_no_formula, SAMPLE_RECORDS)
+        cache.put_entry(key_with_formula, SAMPLE_RECORDS)
+        cache.put_entry(other_table_key, SAMPLE_RECORDS)
+
+        cache.invalidate_table(FAKE_BASE_ID, FAKE_TABLE)
+
+        assert cache.get_entry(key_no_formula) is None
+        assert cache.get_entry(key_with_formula) is None
+        assert cache.get_entry(other_table_key) == SAMPLE_RECORDS
+
+    def test_invalidate_all(self) -> None:
+        cache = _make_cache()
+        cache.put_entry((FAKE_BASE_ID, "A", "", "", (), "", (), False), SAMPLE_RECORDS)
+        cache.put_entry((FAKE_BASE_ID, "B", "", "", (), "", (), False), SAMPLE_RECORDS)
+
+        cache.invalidate_all()
+
+        assert cache.get_entry((FAKE_BASE_ID, "A", "", "", (), "", (), False)) is None
+        assert cache.get_entry((FAKE_BASE_ID, "B", "", "", (), "", (), False)) is None
+
+    def test_stats(self) -> None:
+        cache = _make_cache()
+        cache.put_entry((FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False), SAMPLE_RECORDS)
+        cache.get_entry((FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False))
+
+        stats = cache.stats()
+        assert stats["total_entries"] == 1
+        assert stats["entries"][0]["table"] == FAKE_TABLE
+        assert stats["entries"][0]["hit_count"] == 1
+        assert stats["entries"][0]["record_count"] == 2
+
+    def test_hit_count_increments(self) -> None:
+        cache = _make_cache()
+        key = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
+        cache.put_entry(key, SAMPLE_RECORDS)
+
+        cache.get_entry(key)
+        cache.get_entry(key)
+        cache.get_entry(key)
+
+        stats = cache.stats()
+        assert stats["entries"][0]["hit_count"] == 3
+
+    def test_thread_safety(self) -> None:
+        cache = _make_cache(default_ttl=1)
+        key = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
+        errors: list[Exception] = []
+
+        def reader() -> None:
+            try:
+                for _ in range(50):
+                    cache.get_entry(key)
+            except Exception as exc:
+                errors.append(exc)
+
+        def writer() -> None:
+            try:
+                for _ in range(50):
+                    cache.put_entry(key, SAMPLE_RECORDS)
+            except Exception as exc:
+                errors.append(exc)
+
+        cache.put_entry(key, SAMPLE_RECORDS)
+        threads = [threading.Thread(target=reader) for _ in range(4)]
+        threads += [threading.Thread(target=writer) for _ in range(2)]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+
+    def test_different_cache_keys_separate(self) -> None:
+        cache = _make_cache()
+        key1 = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
+        key2 = (FAKE_BASE_ID, FAKE_TABLE, "{Name}='Alpha'", "", (), "", (), False)
+        key3 = (FAKE_BASE_ID, FAKE_TABLE, "", "", ("Field1", "Field2"), "", (), False)
+
+        records1 = [{"id": "rec1", "fields": {"Name": "One"}}]
+        records2 = [{"id": "rec2", "fields": {"Name": "Two"}}]
+        records3 = [{"id": "rec3", "fields": {"Name": "Three"}}]
+
+        cache.put_entry(key1, records1)
+        cache.put_entry(key2, records2)
+        cache.put_entry(key3, records3)
+
+        assert cache.get_entry(key1) == records1
+        assert cache.get_entry(key2) == records2
+        assert cache.get_entry(key3) == records3
+
+    def test_stats_with_multiple_entries(self) -> None:
+        cache = _make_cache()
+        cache.put_entry((FAKE_BASE_ID, "Table1", "", "", (), "", (), False), SAMPLE_RECORDS)
+        cache.put_entry((FAKE_BASE_ID, "Table2", "", "", (), "", (), False), SAMPLE_RECORDS)
+        cache.put_entry((FAKE_BASE_ID, "Table1", "{Name}='Alpha'", "", (), "", (), False), SAMPLE_RECORDS)
+
+        cache.get_entry((FAKE_BASE_ID, "Table1", "", "", (), "", (), False))
+        cache.get_entry((FAKE_BASE_ID, "Table2", "", "", (), "", (), False))
+
+        stats = cache.stats()
+        assert stats["total_entries"] == 3
+        assert len(stats["entries"]) == 3
+
+    def test_expired_entry_removed_on_get(self) -> None:
+        cache = _make_cache(default_ttl=5)
+        key = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
+
+        with patch("pyairtable.api.caching.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            cache.put_entry(key, SAMPLE_RECORDS)
+            stats_before = cache.stats()
+            assert stats_before["total_entries"] == 1
+
+            mock_time.monotonic.return_value = 1006.0
+            result = cache.get_entry(key)
+            assert result is None
+
+            stats_after = cache.stats()
+            assert stats_after["total_entries"] == 0

--- a/tests/test_api_caching.py
+++ b/tests/test_api_caching.py
@@ -1,31 +1,112 @@
 from __future__ import annotations
 
+import copy
 import threading
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
+from requests_mock import Mocker
 
-from pyairtable.api.caching import CacheEntry, RequestCache, TableTTLConfig
+from pyairtable import Api, Table, TableTTLConfig
+from pyairtable.api.caching import CacheKey, RecordCache, _CacheEntry
 
 
 FAKE_BASE_ID = "appFAKEBASE123"
 FAKE_TABLE = "TestTable"
 
 SAMPLE_RECORDS = [
-    {"id": "rec1", "fields": {"Name": "Alpha"}},
-    {"id": "rec2", "fields": {"Name": "Beta"}},
+    {"id": "rec1", "createdTime": "2024-01-01T00:00:00.000Z", "fields": {"Name": "Alpha"}},
+    {"id": "rec2", "createdTime": "2024-01-01T00:00:00.000Z", "fields": {"Name": "Beta"}},
 ]
 
 
 def _make_cache(
-    default_ttl: int = 300, overrides: dict[str, int] | None = None
-) -> RequestCache:
+    default_ttl: int = 300,
+    overrides: dict[str, int] | None = None,
+    max_entries: int = 1024,
+) -> RecordCache:
     config = TableTTLConfig(
         default_ttl_seconds=default_ttl,
         overrides=overrides or {},
+        max_entries=max_entries,
     )
-    return RequestCache(config)
+    return RecordCache(config)
+
+
+# ---------------------------------------------------------------------------
+# CacheKey
+# ---------------------------------------------------------------------------
+
+
+class TestCacheKey:
+    def test_from_query_defaults(self) -> None:
+        key = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        assert key.base_id == FAKE_BASE_ID
+        assert key.table_id_or_name == FAKE_TABLE
+        assert key.formula == ""
+        assert key.fields == ()
+        assert key.sort == ()
+        assert key.use_field_ids is False
+
+    def test_from_query_with_options(self) -> None:
+        key = CacheKey.from_query(
+            FAKE_BASE_ID,
+            FAKE_TABLE,
+            {
+                "formula": "{Name}='Alpha'",
+                "view": "Grid view",
+                "fields": ["B", "A"],
+                "sort": ["Name", "-Age"],
+                "use_field_ids": True,
+            },
+        )
+        assert key.formula == "{Name}='Alpha'"
+        assert key.view == "Grid view"
+        assert key.fields == ("A", "B")
+        assert key.sort == ("Name", "-Age")
+        assert key.use_field_ids is True
+
+    def test_fields_sorted_for_equality(self) -> None:
+        k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"fields": ["B", "A"]})
+        k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"fields": ["A", "B"]})
+        assert k1 == k2
+
+    def test_sort_order_preserved(self) -> None:
+        k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"sort": ["Name", "-Age"]})
+        k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"sort": ["-Age", "Name"]})
+        assert k1 != k2
+
+    def test_pagination_internals_ignored(self) -> None:
+        """offset and page_size don't affect the result set, so they're excluded."""
+        base = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        with_pagination = CacheKey.from_query(
+            FAKE_BASE_ID,
+            FAKE_TABLE,
+            {"offset": "itr123", "page_size": 100},
+        )
+        assert base == with_pagination
+
+    def test_max_records_included_in_key(self) -> None:
+        """max_records limits the result set, so it's part of the key."""
+        k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"max_records": 50})
+        assert k1 != k2
+
+    def test_hashable(self) -> None:
+        key = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        d = {key: "value"}
+        assert d[key] == "value"
+
+    def test_none_values_treated_as_empty(self) -> None:
+        k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"formula": None})
+        k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        assert k1 == k2
+
+
+# ---------------------------------------------------------------------------
+# TableTTLConfig
+# ---------------------------------------------------------------------------
 
 
 class TestTableTTLConfig:
@@ -41,97 +122,120 @@ class TestTableTTLConfig:
         assert config.ttl_for_table("Workstreams") == 900
         assert config.ttl_for_table("Initiatives") == 300
 
-    def test_frozen_config(self) -> None:
+    def test_frozen(self) -> None:
         config = TableTTLConfig(default_ttl_seconds=300)
         with pytest.raises(AttributeError):
             config.default_ttl_seconds = 100  # type: ignore
 
 
-class TestCacheEntry:
-    def test_cache_entry_creation(self) -> None:
-        entry = CacheEntry(records=SAMPLE_RECORDS, stored_at_seconds=time.monotonic())
-        assert entry.records == SAMPLE_RECORDS
-        assert entry.hit_count == 0
-
-    def test_cache_entry_hit_count(self) -> None:
-        entry = CacheEntry(records=SAMPLE_RECORDS, stored_at_seconds=time.monotonic())
-        entry.hit_count += 1
-        entry.hit_count += 1
-        assert entry.hit_count == 2
+# ---------------------------------------------------------------------------
+# RecordCache unit tests
+# ---------------------------------------------------------------------------
 
 
-class TestRequestCache:
-    def test_put_and_get_entry(self) -> None:
+class TestRecordCache:
+    def test_put_and_get(self) -> None:
         cache = _make_cache()
-        key = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
-        cache.put_entry(key, SAMPLE_RECORDS)
-
-        result = cache.get_entry(key)
-        assert result == SAMPLE_RECORDS
+        key = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        cache.put(key, SAMPLE_RECORDS)
+        assert cache.get(key) == SAMPLE_RECORDS
 
     def test_miss_returns_none(self) -> None:
         cache = _make_cache()
-        result = cache.get_entry((FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False))
-        assert result is None
+        assert cache.get(CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})) is None
 
     def test_ttl_expiry(self) -> None:
         cache = _make_cache(default_ttl=10)
-        key = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
+        key = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
 
         with patch("pyairtable.api.caching.time") as mock_time:
             mock_time.monotonic.return_value = 1000.0
-            cache.put_entry(key, SAMPLE_RECORDS)
+            cache.put(key, SAMPLE_RECORDS)
 
             mock_time.monotonic.return_value = 1005.0
-            assert cache.get_entry(key) == SAMPLE_RECORDS
+            assert cache.get(key) == SAMPLE_RECORDS
 
             mock_time.monotonic.return_value = 1011.0
-            assert cache.get_entry(key) is None
+            assert cache.get(key) is None
 
     def test_per_table_ttl_override(self) -> None:
         cache = _make_cache(default_ttl=300, overrides={"ShortLived": 5})
-        key_short = (FAKE_BASE_ID, "ShortLived", "", "", (), "", (), False)
-        key_long = (FAKE_BASE_ID, "LongLived", "", "", (), "", (), False)
+        key_short = CacheKey.from_query(FAKE_BASE_ID, "ShortLived", {})
+        key_long = CacheKey.from_query(FAKE_BASE_ID, "LongLived", {})
 
         with patch("pyairtable.api.caching.time") as mock_time:
             mock_time.monotonic.return_value = 1000.0
-            cache.put_entry(key_short, SAMPLE_RECORDS)
-            cache.put_entry(key_long, SAMPLE_RECORDS)
+            cache.put(key_short, SAMPLE_RECORDS)
+            cache.put(key_long, SAMPLE_RECORDS)
 
             mock_time.monotonic.return_value = 1006.0
-            assert cache.get_entry(key_short) is None
-            assert cache.get_entry(key_long) == SAMPLE_RECORDS
+            assert cache.get(key_short) is None
+            assert cache.get(key_long) == SAMPLE_RECORDS
 
-    def test_invalidate_table_removes_all_formulas(self) -> None:
+    def test_invalidate_table(self) -> None:
         cache = _make_cache()
-        key_no_formula = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
-        key_with_formula = (FAKE_BASE_ID, FAKE_TABLE, "{Quarter}='Q3'", "", (), "", (), False)
-        other_table_key = (FAKE_BASE_ID, "OtherTable", "", "", (), "", (), False)
+        k1 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        k2 = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {"formula": "x"})
+        k3 = CacheKey.from_query(FAKE_BASE_ID, "Other", {})
 
-        cache.put_entry(key_no_formula, SAMPLE_RECORDS)
-        cache.put_entry(key_with_formula, SAMPLE_RECORDS)
-        cache.put_entry(other_table_key, SAMPLE_RECORDS)
+        cache.put(k1, SAMPLE_RECORDS)
+        cache.put(k2, SAMPLE_RECORDS)
+        cache.put(k3, SAMPLE_RECORDS)
 
         cache.invalidate_table(FAKE_BASE_ID, FAKE_TABLE)
 
-        assert cache.get_entry(key_no_formula) is None
-        assert cache.get_entry(key_with_formula) is None
-        assert cache.get_entry(other_table_key) == SAMPLE_RECORDS
+        assert cache.get(k1) is None
+        assert cache.get(k2) is None
+        assert cache.get(k3) == SAMPLE_RECORDS
 
     def test_invalidate_all(self) -> None:
         cache = _make_cache()
-        cache.put_entry((FAKE_BASE_ID, "A", "", "", (), "", (), False), SAMPLE_RECORDS)
-        cache.put_entry((FAKE_BASE_ID, "B", "", "", (), "", (), False), SAMPLE_RECORDS)
-
+        cache.put(CacheKey.from_query(FAKE_BASE_ID, "A", {}), SAMPLE_RECORDS)
+        cache.put(CacheKey.from_query(FAKE_BASE_ID, "B", {}), SAMPLE_RECORDS)
         cache.invalidate_all()
+        assert cache.get(CacheKey.from_query(FAKE_BASE_ID, "A", {})) is None
 
-        assert cache.get_entry((FAKE_BASE_ID, "A", "", "", (), "", (), False)) is None
-        assert cache.get_entry((FAKE_BASE_ID, "B", "", "", (), "", (), False)) is None
+    def test_deep_copy_isolation(self) -> None:
+        """Mutating returned records must not corrupt the cache."""
+        cache = _make_cache()
+        key = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        original = [{"id": "rec1", "createdTime": "t", "fields": {"Name": "A"}}]
+        cache.put(key, original)
+
+        original[0]["fields"]["Name"] = "MUTATED"
+
+        result = cache.get(key)
+        assert result is not None
+        assert result[0]["fields"]["Name"] == "A"
+
+        result[0]["fields"]["Name"] = "ALSO_MUTATED"
+        result2 = cache.get(key)
+        assert result2 is not None
+        assert result2[0]["fields"]["Name"] == "A"
+
+    def test_max_entries_eviction(self) -> None:
+        cache = _make_cache(max_entries=2)
+        k1 = CacheKey.from_query(FAKE_BASE_ID, "T1", {})
+        k2 = CacheKey.from_query(FAKE_BASE_ID, "T2", {})
+        k3 = CacheKey.from_query(FAKE_BASE_ID, "T3", {})
+
+        with patch("pyairtable.api.caching.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            cache.put(k1, SAMPLE_RECORDS)
+            mock_time.monotonic.return_value = 200.0
+            cache.put(k2, SAMPLE_RECORDS)
+            mock_time.monotonic.return_value = 300.0
+            cache.put(k3, SAMPLE_RECORDS)
+
+            assert cache.get(k1) is None
+            assert cache.get(k2) == SAMPLE_RECORDS
+            assert cache.get(k3) == SAMPLE_RECORDS
 
     def test_stats(self) -> None:
         cache = _make_cache()
-        cache.put_entry((FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False), SAMPLE_RECORDS)
-        cache.get_entry((FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False))
+        key = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
+        cache.put(key, SAMPLE_RECORDS)
+        cache.get(key)
 
         stats = cache.stats()
         assert stats["total_entries"] == 1
@@ -139,41 +243,28 @@ class TestRequestCache:
         assert stats["entries"][0]["hit_count"] == 1
         assert stats["entries"][0]["record_count"] == 2
 
-    def test_hit_count_increments(self) -> None:
-        cache = _make_cache()
-        key = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
-        cache.put_entry(key, SAMPLE_RECORDS)
-
-        cache.get_entry(key)
-        cache.get_entry(key)
-        cache.get_entry(key)
-
-        stats = cache.stats()
-        assert stats["entries"][0]["hit_count"] == 3
-
     def test_thread_safety(self) -> None:
-        cache = _make_cache(default_ttl=1)
-        key = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
+        cache = _make_cache(default_ttl=60)
+        key = CacheKey.from_query(FAKE_BASE_ID, FAKE_TABLE, {})
         errors: list[Exception] = []
 
         def reader() -> None:
             try:
                 for _ in range(50):
-                    cache.get_entry(key)
+                    cache.get(key)
             except Exception as exc:
                 errors.append(exc)
 
         def writer() -> None:
             try:
                 for _ in range(50):
-                    cache.put_entry(key, SAMPLE_RECORDS)
+                    cache.put(key, SAMPLE_RECORDS)
             except Exception as exc:
                 errors.append(exc)
 
-        cache.put_entry(key, SAMPLE_RECORDS)
+        cache.put(key, SAMPLE_RECORDS)
         threads = [threading.Thread(target=reader) for _ in range(4)]
         threads += [threading.Thread(target=writer) for _ in range(2)]
-
         for t in threads:
             t.start()
         for t in threads:
@@ -181,50 +272,216 @@ class TestRequestCache:
 
         assert errors == []
 
-    def test_different_cache_keys_separate(self) -> None:
-        cache = _make_cache()
-        key1 = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
-        key2 = (FAKE_BASE_ID, FAKE_TABLE, "{Name}='Alpha'", "", (), "", (), False)
-        key3 = (FAKE_BASE_ID, FAKE_TABLE, "", "", ("Field1", "Field2"), "", (), False)
 
-        records1 = [{"id": "rec1", "fields": {"Name": "One"}}]
-        records2 = [{"id": "rec2", "fields": {"Name": "Two"}}]
-        records3 = [{"id": "rec3", "fields": {"Name": "Three"}}]
+# ---------------------------------------------------------------------------
+# Integration: Api + Table with caching enabled
+# ---------------------------------------------------------------------------
 
-        cache.put_entry(key1, records1)
-        cache.put_entry(key2, records2)
-        cache.put_entry(key3, records3)
 
-        assert cache.get_entry(key1) == records1
-        assert cache.get_entry(key2) == records2
-        assert cache.get_entry(key3) == records3
+class TestCachingIntegration:
+    """Test that caching works end-to-end through Table.all / iterate / first."""
 
-    def test_stats_with_multiple_entries(self) -> None:
-        cache = _make_cache()
-        cache.put_entry((FAKE_BASE_ID, "Table1", "", "", (), "", (), False), SAMPLE_RECORDS)
-        cache.put_entry((FAKE_BASE_ID, "Table2", "", "", (), "", (), False), SAMPLE_RECORDS)
-        cache.put_entry((FAKE_BASE_ID, "Table1", "{Name}='Alpha'", "", (), "", (), False), SAMPLE_RECORDS)
+    @pytest.fixture()
+    def api(self) -> Api:
+        return Api("FakeApiKey")
 
-        cache.get_entry((FAKE_BASE_ID, "Table1", "", "", (), "", (), False))
-        cache.get_entry((FAKE_BASE_ID, "Table2", "", "", (), "", (), False))
+    @pytest.fixture()
+    def table(self, api: Api) -> Table:
+        api.enable_caching()
+        return api.table("appTEST123", "MyTable")
 
-        stats = cache.stats()
-        assert stats["total_entries"] == 3
-        assert len(stats["entries"]) == 3
+    def _mock_list_records(
+        self,
+        requests_mock: Mocker,
+        table: Table,
+        pages: list[dict],
+    ) -> None:
+        """Register paginated responses for table.urls.records."""
+        responses = [{"json": page, "status_code": 200} for page in pages]
+        requests_mock.get(table.urls.records, responses)
 
-    def test_expired_entry_removed_on_get(self) -> None:
-        cache = _make_cache(default_ttl=5)
-        key = (FAKE_BASE_ID, FAKE_TABLE, "", "", (), "", (), False)
+    def test_all_caches_across_pages(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        """table.all() assembles all pages, and the second call is a cache hit."""
+        page1_records = [
+            {"id": "rec1", "createdTime": "t", "fields": {"X": 1}},
+            {"id": "rec2", "createdTime": "t", "fields": {"X": 2}},
+        ]
+        page2_records = [
+            {"id": "rec3", "createdTime": "t", "fields": {"X": 3}},
+        ]
+        self._mock_list_records(
+            requests_mock,
+            table,
+            [
+                {"records": page1_records, "offset": "off1"},
+                {"records": page2_records},
+            ],
+        )
 
-        with patch("pyairtable.api.caching.time") as mock_time:
-            mock_time.monotonic.return_value = 1000.0
-            cache.put_entry(key, SAMPLE_RECORDS)
-            stats_before = cache.stats()
-            assert stats_before["total_entries"] == 1
+        first_call = table.all()
+        assert len(first_call) == 3
+        assert requests_mock.call_count == 2
 
-            mock_time.monotonic.return_value = 1006.0
-            result = cache.get_entry(key)
-            assert result is None
+        second_call = table.all()
+        assert second_call == first_call
+        assert requests_mock.call_count == 2
 
-            stats_after = cache.stats()
-            assert stats_after["total_entries"] == 0
+    def test_iterate_caches(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        records = [{"id": "rec1", "createdTime": "t", "fields": {}}]
+        self._mock_list_records(
+            requests_mock, table, [{"records": records}]
+        )
+
+        pages1 = list(table.iterate())
+        assert len(pages1) == 1
+        assert requests_mock.call_count == 1
+
+        pages2 = list(table.iterate())
+        assert pages2[0] == pages1[0]
+        assert requests_mock.call_count == 1
+
+    def test_first_does_not_cache_partial_iteration(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        """first() short-circuits the iterator, so the cache is never populated.
+        This is correct: first() uses max_records=1, which generates a distinct
+        cache key, and the generator exits before cache.put() is reached."""
+        records = [{"id": "rec1", "createdTime": "t", "fields": {"A": 1}}]
+        requests_mock.get(table.urls.records, [
+            {"json": {"records": records}, "status_code": 200},
+            {"json": {"records": records}, "status_code": 200},
+        ])
+
+        r1 = table.first()
+        r2 = table.first()
+        assert r1 == r2
+        assert requests_mock.call_count == 2
+
+    def test_different_formulas_cached_separately(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        rec_a = [{"id": "rec1", "createdTime": "t", "fields": {"X": "A"}}]
+        rec_b = [{"id": "rec2", "createdTime": "t", "fields": {"X": "B"}}]
+
+        # Two different formulas, each served once.
+        requests_mock.get(table.urls.records, [
+            {"json": {"records": rec_a}, "status_code": 200},
+            {"json": {"records": rec_b}, "status_code": 200},
+        ])
+
+        result_a = table.all(formula="{X}='A'")
+        result_b = table.all(formula="{X}='B'")
+        assert result_a != result_b
+        assert requests_mock.call_count == 2
+
+        result_a2 = table.all(formula="{X}='A'")
+        assert result_a2 == result_a
+        assert requests_mock.call_count == 2
+
+    def test_mutation_invalidates_cache(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        records = [{"id": "rec1", "createdTime": "t", "fields": {"X": 1}}]
+        self._mock_list_records(
+            requests_mock, table, [{"records": records}]
+        )
+        table.all()
+        assert requests_mock.call_count == 1
+
+        # Second all() is a cache hit — no network.
+        table.all()
+        assert requests_mock.call_count == 1
+
+        # Mutation invalidates cache.
+        requests_mock.post(table.urls.records, json={
+            "id": "rec2",
+            "createdTime": "t",
+            "fields": {"X": 2},
+        })
+        table.create({"X": 2})
+        assert requests_mock.call_count == 2
+
+        # Re-register GET response for the post-invalidation fetch.
+        self._mock_list_records(
+            requests_mock, table, [{"records": records}]
+        )
+        table.all()
+        assert requests_mock.call_count == 3
+
+    def test_delete_invalidates_cache(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        records = [{"id": "rec1", "createdTime": "t", "fields": {"X": 1}}]
+        self._mock_list_records(
+            requests_mock, table, [{"records": records}]
+        )
+        table.all()
+        assert requests_mock.call_count == 1
+
+        requests_mock.delete(
+            table.urls.records + "/rec1",
+            json={"id": "rec1", "deleted": True},
+        )
+        table.delete("rec1")
+        assert requests_mock.call_count == 2
+
+        self._mock_list_records(
+            requests_mock, table, [{"records": []}]
+        )
+        table.all()
+        assert requests_mock.call_count == 3
+
+    def test_caching_disabled_by_default(self, requests_mock: Mocker) -> None:
+        api = Api("FakeApiKey")
+        tbl = api.table("appTEST123", "MyTable")
+
+        records = [{"id": "rec1", "createdTime": "t", "fields": {}}]
+        requests_mock.get(tbl.urls.records, [
+            {"json": {"records": records}, "status_code": 200},
+            {"json": {"records": records}, "status_code": 200},
+        ])
+
+        tbl.all()
+        tbl.all()
+        assert requests_mock.call_count == 2
+
+    def test_disable_caching(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        records = [{"id": "rec1", "createdTime": "t", "fields": {}}]
+        requests_mock.get(table.urls.records, [
+            {"json": {"records": records}, "status_code": 200},
+            {"json": {"records": records}, "status_code": 200},
+        ])
+
+        table.all()
+        assert requests_mock.call_count == 1
+
+        table.api.disable_caching()
+
+        table.all()
+        assert requests_mock.call_count == 2
+
+    def test_cache_stats(
+        self, table: Table, requests_mock: Mocker
+    ) -> None:
+        records = [{"id": "rec1", "createdTime": "t", "fields": {}}]
+        self._mock_list_records(
+            requests_mock, table, [{"records": records}]
+        )
+        table.all()
+        table.all()
+
+        stats = table.api.cache_stats()
+        assert stats is not None
+        assert stats["total_entries"] == 1
+        assert stats["entries"][0]["hit_count"] == 1
+        assert stats["entries"][0]["record_count"] == 1
+
+    def test_cache_stats_disabled(self) -> None:
+        api = Api("FakeApiKey")
+        assert api.cache_stats() is None


### PR DESCRIPTION
This came up in a recent project that pulls a large amount of Airtable data and was taking 30-60 seconds to paint every time the page was called. To work around it, I just implemented a caching shim at the service level but figured we might as well bring the benefits directly into the library. I deliberately designed this as opt-in and as minimal as possible, so it should be a drop in enhancement that does not disrupt existing usage. 

## Summary

- Add opt-in TTL-based caching for `Table.all()` and `Table.first()` via `Api.enable_caching()`.
- Add `TableTTLConfig` for default/per-table TTLs and cache size limits, and expose cache diagnostics with `Api.cache_stats()`.
- Automatically invalidate cached table results after record or attachment mutations made through the same `Api` instance.
- Export and document the new caching configuration API.

## Tests

- Added unit and integration coverage for cache key normalization, TTL expiry, per-table overrides, deep-copy isolation, max-entry eviction, thread safety, disabled-by-default behavior, query separation, and mutation invalidation.

@mesozoic for viz