### PR TITLE
Release 3.4.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,23 @@
 Changelog
 =========
 
+3.4.0 (2026-06-02)
+------------------------
+
+* Added pyairtable.models.schema.FieldType enum.
+  - `PR #444 <https://github.com/gtalarico/pyairtable/pull/444>`_
+* Fixed some long-standing typos in documentation.
+  - `PR #449 <https://github.com/gtalarico/pyairtable/pull/449>`_
+* Added :meth:`Enterprise.packages <pyairtable.Enterprise.packages>`,
+  :meth:`Enterprise.package <pyairtable.Enterprise.package>`,
+  :meth:`Enterprise.create_base <pyairtable.Enterprise.create_base>`,
+  and :meth:`Enterprise.create_base_from_package <pyairtable.Enterprise.create_base_from_package>`.
+  - `PR #454 <https://github.com/gtalarico/pyairtable/pull/454>`_
+* Added support for ``attachments`` on :class:`pyairtable.models.Comment` models,
+  plus new schema fields ``BaseCollaborators.package_installations``
+  and ``TableSchema.DateDependency.is_forward_only``.
+  - `PR #456 <https://github.com/gtalarico/pyairtable/pull/456>`_
+
 3.3.0 (2025-11-05)
 ------------------------
 
@@ -12,8 +29,6 @@ Changelog
   - `PR #442 <https://github.com/gtalarico/pyairtable/pull/442>`_
 * Added support for Python 3.14 and dropped support for Python 3.9.
   - `PR #443 <https://github.com/gtalarico/pyairtable/pull/443>`_
-* Added pyairtable.models.schema.FieldType enum.
-  - `PR #444 <https://github.com/gtalarico/pyairtable/pull/444>`_
 
 3.2.0 (2025-08-17)
 ------------------------

--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -193,3 +193,32 @@ via the following methods.
 `Create descendant enterprise <https://airtable.com/developers/web/api/create-descendant-enterprise>`__
 
     >>> descendant = enterprise.create_descendant("Descendant Organization Name")
+
+
+Managing bases and packages
+---------------------------
+
+You can use pyAirtable to create bases inside an enterprise workspace, list enterprise packages
+available to use, and create new bases using those packages.
+
+`Create base <https://airtable.com/developers/web/api/create-base>`__
+
+    >>> base = enterprise.create_base("wspWorkspaceId", "My New Base", tables=[...])
+
+`List packages <https://airtable.com/developers/web/api/list-enterprise-packages>`__
+
+    >>> for package in enterprise.packages():
+    ...     print(package.id, package.name)
+    >>> # Across the entire enterprise grid (root accounts only):
+    >>> all_packages = enterprise.packages(all_enterprises=True)
+    >>> # Look up a single package by ID:
+    >>> package = enterprise.package("pkgPackageId")
+
+`Create base from package <https://airtable.com/developers/web/api/create-base-from-package-enterprise>`__
+
+    >>> # Install a package's latest release; accepts a Package, a package ID, or a package release ID:
+    >>> base = enterprise.create_base_from_package(
+    ...     workspace="wspWorkspaceId",
+    ...     name="My New Base",
+    ...     package_or_release="pkrPackageReleaseId",
+    ... )

--- a/pyairtable/__init__.py
+++ b/pyairtable/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 
 from pyairtable.api import Api, Base, Table
 from pyairtable.api.enterprise import Enterprise

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -631,10 +631,9 @@ class Enterprise:
         self,
         workspace: Union[str, "Workspace"],
         name: str,
-        package: Union[str, Package],
+        package_or_release: Union[str, Package],
         *,
         description: Optional[str] = None,
-        release_id: Optional[str] = None,
     ) -> "Base":
         """
         Create a base from an enterprise package template in the specified workspace.
@@ -644,30 +643,37 @@ class Enterprise:
         Args:
             workspace: The ID of the workspace or a :class:`~pyairtable.Workspace` object.
             name: The name for the new base.
-            package: Package ID (str) or Package object to install.
+            package_or_release: A :class:`~pyairtable.models.schema.Package` object,
+                a package ID (``pkg...``), or a package release ID. When a package
+                or package ID is given, the package's latest release is installed.
+                Any other string is forwarded to the API as the release ID.
             description: Optional description for the base.
-            release_id: The package release ID to install. If not provided,
-                attempts to use ``Package.latest_release_id`` if package is a Package object,
-                or calls the :meth:`Enterprise.packages` method to find it.
 
         Returns:
             The newly created Base object.
 
         Raises:
-            MissingRecordError: If the specified package ID does not exist.
-            InvalidParameterError: If release_id cannot be determined.
+            MissingRecordError: If the given package ID is not found.
+            InvalidParameterError: If the resolved package has no latest release.
         """
         workspace_id = workspace if isinstance(workspace, str) else workspace.id
-        package_id = package if isinstance(package, str) else package.id
 
-        # Only fetch the list of packages if we need to get the latest release ID
-        if release_id is None:
-            package = self.package(package_id) if isinstance(package, str) else package
+        if isinstance(package_or_release, Package):
+            package_id = package_or_release.id
+            release_id = package_or_release.latest_release_id
+        elif package_or_release.startswith("pkg"):
+            package = self.package(package_or_release)
+            package_id = package.id
             release_id = package.latest_release_id
-        if release_id is None:
-            raise InvalidParameterError("release_id is required")
+        else:
+            package_id = release_id = package_or_release
 
-        payload: Dict[str, Any] = {
+        if release_id is None:
+            raise InvalidParameterError(
+                f"Package {package_id!r} has no latest release to install"
+            )
+
+        payload = {
             "name": name,
             "packageReleaseId": release_id,
             "workspaceId": workspace_id,

--- a/tests/test_api_enterprise.py
+++ b/tests/test_api_enterprise.py
@@ -544,14 +544,12 @@ def test_package__not_found(enterprise, enterprise_mocks):
 
 
 def test_create_base_from_package__with_package_object(
-    api, base_id, workspace_id, requests_mock, sample_json
+    enterprise, enterprise_mocks, base_id, workspace_id, requests_mock, sample_json
 ):
-    enterprise_id = fake_id("ent")
-    enterprise = api.enterprise(enterprise_id)
-    package = Package.from_api(sample_json("Package"), api)
+    package = Package.from_api(sample_json("Package"), enterprise.api)
 
     url = enterprise.urls.package_install(package.id)
-    requests_mock.get(api.urls.bases, json=sample_json("Bases"))
+    requests_mock.get(enterprise.api.urls.bases, json=sample_json("Bases"))
     m = requests_mock.post(url, json={"id": base_id})
 
     base = enterprise.create_base_from_package(
@@ -570,20 +568,16 @@ def test_create_base_from_package__with_package_object(
 
 
 def test_create_base_from_package__with_package_id(
-    api, base_id, workspace_id, requests_mock, sample_json
+    enterprise, enterprise_mocks, base_id, workspace_id, requests_mock, sample_json
 ):
-    enterprise_id = fake_id("ent")
-    enterprise = api.enterprise(enterprise_id)
-    package_id = fake_id("pkg")
-    release_id = fake_id("pkr")
+    package_id = enterprise_mocks.json_package["id"]
+    release_id = enterprise_mocks.json_package["latestReleaseId"]
 
     url = enterprise.urls.package_install(package_id)
-    requests_mock.get(api.urls.bases, json=sample_json("Bases"))
+    requests_mock.get(enterprise.api.urls.bases, json=sample_json("Bases"))
     m = requests_mock.post(url, json={"id": base_id})
 
-    base = enterprise.create_base_from_package(
-        workspace_id, "My New Base", package_id, release_id=release_id
-    )
+    base = enterprise.create_base_from_package(workspace_id, "My New Base", package_id)
 
     assert isinstance(base, Base)
     assert base.id == base_id
@@ -595,21 +589,79 @@ def test_create_base_from_package__with_package_id(
     }
 
 
-def test_create_base_from_package__no_package_release_id(
-    api, workspace_id, requests_mock, sample_json
+def test_create_base_from_package__with_release_id(
+    enterprise, enterprise_mocks, base_id, workspace_id, requests_mock, sample_json
 ):
-    enterprise_id = fake_id("ent")
-    enterprise = api.enterprise(enterprise_id)
-    package_id = fake_id("pkg")
+    release_id = enterprise_mocks.json_package["latestReleaseId"]
 
-    # Mock a package response where latestReleaseId is null
+    url = enterprise.urls.package_install(release_id)
+    requests_mock.get(enterprise.api.urls.bases, json=sample_json("Bases"))
+    m = requests_mock.post(url, json={"id": base_id})
+
+    base = enterprise.create_base_from_package(workspace_id, "My New Base", release_id)
+
+    assert isinstance(base, Base)
+    assert base.id == base_id
+    assert m.call_count == 1
+    assert m.last_request.json() == {
+        "name": "My New Base",
+        "packageReleaseId": release_id,
+        "workspaceId": workspace_id,
+    }
+    assert enterprise_mocks.get_packages.call_count == 0
+
+
+def test_create_base_from_package__non_package_string_passes_through(
+    enterprise, enterprise_mocks, base_id, workspace_id, requests_mock, sample_json
+):
+    arbitrary = fake_id("xyz")
+
+    url = enterprise.urls.package_install(arbitrary)
+    requests_mock.get(enterprise.api.urls.bases, json=sample_json("Bases"))
+    m = requests_mock.post(url, json={"id": base_id})
+
+    base = enterprise.create_base_from_package(workspace_id, "My New Base", arbitrary)
+
+    assert isinstance(base, Base)
+    assert base.id == base_id
+    assert m.call_count == 1
+    assert m.last_request.json() == {
+        "name": "My New Base",
+        "packageReleaseId": arbitrary,
+        "workspaceId": workspace_id,
+    }
+    assert enterprise_mocks.get_packages.call_count == 0
+
+
+def test_create_base_from_package__package_id_not_found(
+    enterprise, enterprise_mocks, workspace_id
+):
+    with pytest.raises(MissingRecordError):
+        enterprise.create_base_from_package(workspace_id, "My New Base", fake_id("pkg"))
+
+
+def test_create_base_from_package__package_id_with_no_latest_release(
+    enterprise, enterprise_mocks, workspace_id, requests_mock, sample_json
+):
     package_json = sample_json("Package")
-    package_json["id"] = package_id
     package_json["latestReleaseId"] = None
     requests_mock.get(enterprise.urls.packages, json={"packages": [package_json]})
 
-    with pytest.raises(InvalidParameterError, match="release_id is required"):
-        enterprise.create_base_from_package(workspace_id, "My New Base", package_id)
+    with pytest.raises(InvalidParameterError):
+        enterprise.create_base_from_package(
+            workspace_id, "My New Base", package_json["id"]
+        )
+
+
+def test_create_base_from_package__package_object_with_no_latest_release(
+    enterprise, enterprise_mocks, workspace_id, sample_json
+):
+    package_json = sample_json("Package")
+    package_json["latestReleaseId"] = None
+    package = Package.from_api(package_json, enterprise.api)
+
+    with pytest.raises(InvalidParameterError):
+        enterprise.create_base_from_package(workspace_id, "My New Base", package)
 
 
 def test_create_base(api, base_id, workspace_id, requests_mock, sample_json):


### PR DESCRIPTION
- Fixed some long-standing typos in documentation.
- Added `pyairtable.models.schema.FieldType` enum.
- Added method `Enterprise.packages`
- Added method `Enterprise.package`
- Added method `Enterprise.create_base`
- Added method `Enterprise.create_base_from_package`
- Added support for attachments on `pyairtable.models.Comment`
- Added new schema field `BaseCollaborators.package_installations` 
- Added new schema field `TableSchema.DateDependency.is_forward_only`