### PR TITLE
Add support for new Airtable endpoints (Nov 2025)

### DIFF
--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -3,6 +3,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 import pyairtable.api.table
+from pyairtable.exceptions import MissingRecordError
 from pyairtable.models.schema import BaseCollaborators, BaseSchema, BaseShares
 from pyairtable.models.webhook import (
     CreateWebhook,
@@ -241,7 +242,7 @@ class Base:
 
     def webhook(self, webhook_id: str) -> Webhook:
         """
-        Build a single webhook or raises ``KeyError`` if the given ID is invalid.
+        Build a single webhook or raises ``MissingRecordError`` if the given ID is invalid.
 
         Airtable's API does not permit retrieving a single webhook, so this function
         will call :meth:`~webhooks` and simply return one item from the list.
@@ -249,7 +250,7 @@ class Base:
         for webhook in self.webhooks():
             if webhook.id == webhook_id:
                 return webhook
-        raise KeyError(f"webhook not found: {webhook_id!r}")
+        raise MissingRecordError(webhook_id)
 
     def add_webhook(
         self,

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -557,6 +557,7 @@ class Enterprise:
         )
         return self.api.workspace(str(response["id"]))
 
+    @cache_unless_forced
     def packages(
         self,
         *,
@@ -585,12 +586,13 @@ class Enterprise:
             for pkg in response.get("packages", [])
         ]
 
-    def package(self, package_id: str) -> Package:
+    def package(self, package_id: str, *, force: bool = False) -> Package:
         """
         Retrieve information about a single package by ID.
 
         Args:
             package_id: The ID of the package to retrieve.
+            force: If ``True``, forces a refresh of the cached package list.
 
         Returns:
             A Package object representing the enterprise package.
@@ -598,7 +600,7 @@ class Enterprise:
         try:
             return next(
                 package
-                for package in iter(self.packages(all_enterprises=True))
+                for package in self.packages(force=force)
                 if package.id == package_id
             )
         except StopIteration:

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -17,7 +17,13 @@ from typing_extensions import Self
 
 from pyairtable.models._base import AirtableModel, rebuild_models
 from pyairtable.models.audit import AuditLogResponse
-from pyairtable.models.schema import EnterpriseInfo, NestedId, UserGroup, UserInfo
+from pyairtable.models.schema import (
+    EnterpriseInfo,
+    NestedId,
+    Package,
+    UserGroup,
+    UserInfo,
+)
 from pyairtable.utils import (
     Url,
     UrlBuilder,
@@ -69,6 +75,9 @@ class Enterprise:
 
         #: URL for creating a new workspace.
         create_workspace = Url("meta/workspaces")
+
+        #: URL for listing enterprise packages.
+        packages = meta / "packages"
 
         def user(self, user_id: str) -> Url:
             """
@@ -538,6 +547,34 @@ class Enterprise:
             },
         )
         return self.api.workspace(str(response["id"]))
+
+    def packages(
+        self,
+        *,
+        all_enterprises: bool = False,
+    ) -> List[Package]:
+        """
+        List all packages for the enterprise account.
+
+        See `List packages <https://airtable.com/developers/web/api/list-enterprise-packages>`__.
+
+        Args:
+            all_enterprises: If True and the enterprise account is the root
+                enterprise account, returns all packages across the entire
+                enterprise grid. Defaults to False.
+
+        Returns:
+            A list of Package objects representing the enterprise packages.
+        """
+        params: Dict[str, Any] = {}
+        if all_enterprises:
+            params["shouldGetAllPackagesInGrid"] = True
+
+        response = self.api.get(self.urls.packages, params=params)
+        return [
+            Package.from_api(pkg, self.api, context=self)
+            for pkg in response.get("packages", [])
+        ]
 
 
 class UserRemoved(AirtableModel):

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -9,12 +9,14 @@ from typing import (
     List,
     Literal,
     Optional,
+    Sequence,
     Union,
 )
 
 import pydantic
 from typing_extensions import Self
 
+from pyairtable.exceptions import InvalidParameterError, MissingRecordError
 from pyairtable.models._base import AirtableModel, rebuild_models
 from pyairtable.models.audit import AuditLogResponse
 from pyairtable.models.schema import (
@@ -35,6 +37,7 @@ from pyairtable.utils import (
 
 if TYPE_CHECKING:
     from pyairtable.api.api import Api
+    from pyairtable.api.base import Base
     from pyairtable.api.workspace import Workspace
 
 
@@ -79,6 +82,12 @@ class Enterprise:
         #: URL for listing enterprise packages.
         packages = meta / "packages"
 
+        def package_install(self, package_id: str) -> Url:
+            """
+            URL for installing a package (creating a base from a package).
+            """
+            return self.meta / "packages" / package_id / "install"
+
         def user(self, user_id: str) -> Url:
             """
             URL for retrieving information about a single user.
@@ -111,9 +120,9 @@ class Enterprise:
 
     urls = cached_property(_urls)
 
-    def __init__(self, api: "Api", workspace_id: str):
+    def __init__(self, api: "Api", enterprise_id: str):
         self.api = api
-        self.id = workspace_id
+        self.id = enterprise_id
         self._info: Optional[EnterpriseInfo] = None
 
     @cache_unless_forced
@@ -575,6 +584,97 @@ class Enterprise:
             Package.from_api(pkg, self.api, context=self)
             for pkg in response.get("packages", [])
         ]
+
+    def package(self, package_id: str) -> Package:
+        """
+        Retrieve information about a single package by ID.
+
+        Args:
+            package_id: The ID of the package to retrieve.
+
+        Returns:
+            A Package object representing the enterprise package.
+        """
+        try:
+            return next(
+                package
+                for package in iter(self.packages(all_enterprises=True))
+                if package.id == package_id
+            )
+        except StopIteration:
+            raise MissingRecordError(package_id)
+
+    def create_base(
+        self,
+        workspace: Union[str, "Workspace"],
+        name: str,
+        tables: Sequence[Dict[str, Any]],
+    ) -> "Base":
+        """
+        Create a base in the given workspace.
+
+        See https://airtable.com/developers/web/api/create-base
+
+        Args:
+            workspace: The ID of the workspace or a :class:`~pyairtable.Workspace` object.
+            name: The name to give to the new base. Does not need to be unique.
+            tables: A list of ``dict`` objects that conform to Airtable's
+                `Table model <https://airtable.com/developers/web/api/model/table-model>`__.
+        """
+        if isinstance(workspace, str):
+            workspace = self.api.workspace(workspace)
+        return workspace.create_base(name, tables)
+
+    def create_base_from_package(
+        self,
+        workspace: Union[str, "Workspace"],
+        name: str,
+        package: Union[str, Package],
+        *,
+        description: Optional[str] = None,
+        release_id: Optional[str] = None,
+    ) -> "Base":
+        """
+        Create a base from an enterprise package template in the specified workspace.
+
+        See https://airtable.com/developers/web/api/create-base-from-package-enterprise
+
+        Args:
+            workspace: The ID of the workspace or a :class:`~pyairtable.Workspace` object.
+            name: The name for the new base.
+            package: Package ID (str) or Package object to install.
+            description: Optional description for the base.
+            release_id: The package release ID to install. If not provided,
+                attempts to use ``Package.latest_release_id`` if package is a Package object,
+                or calls the :meth:`Enterprise.packages` method to find it.
+
+        Returns:
+            The newly created Base object.
+
+        Raises:
+            MissingRecordError: If the specified package ID does not exist.
+            InvalidParameterError: If release_id cannot be determined.
+        """
+        workspace_id = workspace if isinstance(workspace, str) else workspace.id
+        package_id = package if isinstance(package, str) else package.id
+
+        # Only fetch the list of packages if we need to get the latest release ID
+        if release_id is None:
+            package = self.package(package_id) if isinstance(package, str) else package
+            release_id = package.latest_release_id
+        if release_id is None:
+            raise InvalidParameterError("release_id is required")
+
+        payload: Dict[str, Any] = {
+            "name": name,
+            "packageReleaseId": release_id,
+            "workspaceId": workspace_id,
+        }
+        if description is not None:
+            payload["description"] = description
+
+        response = self.api.post(self.urls.package_install(package_id), json=payload)
+        return self.api.base(response["id"], validate=True, force=True)
 
 
 class UserRemoved(AirtableModel):

--- a/pyairtable/exceptions.py
+++ b/pyairtable/exceptions.py
@@ -16,6 +16,12 @@ class InvalidParameterError(PyAirtableError, ValueError):
     """
 
 
+class MissingRecordError(PyAirtableError, KeyError):
+    """
+    A requested record was not found in Airtable.
+    """
+
+
 class MissingValueError(PyAirtableError, ValueError):
     """
     A required field received an empty value, either from Airtable or other code.

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -613,6 +613,28 @@ class EnterpriseInfo(AirtableModel):
         workspace_ids: List[str] = _FL()
 
 
+class Package(AirtableModel):
+    """
+    Represents an enterprise package.
+
+    Returned from the `List packages <https://airtable.com/developers/web/api/list-enterprise-packages>`__ endpoint.
+    """
+
+    id: str
+    type: str
+    created_by_user_id: str
+    created_time: datetime
+    description: Optional[str] = None
+    enterprise_account_id: Optional[str] = None
+    install_count: int
+    last_updated_by_user_id: str
+    last_updated_time: datetime
+    latest_release_id: Optional[str] = None
+    name: str
+    source_application_id: str
+    tagline: Optional[str] = None
+
+
 class WorkspaceCollaborators(_Collaborators, url="meta/workspaces/{self.id}"):
     """
     Detailed information about who can access a workspace.

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -31,6 +31,7 @@ from pyairtable.api.types import (
     UpdateRecordDict,
     WritableFields,
 )
+from pyairtable.exceptions import MissingRecordError
 from pyairtable.formulas import EQ, OR, RECORD_ID
 from pyairtable.models import Comment
 from pyairtable.orm.fields import AnyField, Field
@@ -466,7 +467,10 @@ class Model:
                 {obj.id: obj for obj in cls.all(formula=formula, memoize=memoize)}
             )
 
-        # Ensure we return records in the same order, and raise KeyError if any are missing
+        # Ensure we return records in the same order, and raise if any are missing
+        if missing_ids := set(record_ids) - set(by_id):
+            raise MissingRecordError(sorted(missing_ids))
+
         return [by_id[record_id] for record_id in record_ids]
 
     @classmethod

--- a/tests/sample_data/Package.json
+++ b/tests/sample_data/Package.json
@@ -1,0 +1,15 @@
+{
+  "createdByUserId": "usrL2PNC5o3H4lBEi",
+  "createdTime": "2022-09-12T21:03:48.000Z",
+  "description": "A new enterprise managed app for the entire grid.",
+  "enterpriseAccountId": "entUBq2RGdihxl3vU",
+  "id": "pkggUqk9xHiC4BeeH",
+  "installCount": 12,
+  "lastUpdatedByUserId": "usrsOEchC9xuwRgKk",
+  "lastUpdatedTime": "2022-11-15T01:02:04.400Z",
+  "latestReleaseId": "pkrsTB7Ic2RhsA4pe",
+  "name": "New Enterprise Managed App 1",
+  "sourceApplicationId": "appLkNDICXNqxSDhG",
+  "tagline": "A new enterprise managed app",
+  "type": "appTemplate"
+}

--- a/tests/test_api_enterprise.py
+++ b/tests/test_api_enterprise.py
@@ -3,11 +3,13 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 
+from pyairtable.api.base import Base
 from pyairtable.api.enterprise import (
     DeleteUsersResponse,
     Enterprise,
     ManageUsersResponse,
 )
+from pyairtable.exceptions import InvalidParameterError, MissingRecordError
 from pyairtable.models.schema import EnterpriseInfo, Package, UserGroup, UserInfo
 from pyairtable.testing import fake_id
 
@@ -526,3 +528,104 @@ def test_packages__all_enterprises(enterprise, enterprise_mocks):
     assert ["True"] == enterprise_mocks.get_packages.last_request.qs[
         "shouldGetAllPackagesInGrid"
     ]
+
+
+def test_package(enterprise, enterprise_mocks):
+    package = enterprise.package("pkggUqk9xHiC4BeeH")
+    assert enterprise_mocks.get_packages.call_count == 1
+    assert isinstance(package, Package)
+    assert package.id == "pkggUqk9xHiC4BeeH"
+    assert package.name == "New Enterprise Managed App 1"
+
+
+def test_package__not_found(enterprise, enterprise_mocks):
+    with pytest.raises(MissingRecordError):
+        enterprise.package(fake_id("pkg"))
+
+
+def test_create_base_from_package__with_package_object(
+    api, base_id, workspace_id, requests_mock, sample_json
+):
+    enterprise_id = fake_id("ent")
+    enterprise = api.enterprise(enterprise_id)
+    package = Package.from_api(sample_json("Package"), api)
+
+    url = enterprise.urls.package_install(package.id)
+    requests_mock.get(api.urls.bases, json=sample_json("Bases"))
+    m = requests_mock.post(url, json={"id": base_id})
+
+    base = enterprise.create_base_from_package(
+        workspace_id, "My New Base", package, description="Test base"
+    )
+
+    assert isinstance(base, Base)
+    assert base.id == base_id
+    assert m.call_count == 1
+    assert m.last_request.json() == {
+        "name": "My New Base",
+        "packageReleaseId": package.latest_release_id,
+        "workspaceId": workspace_id,
+        "description": "Test base",
+    }
+
+
+def test_create_base_from_package__with_package_id(
+    api, base_id, workspace_id, requests_mock, sample_json
+):
+    enterprise_id = fake_id("ent")
+    enterprise = api.enterprise(enterprise_id)
+    package_id = fake_id("pkg")
+    release_id = fake_id("pkr")
+
+    url = enterprise.urls.package_install(package_id)
+    requests_mock.get(api.urls.bases, json=sample_json("Bases"))
+    m = requests_mock.post(url, json={"id": base_id})
+
+    base = enterprise.create_base_from_package(
+        workspace_id, "My New Base", package_id, release_id=release_id
+    )
+
+    assert isinstance(base, Base)
+    assert base.id == base_id
+    assert m.call_count == 1
+    assert m.last_request.json() == {
+        "name": "My New Base",
+        "packageReleaseId": release_id,
+        "workspaceId": workspace_id,
+    }
+
+
+def test_create_base_from_package__no_package_release_id(
+    api, workspace_id, requests_mock, sample_json
+):
+    enterprise_id = fake_id("ent")
+    enterprise = api.enterprise(enterprise_id)
+    package_id = fake_id("pkg")
+
+    # Mock a package response where latestReleaseId is null
+    package_json = sample_json("Package")
+    package_json["id"] = package_id
+    package_json["latestReleaseId"] = None
+    requests_mock.get(enterprise.urls.packages, json={"packages": [package_json]})
+
+    with pytest.raises(InvalidParameterError, match="release_id is required"):
+        enterprise.create_base_from_package(workspace_id, "My New Base", package_id)
+
+
+def test_create_base(api, base_id, workspace_id, requests_mock, sample_json):
+    enterprise_id = fake_id("ent")
+    enterprise = api.enterprise(enterprise_id)
+
+    requests_mock.get(api.urls.bases, json=sample_json("Bases"))
+    m = requests_mock.post(api.urls.bases, json={"id": base_id})
+
+    base = enterprise.create_base(workspace_id, "My New Base", [{"name": "Table1"}])
+
+    assert isinstance(base, Base)
+    assert base.id == base_id
+    assert m.call_count == 1
+    assert m.last_request.json() == {
+        "name": "My New Base",
+        "workspaceId": workspace_id,
+        "tables": [{"name": "Table1"}],
+    }

--- a/tests/test_api_enterprise.py
+++ b/tests/test_api_enterprise.py
@@ -8,7 +8,7 @@ from pyairtable.api.enterprise import (
     Enterprise,
     ManageUsersResponse,
 )
-from pyairtable.models.schema import EnterpriseInfo, UserGroup, UserInfo
+from pyairtable.models.schema import EnterpriseInfo, Package, UserGroup, UserInfo
 from pyairtable.testing import fake_id
 
 N_AUDIT_PAGES = 15
@@ -72,6 +72,12 @@ def enterprise_mocks(enterprise, requests_mock, sample_json):
     m.move_workspaces_json = {}
     m.move_workspaces = requests_mock.post(
         f"{enterprise_url}/moveWorkspaces", json=m.move_workspaces_json
+    )
+    m.json_package = sample_json("Package")
+    m.json_packages = {"packages": [m.json_package]}
+    m.get_packages = requests_mock.get(
+        f"{enterprise_url}/packages",
+        json=m.json_packages,
     )
     return m
 
@@ -494,3 +500,29 @@ def test_move_workspaces(api, enterprise, enterprise_mocks):
             "workspaceIds": workspace_ids,
         }
         assert set(m.id for m in result.moved_workspaces) == set(workspace_ids)
+
+
+def test_packages(enterprise, enterprise_mocks):
+    packages = enterprise.packages()
+    assert enterprise_mocks.get_packages.call_count == 1
+    assert isinstance(packages, list)
+    assert len(packages) == 1
+    assert isinstance(packages[0], Package)
+    assert packages[0].id == "pkggUqk9xHiC4BeeH"
+    assert packages[0].name == "New Enterprise Managed App 1"
+    assert packages[0].type == "appTemplate"
+    assert packages[0].install_count == 12
+    assert packages[0].latest_release_id == "pkrsTB7Ic2RhsA4pe"
+    for key in ("shouldgetallpackagesingrid", "shouldGetAllPackagesInGrid"):
+        assert key not in enterprise_mocks.get_packages.last_request.qs
+
+
+def test_packages__all_enterprises(enterprise, enterprise_mocks):
+    packages = enterprise.packages(all_enterprises=True)
+    assert enterprise_mocks.get_packages.call_count == 1
+    assert isinstance(packages, list)
+    assert len(packages) == 1
+    assert isinstance(packages[0], Package)
+    assert ["True"] == enterprise_mocks.get_packages.last_request.qs[
+        "shouldGetAllPackagesInGrid"
+    ]

--- a/tests/test_orm_model.py
+++ b/tests/test_orm_model.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 from requests_mock import Mocker
 
+from pyairtable.exceptions import MissingRecordError
 from pyairtable.orm import Model
 from pyairtable.orm import fields as f
 from pyairtable.orm.model import SaveResult
@@ -250,8 +251,8 @@ def test_from_ids(mock_api):
 
 @mock.patch("pyairtable.Table.all")
 def test_from_ids__invalid_id(mock_all):
-    # Should raise KeyError because of the invalid ID
-    with pytest.raises(KeyError):
+    # Should raise MissingRecordError because of the invalid ID
+    with pytest.raises(MissingRecordError):
         FakeModel.from_ids(["recDefinitelyNotValid"])
     mock_all.assert_called_once()
 


### PR DESCRIPTION
Adds support for these two endpoints released in November 2025:

- New API endpoint: [List packages](https://airtable.com/developers/web/api/list-enterprise-packages) to retrieve all packages in an enterprise.
- New API endpoint: [Create base from package](https://airtable.com/developers/web/api/create-base-from-package-enterprise) to create an enterprise managed app from a package.