### PR TITLE
Release 3.4.2

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,20 @@
 Changelog
 =========
 
+3.4.2 (2026-07-25)
+------------------------
+
+* Fixed :meth:`Enterprise.move_groups <pyairtable.Enterprise.move_groups>` and
+  :meth:`Enterprise.move_workspaces <pyairtable.Enterprise.move_workspaces>`
+  raising ``TypeError`` when given a generator or other non-list iterable.
+* :class:`~pyairtable.orm.fields.DurationField` now declares that API values
+  may be fractional (``int | float``), matching Airtable's field model.
+* Removed the non-functional ``quoted`` parameter from
+  :data:`Table.id_or_name <pyairtable.Table.id_or_name>`; as a property,
+  it could never receive arguments, and its behavior is unchanged.
+* Fixed documentation errors in :meth:`Enterprise.audit_log <pyairtable.Enterprise.audit_log>`
+  and :class:`~pyairtable.orm.fields.BarcodeField`.
+
 3.4.1 (2026-07-25)
 ------------------------
 

--- a/pyairtable/__init__.py
+++ b/pyairtable/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.4.1"
+__version__ = "3.4.2"
 
 from pyairtable.api import Api, Base, Table
 from pyairtable.api.enterprise import Enterprise

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -501,7 +501,7 @@ class Enterprise:
         response = self.api.post(
             self.urls.move_groups,
             json={
-                "groupIds": group_ids,
+                "groupIds": list(group_ids),
                 "targetEnterpriseAccountId": target,
             },
         )
@@ -527,7 +527,7 @@ class Enterprise:
         response = self.api.post(
             self.urls.move_workspaces,
             json={
-                "workspaceIds": workspace_ids,
+                "workspaceIds": list(workspace_ids),
                 "targetEnterpriseAccountId": target,
             },
         )

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -316,7 +316,7 @@ class Enterprise:
                 for more information on pagination parameters.
             start_time: Earliest timestamp to retrieve (inclusive).
             end_time: Latest timestamp to retrieve (inclusive).
-            originating_user_id: Retrieve audit log events originating
+            user_id: Retrieve audit log events originating
                 from the provided user ID or IDs (maximum 100).
             event_type: Retrieve audit log events falling under the provided
                 `audit log event type <https://airtable.com/developers/web/api/audit-log-event-types>`__

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -202,13 +202,10 @@ class Table:
         return self.schema().id
 
     @property
-    def id_or_name(self, quoted: bool = True) -> str:
+    def id_or_name(self) -> str:
         """
         Return the table ID if it is known, otherwise the table name used for the constructor.
         This is the URL component used to identify the table in Airtable's API.
-
-        Args:
-            quoted: Whether to return a URL-encoded value.
 
         Usage:
 
@@ -220,8 +217,7 @@ class Table:
             'tblXXXXXXXXXXXXXX'
         """
         value = self._schema.id if self._schema else self.name
-        value = value if not quoted else urllib.parse.quote(value, safe="")
-        return value
+        return urllib.parse.quote(value, safe="")
 
     @property
     def api(self) -> "Api":

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -1146,7 +1146,7 @@ class AttachmentsField(
 @_field_api_docstring("Barcode")
 class BarcodeField(_DictField[BarcodeDict], _FieldSchema[S.BarcodeFieldSchema]):
     """
-    Accepts a list of :class:`~pyairtable.api.types.BarcodeDict`.
+    Accepts a :class:`~pyairtable.api.types.BarcodeDict`.
     """
 
 

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -643,7 +643,9 @@ class DateField(Field[str, date, None], _FieldSchema[S.DateFieldSchema]):
 
 
 @_field_api_docstring("Duration", "durationnumber")
-class DurationField(Field[int, timedelta, None], _FieldSchema[S.DurationFieldSchema]):
+class DurationField(
+    Field[int | float, timedelta, None], _FieldSchema[S.DurationFieldSchema]
+):
     """
     Duration field. Accepts only `timedelta <https://docs.python.org/3/library/datetime.html#timedelta-objects>`_ values.
     """
@@ -1314,7 +1316,7 @@ class RequiredDatetimeField(DatetimeField, _Requires_API_ORM[str, datetime]):
 
 
 @_required_value_docstring
-class RequiredDurationField(DurationField, _Requires_API_ORM[int, timedelta]):
+class RequiredDurationField(DurationField, _Requires_API_ORM[int | float, timedelta]):
     pass
 
 

--- a/tests/test_api_enterprise.py
+++ b/tests/test_api_enterprise.py
@@ -470,7 +470,10 @@ def test_create_workspace(enterprise, requests_mock):
     assert result.id == workspace_id
 
 
-def test_move_groups(api, enterprise, enterprise_mocks):
+# group_ids is typed as Iterable[str]; an iterator must not raise
+# TypeError: Object of type generator is not JSON serializable
+@pytest.mark.parametrize("container", [list, iter])
+def test_move_groups(api, enterprise, enterprise_mocks, container):
     other_id = fake_id("ent")
     group_ids = [fake_id("ugp") for _ in range(3)]
     enterprise_mocks.move_groups_json["movedGroups"] = [
@@ -478,7 +481,7 @@ def test_move_groups(api, enterprise, enterprise_mocks):
     ]
     for target in [other_id, api.enterprise(other_id)]:
         enterprise_mocks.move_groups.reset()
-        result = enterprise.move_groups(group_ids, target)
+        result = enterprise.move_groups(container(group_ids), target)
         assert enterprise_mocks.move_groups.call_count == 1
         assert enterprise_mocks.move_groups.last_request.json() == {
             "targetEnterpriseAccountId": other_id,
@@ -487,7 +490,10 @@ def test_move_groups(api, enterprise, enterprise_mocks):
         assert set(m.id for m in result.moved_groups) == set(group_ids)
 
 
-def test_move_workspaces(api, enterprise, enterprise_mocks):
+# workspace_ids is typed as Iterable[str]; an iterator must not raise
+# TypeError: Object of type generator is not JSON serializable
+@pytest.mark.parametrize("container", [list, iter])
+def test_move_workspaces(api, enterprise, enterprise_mocks, container):
     other_id = fake_id("ent")
     workspace_ids = [fake_id("wsp") for _ in range(3)]
     enterprise_mocks.move_workspaces_json["movedWorkspaces"] = [
@@ -495,7 +501,7 @@ def test_move_workspaces(api, enterprise, enterprise_mocks):
     ]
     for target in [other_id, api.enterprise(other_id)]:
         enterprise_mocks.move_workspaces.reset()
-        result = enterprise.move_workspaces(workspace_ids, target)
+        result = enterprise.move_workspaces(container(workspace_ids), target)
         assert enterprise_mocks.move_workspaces.call_count == 1
         assert enterprise_mocks.move_workspaces.last_request.json() == {
             "targetEnterpriseAccountId": other_id,


### PR DESCRIPTION
I asked Claude to audit for bugs and it found a few of them:

* Fixed `Enterprise.move_groups` and `Enterprise.move_workspaces` raising ``TypeError`` when given a generator or other non-list iterable.
* `orm.fields.DurationField` now declares that API values may be fractional (``int | float``), matching Airtable's field model.
* Removed the non-functional ``quoted`` parameter from `Table.id_or_name` property.
* Fixed documentation errors in `Enterprise.audit_log` and `orm.fields.BarcodeField`.