### PR TITLE
Add parent_comment_id support to Table.add_comment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,8 @@ When changing code in `docs/`, follow these steps instead:
 
 1. `make docs`
 2. `make lint`
+
+## Documentation
+
+When adding notes to the changelog, follow the existing convention for notes,
+but do not add PR numbers because those likely don't exist yet.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+3.5.0 (unreleased)
+------------------------
+
+* Added support for the ``parent_comment_id`` parameter to
+  :meth:`Table.add_comment <pyairtable.Table.add_comment>`, allowing
+  `threaded replies <https://airtable.com/developers/web/api/create-comment>`_.
+
 3.4.2 (2026-07-25)
 ------------------------
 

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -658,6 +658,7 @@ class Table:
         self,
         record_id: RecordId,
         text: str,
+        parent_comment_id: Optional[str] = None,
     ) -> "pyairtable.models.Comment":
         """
         Create a comment on a record.
@@ -673,9 +674,14 @@ class Table:
         Args:
             record_id: |arg_record_id|
             text: The text of the comment. Use ``@[usrIdentifier]`` to mention users.
+            parent_comment_id: The ID of the parent comment, if this comment is a
+                threaded reply to an existing comment.
         """
         url = self.urls.record_comments(record_id)
-        response = self.api.post(url, json={"text": text})
+        payload = {"text": text}
+        if parent_comment_id is not None:
+            payload["parentCommentId"] = parent_comment_id
+        response = self.api.post(url, json=payload)
         return pyairtable.models.Comment.from_api(
             response, self.api, context={"record_url": self.urls.record(record_id)}
         )

--- a/tests/test_models_comment.py
+++ b/tests/test_models_comment.py
@@ -142,4 +142,25 @@ def test_table_add_comment(table, comment_json, comments_url, requests_mock):
     text = "I'd like to weigh in here."
     comment = table.add_comment(RECORD_ID, text)
     assert m.call_count == 1
+    assert m.last_request.json() == {"text": text}
     assert comment.text == text
+
+
+def test_table_add_comment__parent_comment_id(
+    table, comment_json, comments_url, requests_mock
+):
+    def _callback(request, context):
+        return {**comment_json, **request.json()}
+
+    m = requests_mock.post(comments_url, json=_callback)
+
+    text = "I'd like to reply here."
+    parent_comment_id = "comkNDICXNqxSDhGL"
+    comment = table.add_comment(RECORD_ID, text, parent_comment_id=parent_comment_id)
+    assert m.call_count == 1
+    assert m.last_request.json() == {
+        "text": text,
+        "parentCommentId": parent_comment_id,
+    }
+    assert comment.text == text
+    assert comment.parent_comment_id == parent_comment_id


### PR DESCRIPTION
Threaded comment replies can now be created by passing parent_comment_id to add_comment. Fixes #459 