### PR TITLE
Properly handle multi-codepoint emoji

### DIFF
--- a/pyairtable/models/comment.py
+++ b/pyairtable/models/comment.py
@@ -123,7 +123,12 @@ class Reaction(AirtableModel):
         """
         The emoji character used for the reaction.
         """
-        return chr(int(self.emoji_info.unicode_character, 16))
+        return "".join(
+            [
+                chr(int(codepoint, 16))
+                for codepoint in self.emoji_info.unicode_character.split("-")
+            ]
+        )
 
 
 class Attachment(AirtableModel):

--- a/tests/sample_data/Comment.json
+++ b/tests/sample_data/Comment.json
@@ -23,6 +23,13 @@
                 "userId": "usr0000000reacted",
                 "email": "carol@example.com"
             }
+        },
+        {
+            "emoji": {"unicodeCharacter": "1f468-200d-1f469-200d-1f466"},
+            "reactingUser": {
+                "userId": "usr0000000reacted",
+                "email": "carol@example.com"
+            }
         }
     ],
     "attachments": [

--- a/tests/test_models_comment.py
+++ b/tests/test_models_comment.py
@@ -31,6 +31,7 @@ def test_parse(comment):
     assert comment.author.id == "usrLkNDICXNqxSDhG"
     assert comment.mentioned["usr00000mentioned"].display_name == "Alice Doe"
     assert comment.reactions[0].emoji == "👍"
+    assert comment.reactions[1].emoji == "👨‍👩‍👦"
     assert comment.attachments[0].id == "attLkNDICXNqxSDhG"
     assert comment.attachments[0].filename == "cat.png"
     assert (


### PR DESCRIPTION
Emoji can consist of multiple Unicode codepoints. When these are used for reactions in AirTable, the API returns all codepoints, separated by hyphens. This handles that use case, which previously caused an error.