### PR TITLE
Various bug fixes and type annotation updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ release:
 
 .PHONY: test coverage lint format docs clean
 test:
-	tox
+	tox run-parallel
 
 coverage:
 	tox -e coverage

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,14 @@ Changelog
 * Added support for the ``parent_comment_id`` parameter to
   :meth:`Table.add_comment <pyairtable.Table.add_comment>`, allowing
   `threaded replies <https://airtable.com/developers/web/api/create-comment>`_.
+* Fixed a regression, introduced in 3.0.0, that caused the ``timeout``
+  argument to :class:`~pyairtable.Api` to be ignored.
+* :func:`~pyairtable.formulas.AND` and :func:`~pyairtable.formulas.OR` no longer
+  accept (in type annotations) a mix of iterables and formulas, since
+  that would produce an invalid formula at runtime.
+* Formula functions now accept ORM fields without type errors,
+  e.g. ``SUM(MyModel.amount, 1)``.
+* Fixed the type annotation of :meth:`Url.add_path <pyairtable.utils.Url.add_path>`.
 
 3.4.2 (2026-07-25)
 ------------------------

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -1,9 +1,9 @@
+from collections.abc import Iterator, Sequence
 from functools import cached_property
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Any, TypeAlias, TypeVar
 
 import requests
 from requests.sessions import Session
-from typing_extensions import TypeAlias
 
 from pyairtable.api import retrying
 from pyairtable.api.base import Base
@@ -22,7 +22,7 @@ from pyairtable.utils import (
 )
 
 T = TypeVar("T")
-TimeoutTuple: TypeAlias = Tuple[int, int]
+TimeoutTuple: TypeAlias = tuple[int, int]
 
 
 class Api:
@@ -46,7 +46,7 @@ class Api:
     MAX_URL_LENGTH = 16000
 
     # Cached metadata to reduce API calls
-    _bases: Optional[Dict[str, "Base"]] = None
+    _bases: dict[str, "Base"] | None = None
 
     endpoint_url: Url
     session: Session
@@ -62,8 +62,8 @@ class Api:
         self,
         api_key: str,
         *,
-        timeout: Optional[TimeoutTuple] = None,
-        retry_strategy: Optional[Union[bool, retrying.Retry]] = True,
+        timeout: TimeoutTuple | None = None,
+        retry_strategy: bool | retrying.Retry | None = True,
         endpoint_url: str = "https://api.airtable.com",
         use_field_ids: bool = False,
     ):
@@ -168,7 +168,7 @@ class Api:
             permission_level=base_info.permission_level,
         )
 
-    def bases(self, *, force: bool = False) -> List["Base"]:
+    def bases(self, *, force: bool = False) -> list["Base"]:
         """
         Retrieve the base's schema and return a list of :class:`Base` instances.
 
@@ -190,7 +190,7 @@ class Api:
         self,
         workspace_id: str,
         name: str,
-        tables: Sequence[Dict[str, Any]],
+        tables: Sequence[dict[str, Any]],
     ) -> "Base":
         """
         Create a base in the given workspace.
@@ -236,10 +236,10 @@ class Api:
         self,
         method: str,
         url: str,
-        fallback: Optional[Tuple[str, str]] = None,
-        options: Optional[Dict[str, Any]] = None,
-        params: Optional[Dict[str, Any]] = None,
-        json: Optional[Dict[str, Any]] = None,
+        fallback: tuple[str, str] | None = None,
+        options: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
     ) -> Any:
         """
         Make a request to the Airtable API, optionally converting a GET to a POST if the URL exceeds the
@@ -345,9 +345,9 @@ class Api:
         self,
         method: str,
         url: str,
-        fallback: Optional[Tuple[str, str]] = None,
-        options: Optional[Dict[str, Any]] = None,
-        params: Optional[Dict[str, Any]] = None,
+        fallback: tuple[str, str] | None = None,
+        options: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
         offset_field: str = "offset",
     ) -> Iterator[Any]:
         """
@@ -373,7 +373,7 @@ class Api:
         options = options or {}
         params = params or {}
 
-        def _get_offset_field(response: Dict[str, Any]) -> Optional[str]:
+        def _get_offset_field(response: dict[str, Any]) -> str | None:
             value = response.get("pagination") or response  # see Enterprise.audit_log
             field_names = offset_field.split(".")
             while field_names:

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -291,6 +291,7 @@ class Api:
             url=url,
             params=request_params,
             json=json,
+            timeout=self.timeout,
         )
         return self._process_response(response)
 

--- a/pyairtable/api/base.py
+++ b/pyairtable/api/base.py
@@ -1,6 +1,7 @@
 import warnings
+from collections.abc import Sequence
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any
 
 import pyairtable.api.table
 from pyairtable.exceptions import MissingRecordError
@@ -34,12 +35,12 @@ class Base:
     id: str
 
     #: The permission level the current user has on the base
-    permission_level: Optional[str]
+    permission_level: str | None
 
     # Cached metadata to reduce API calls
-    _collaborators: Optional[BaseCollaborators] = None
-    _schema: Optional[BaseSchema] = None
-    _shares: Optional[List[BaseShares.Info]] = None
+    _collaborators: BaseCollaborators | None = None
+    _schema: BaseSchema | None = None
+    _shares: list[BaseShares.Info] | None = None
 
     class _urls(UrlBuilder):
         #: URL for retrieving the base's metadata and collaborators.
@@ -70,11 +71,11 @@ class Base:
 
     def __init__(
         self,
-        api: Union["Api", str],
+        api: "Api | str",
         base_id: str,
         *,
-        name: Optional[str] = None,
-        permission_level: Optional[str] = None,
+        name: str | None = None,
+        permission_level: str | None = None,
     ):
         """
         Old style constructor takes ``str`` arguments, and will create its own
@@ -113,7 +114,7 @@ class Base:
         self._name = name
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         """
         The name of the base, if provided to the constructor
         or available in cached base information.
@@ -154,7 +155,7 @@ class Base:
             return pyairtable.api.table.Table(None, self, schema)
         return pyairtable.api.table.Table(None, self, id_or_name)
 
-    def tables(self, *, force: bool = False) -> List["pyairtable.api.table.Table"]:
+    def tables(self, *, force: bool = False) -> list["pyairtable.api.table.Table"]:
         """
         Retrieve the base's schema and returns a list of :class:`Table` instances.
 
@@ -176,8 +177,8 @@ class Base:
     def create_table(
         self,
         name: str,
-        fields: Sequence[Dict[str, Any]],
-        description: Optional[str] = None,
+        fields: Sequence[dict[str, Any]],
+        description: str | None = None,
     ) -> "pyairtable.api.table.Table":
         """
         Create a table in the given base.
@@ -213,7 +214,7 @@ class Base:
         data = self.api.get(url, params=params)
         return BaseSchema.from_api(data, self.api, context=self)
 
-    def webhooks(self) -> List[Webhook]:
+    def webhooks(self) -> list[Webhook]:
         """
         Retrieve all the base's webhooks
         (see: `List webhooks <https://airtable.com/developers/web/api/list-webhooks>`_).
@@ -255,7 +256,7 @@ class Base:
     def add_webhook(
         self,
         notify_url: str,
-        spec: Union[WebhookSpecification, Dict[Any, Any]],
+        spec: WebhookSpecification | dict[Any, Any],
     ) -> CreateWebhookResponse:
         """
         Create a webhook on the base with the given
@@ -314,7 +315,7 @@ class Base:
 
     @enterprise_only
     @cache_unless_forced
-    def shares(self) -> List[BaseShares.Info]:
+    def shares(self) -> list[BaseShares.Info]:
         """
         Retrieve `base shares <https://airtable.com/developers/web/api/list-shares>`__.
         """

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -1,17 +1,7 @@
+from collections.abc import Iterable, Iterator, Sequence
 from datetime import date, datetime
 from functools import cached_property, partialmethod
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Literal,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Literal
 
 import pydantic
 from typing_extensions import Self
@@ -123,7 +113,7 @@ class Enterprise:
     def __init__(self, api: "Api", enterprise_id: str):
         self.api = api
         self.id = enterprise_id
-        self._info: Optional[EnterpriseInfo] = None
+        self._info: EnterpriseInfo | None = None
 
     @cache_unless_forced
     def info(
@@ -197,7 +187,7 @@ class Enterprise:
         collaborations: bool = True,
         aggregated: bool = False,
         descendants: bool = False,
-    ) -> List[UserInfo]:
+    ) -> list[UserInfo]:
         """
         Retrieve information on the users with the given IDs or emails.
 
@@ -213,8 +203,8 @@ class Enterprise:
             descendants: If ``True``, includes information about the user
                 in a ``dict`` keyed per descendant enterprise account.
         """
-        user_ids: List[str] = []
-        emails: List[str] = []
+        user_ids: list[str] = []
+        emails: list[str] = []
         for value in ids_or_emails:
             (emails if "@" in value else user_ids).append(value)
 
@@ -245,17 +235,17 @@ class Enterprise:
     def audit_log(
         self,
         *,
-        page_size: Optional[int] = None,
-        page_limit: Optional[int] = None,
-        sort_asc: Optional[bool] = False,
-        previous: Optional[str] = None,
-        next: Optional[str] = None,
-        start_time: Optional[Union[str, date, datetime]] = None,
-        end_time: Optional[Union[str, date, datetime]] = None,
-        user_id: Optional[Union[str, Iterable[str]]] = None,
-        event_type: Optional[Union[str, Iterable[str]]] = None,
-        model_id: Optional[Union[str, Iterable[str]]] = None,
-        category: Optional[Union[str, Iterable[str]]] = None,
+        page_size: int | None = None,
+        page_limit: int | None = None,
+        sort_asc: bool | None = False,
+        previous: str | None = None,
+        next: str | None = None,
+        start_time: str | date | datetime | None = None,
+        end_time: str | date | datetime | None = None,
+        user_id: str | Iterable[str] | None = None,
+        event_type: str | Iterable[str] | None = None,
+        model_id: str | Iterable[str] | None = None,
+        category: str | Iterable[str] | None = None,
     ) -> Iterator[AuditLogResponse]:
         """
         Retrieve and yield results from the `Audit Log <https://airtable.com/developers/web/api/audit-logs-integration-guide>`__,
@@ -367,7 +357,7 @@ class Enterprise:
     def remove_user(
         self,
         user_id: str,
-        replacement: Optional[str] = None,
+        replacement: str | None = None,
         *,
         descendants: bool = False,
     ) -> "UserRemoved":
@@ -387,7 +377,7 @@ class Enterprise:
             descendants: If ``True``, removes the user from descendant enterprise accounts.
         """
         url = self.urls.remove_user(user_id)
-        payload: Dict[str, Any] = {"isDryRun": False}
+        payload: dict[str, Any] = {"isDryRun": False}
         if replacement:
             payload["replacementOwnerId"] = replacement
         if descendants:
@@ -396,7 +386,7 @@ class Enterprise:
         return UserRemoved.from_api(response, self.api, context=self)
 
     def claim_users(
-        self, users: Dict[str, Literal["managed", "unmanaged"]]
+        self, users: dict[str, Literal["managed", "unmanaged"]]
     ) -> "ManageUsersResponse":
         """
         Batch manage organizations enterprise account users. This endpoint allows you
@@ -432,7 +422,7 @@ class Enterprise:
         response = self.api.delete(self.urls.users, params={"email": list(emails)})
         return DeleteUsersResponse.from_api(response, self.api, context=self)
 
-    def grant_admin(self, *users: Union[str, UserInfo]) -> "ManageUsersResponse":
+    def grant_admin(self, *users: str | UserInfo) -> "ManageUsersResponse":
         """
         Grant admin access to one or more users.
 
@@ -442,7 +432,7 @@ class Enterprise:
         """
         return self._post_admin_access("grant", users)
 
-    def revoke_admin(self, *users: Union[str, UserInfo]) -> "ManageUsersResponse":
+    def revoke_admin(self, *users: str | UserInfo) -> "ManageUsersResponse":
         """
         Revoke admin access to one or more users.
 
@@ -453,7 +443,7 @@ class Enterprise:
         return self._post_admin_access("revoke", users)
 
     def _post_admin_access(
-        self, action: Literal["grant", "revoke"], users: Iterable[Union[str, UserInfo]]
+        self, action: Literal["grant", "revoke"], users: Iterable[str | UserInfo]
     ) -> "ManageUsersResponse":
         response = self.api.post(
             self.urls.admin_access(action),
@@ -484,7 +474,7 @@ class Enterprise:
     def move_groups(
         self,
         group_ids: Iterable[str],
-        target: Union[str, Self],
+        target: str | Self,
     ) -> "MoveGroupsResponse":
         """
         Move one or more user groups from the current enterprise account
@@ -510,7 +500,7 @@ class Enterprise:
     def move_workspaces(
         self,
         workspace_ids: Iterable[str],
-        target: Union[str, Self],
+        target: str | Self,
     ) -> "MoveWorkspacesResponse":
         """
         Move one or more workspaces from the current enterprise account
@@ -562,7 +552,7 @@ class Enterprise:
         self,
         *,
         all_enterprises: bool = False,
-    ) -> List[Package]:
+    ) -> list[Package]:
         """
         List all packages for the enterprise account.
 
@@ -576,7 +566,7 @@ class Enterprise:
         Returns:
             A list of Package objects representing the enterprise packages.
         """
-        params: Dict[str, Any] = {}
+        params: dict[str, Any] = {}
         if all_enterprises:
             params["shouldGetAllPackagesInGrid"] = True
 
@@ -608,9 +598,9 @@ class Enterprise:
 
     def create_base(
         self,
-        workspace: Union[str, "Workspace"],
+        workspace: "str | Workspace",
         name: str,
-        tables: Sequence[Dict[str, Any]],
+        tables: Sequence[dict[str, Any]],
     ) -> "Base":
         """
         Create a base in the given workspace.
@@ -629,11 +619,11 @@ class Enterprise:
 
     def create_base_from_package(
         self,
-        workspace: Union[str, "Workspace"],
+        workspace: "str | Workspace",
         name: str,
-        package_or_release: Union[str, Package],
+        package_or_release: str | Package,
         *,
-        description: Optional[str] = None,
+        description: str | None = None,
     ) -> "Base":
         """
         Create a base from an enterprise package template in the specified workspace.
@@ -696,28 +686,28 @@ class UserRemoved(AirtableModel):
     unshared: "UserRemoved.Unshared"
 
     class Shared(AirtableModel):
-        workspaces: List["UserRemoved.Shared.Workspace"]
+        workspaces: list["UserRemoved.Shared.Workspace"]
 
         class Workspace(AirtableModel):
             permission_level: str
             workspace_id: str
             workspace_name: str
             user_id: str = ""
-            deleted_time: Optional[datetime] = None
-            enterprise_account_id: Optional[str] = None
+            deleted_time: datetime | None = None
+            enterprise_account_id: str | None = None
 
     class Unshared(AirtableModel):
-        bases: List["UserRemoved.Unshared.Base"]
-        interfaces: List["UserRemoved.Unshared.Interface"]
-        workspaces: List["UserRemoved.Unshared.Workspace"]
+        bases: list["UserRemoved.Unshared.Base"]
+        interfaces: list["UserRemoved.Unshared.Interface"]
+        workspaces: list["UserRemoved.Unshared.Workspace"]
 
         class Base(AirtableModel):
             user_id: str
             base_id: str
             base_name: str
             former_permission_level: str
-            deleted_time: Optional[datetime] = None
-            enterprise_account_id: Optional[str] = None
+            deleted_time: datetime | None = None
+            enterprise_account_id: str | None = None
 
         class Interface(AirtableModel):
             user_id: str
@@ -725,16 +715,16 @@ class UserRemoved(AirtableModel):
             interface_id: str
             interface_name: str
             former_permission_level: str
-            deleted_time: Optional[datetime] = None
-            enterprise_account_id: Optional[str] = None
+            deleted_time: datetime | None = None
+            enterprise_account_id: str | None = None
 
         class Workspace(AirtableModel):
             user_id: str
             former_permission_level: str
             workspace_id: str
             workspace_name: str
-            deleted_time: Optional[datetime] = None
-            enterprise_account_id: Optional[str] = None
+            deleted_time: datetime | None = None
+            enterprise_account_id: str | None = None
 
 
 class DeleteUsersResponse(AirtableModel):
@@ -743,8 +733,8 @@ class DeleteUsersResponse(AirtableModel):
     endpoint.
     """
 
-    deleted_users: List["DeleteUsersResponse.UserInfo"]
-    errors: List["DeleteUsersResponse.Error"]
+    deleted_users: list["DeleteUsersResponse.UserInfo"]
+    errors: list["DeleteUsersResponse.Error"]
 
     class UserInfo(AirtableModel):
         id: str
@@ -753,7 +743,7 @@ class DeleteUsersResponse(AirtableModel):
     class Error(AirtableModel):
         type: str
         email: str
-        message: Optional[str] = None
+        message: str | None = None
 
 
 class ManageUsersResponse(AirtableModel):
@@ -764,11 +754,11 @@ class ManageUsersResponse(AirtableModel):
     endpoints.
     """
 
-    errors: List["ManageUsersResponse.Error"] = pydantic.Field(default_factory=list)
+    errors: list["ManageUsersResponse.Error"] = pydantic.Field(default_factory=list)
 
     class Error(AirtableModel):
-        id: Optional[str] = None
-        email: Optional[str] = None
+        id: str | None = None
+        email: str | None = None
         type: str
         message: str
 
@@ -784,8 +774,8 @@ class MoveGroupsResponse(AirtableModel):
     Returned by `Move user groups <https://airtable.com/developers/web/api/move-user-groups>`__.
     """
 
-    moved_groups: List[NestedId] = pydantic.Field(default_factory=list)
-    errors: List[MoveError] = pydantic.Field(default_factory=list)
+    moved_groups: list[NestedId] = pydantic.Field(default_factory=list)
+    errors: list[MoveError] = pydantic.Field(default_factory=list)
 
 
 class MoveWorkspacesResponse(AirtableModel):
@@ -793,8 +783,8 @@ class MoveWorkspacesResponse(AirtableModel):
     Returned by `Move workspaces <https://airtable.com/developers/web/api/move-workspaces>`__.
     """
 
-    moved_workspaces: List[NestedId] = pydantic.Field(default_factory=list)
-    errors: List[MoveError] = pydantic.Field(default_factory=list)
+    moved_workspaces: list[NestedId] = pydantic.Field(default_factory=list)
+    errors: list[MoveError] = pydantic.Field(default_factory=list)
 
 
 rebuild_models(vars())

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -1,12 +1,12 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from pyairtable.exceptions import InvalidParameterError
 
 
 def dict_list_to_request_params(
     param_name: str,
-    values: List[Dict[str, str]],
-) -> Dict[str, str]:
+    values: list[dict[str, str]],
+) -> dict[str, str]:
     """
     Build the dict to be used by request params from dict list
 
@@ -35,7 +35,7 @@ def dict_list_to_request_params(
     }
 
 
-def field_names_to_sorting_dict(field_names: List[str]) -> List[Dict[str, str]]:
+def field_names_to_sorting_dict(field_names: list[str]) -> list[dict[str, str]]:
     """
     >>> field_names_to_sorting_dict(["Name", "-Age"])
     [
@@ -98,7 +98,7 @@ OPTIONS_TO_RECORD_METADATA = {
 }
 
 
-def _build_record_metadata(options: Dict[str, Any]) -> List[str]:
+def _build_record_metadata(options: dict[str, Any]) -> list[str]:
     return [
         metadata_value
         for option_name, metadata_value in OPTIONS_TO_RECORD_METADATA.items()
@@ -106,7 +106,7 @@ def _build_record_metadata(options: Dict[str, Any]) -> List[str]:
     ]
 
 
-def options_to_params(options: Dict[str, Any]) -> Dict[str, Any]:
+def options_to_params(options: dict[str, Any]) -> dict[str, Any]:
     """
     Convert Airtable options to a dict of query params.
 
@@ -136,8 +136,8 @@ def options_to_params(options: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def options_to_json_and_params(
-    options: Dict[str, Any],
-) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    options: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
     """
     Convert Airtable options to a JSON payload with (possibly) leftover query params.
 

--- a/pyairtable/api/retrying.py
+++ b/pyairtable/api/retrying.py
@@ -1,4 +1,5 @@
-from typing import Any, Collection, Optional, Tuple, Union
+from collections.abc import Collection
+from typing import Any
 
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -11,10 +12,10 @@ DEFAULT_MAX_RETRIES = 5
 
 def retry_strategy(
     *,
-    status_forcelist: Tuple[int, ...] = DEFAULT_RETRIABLE_STATUS_CODES,
-    backoff_factor: Union[int, float] = DEFAULT_BACKOFF_FACTOR,
+    status_forcelist: tuple[int, ...] = DEFAULT_RETRIABLE_STATUS_CODES,
+    backoff_factor: int | float = DEFAULT_BACKOFF_FACTOR,
     total: int = DEFAULT_MAX_RETRIES,
-    allowed_methods: Optional[Collection[str]] = None,
+    allowed_methods: Collection[str] | None = None,
     **kwargs: Any,
 ) -> Retry:
     """

--- a/pyairtable/api/table.py
+++ b/pyairtable/api/table.py
@@ -3,19 +3,10 @@ import mimetypes
 import os
 import urllib.parse
 import warnings
+from collections.abc import Iterable, Iterator
 from functools import cached_property
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, overload
 
 import pyairtable.models
 from pyairtable.api.types import (
@@ -57,7 +48,7 @@ class Table:
     name: str
 
     # Cached schema information to reduce API calls
-    _schema: Optional[TableSchema] = None
+    _schema: TableSchema | None = None
 
     class _urls(UrlBuilder):
         #: URL for retrieving all records in the table
@@ -96,8 +87,8 @@ class Table:
         base_id: str,
         table_name: str,
         *,
-        timeout: Optional["TimeoutTuple"] = None,
-        retry_strategy: Optional["Retry"] = None,
+        timeout: "TimeoutTuple | None" = None,
+        retry_strategy: "Retry | None" = None,
         endpoint_url: str = "https://api.airtable.com",
     ): ...
 
@@ -119,9 +110,9 @@ class Table:
 
     def __init__(
         self,
-        api_key: Union[None, str],
-        base_id: Union["Base", str],
-        table_name: Union[str, TableSchema],
+        api_key: str | None,
+        base_id: "Base | str",
+        table_name: str | TableSchema,
         **kwargs: Any,
     ):
         """
@@ -247,7 +238,7 @@ class Table:
         record = self.api.get(self.urls.record(record_id), options=options)
         return assert_typed_dict(RecordDict, record)
 
-    def iterate(self, **options: Any) -> Iterator[List[RecordDict]]:
+    def iterate(self, **options: Any) -> Iterator[list[RecordDict]]:
         """
         Iterate through each page of results from `List records <https://airtable.com/developers/web/api/list-records>`_.
         To get all records at once, use :meth:`all`.
@@ -288,7 +279,7 @@ class Table:
         ):
             yield assert_typed_dicts(RecordDict, page.get("records", []))
 
-    def all(self, **options: Any) -> List[RecordDict]:
+    def all(self, **options: Any) -> list[RecordDict]:
         """
         Retrieve all matching records in a single list.
 
@@ -313,7 +304,7 @@ class Table:
         """
         return [record for page in self.iterate(**options) for record in page]
 
-    def first(self, **options: Any) -> Optional[RecordDict]:
+    def first(self, **options: Any) -> RecordDict | None:
         """
         Retrieve the first matching record.
         Returns ``None`` if no records are returned.
@@ -342,7 +333,7 @@ class Table:
         self,
         fields: WritableFields,
         typecast: bool = False,
-        use_field_ids: Optional[bool] = None,
+        use_field_ids: bool | None = None,
     ) -> RecordDict:
         """
         Create a new record
@@ -372,8 +363,8 @@ class Table:
         self,
         records: Iterable[WritableFields],
         typecast: bool = False,
-        use_field_ids: Optional[bool] = None,
-    ) -> List[RecordDict]:
+        use_field_ids: bool | None = None,
+    ) -> list[RecordDict]:
         """
         Create a number of new records in batches.
 
@@ -423,7 +414,7 @@ class Table:
         fields: WritableFields,
         replace: bool = False,
         typecast: bool = False,
-        use_field_ids: Optional[bool] = None,
+        use_field_ids: bool | None = None,
     ) -> RecordDict:
         """
         Update a particular record ID with the given fields.
@@ -459,8 +450,8 @@ class Table:
         records: Iterable[UpdateRecordDict],
         replace: bool = False,
         typecast: bool = False,
-        use_field_ids: Optional[bool] = None,
-    ) -> List[RecordDict]:
+        use_field_ids: bool | None = None,
+    ) -> list[RecordDict]:
         """
         Update several records in batches.
 
@@ -498,11 +489,11 @@ class Table:
 
     def batch_upsert(
         self,
-        records: Iterable[Dict[str, Any]],
-        key_fields: List[FieldName],
+        records: Iterable[dict[str, Any]],
+        key_fields: list[FieldName],
         replace: bool = False,
         typecast: bool = False,
-        use_field_ids: Optional[bool] = None,
+        use_field_ids: bool | None = None,
     ) -> UpsertResultDict:
         """
         Update or create records in batches, either using ``id`` (if given) or using a set of
@@ -587,7 +578,7 @@ class Table:
             self.api.delete(self.urls.record(record_id)),
         )
 
-    def batch_delete(self, record_ids: Iterable[RecordId]) -> List[RecordDeletedDict]:
+    def batch_delete(self, record_ids: Iterable[RecordId]) -> list[RecordDeletedDict]:
         """
         Delete the given records, operating in batches.
 
@@ -614,7 +605,7 @@ class Table:
 
         return deleted_records
 
-    def comments(self, record_id: RecordId) -> List["pyairtable.models.Comment"]:
+    def comments(self, record_id: RecordId) -> list["pyairtable.models.Comment"]:
         """
         Retrieve all comments on the given record.
 
@@ -658,7 +649,7 @@ class Table:
         self,
         record_id: RecordId,
         text: str,
-        parent_comment_id: Optional[str] = None,
+        parent_comment_id: str | None = None,
     ) -> "pyairtable.models.Comment":
         """
         Create a comment on a record.
@@ -711,8 +702,8 @@ class Table:
         self,
         name: str,
         field_type: str,
-        description: Optional[str] = None,
-        options: Optional[Dict[str, Any]] = None,
+        description: str | None = None,
+        options: dict[str, Any] | None = None,
     ) -> FieldSchema:
         """
         Create a field on the table.
@@ -734,7 +725,7 @@ class Table:
             options: Only available for some field types. For more information, read about the
                 `Airtable field model <https://airtable.com/developers/web/api/field-model>`__.
         """
-        request: Dict[str, Any] = {"name": name, "type": field_type}
+        request: dict[str, Any] = {"name": name, "type": field_type}
         if description:
             request["description"] = description
         if options:
@@ -758,9 +749,9 @@ class Table:
         self,
         record_id: RecordId,
         field: str,
-        filename: Union[str, Path],
-        content: Optional[Union[str, bytes]] = None,
-        content_type: Optional[str] = None,
+        filename: str | Path,
+        content: str | bytes | None = None,
+        content_type: str | None = None,
     ) -> UploadAttachmentResultDict:
         """
         Upload an attachment to the Airtable API, either by supplying the path to the file

--- a/pyairtable/api/types.py
+++ b/pyairtable/api/types.py
@@ -3,11 +3,12 @@ pyAirtable provides a number of type aliases and TypedDicts which are used as in
 and return values to various pyAirtable methods.
 """
 
+import types
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, TypeAlias, TypeVar, Union, cast
 
 import pydantic
-from typing_extensions import Required, TypeAlias, TypedDict
+from typing_extensions import Required, TypedDict
 
 T = TypeVar("T")
 
@@ -44,7 +45,7 @@ class AITextDict(TypedDict, total=False):
 
     state: Required[str]
     isStale: Required[bool]
-    value: Required[Optional[str]]
+    value: Required[str | None]
     errorType: str
 
 
@@ -72,7 +73,7 @@ class AttachmentDict(TypedDict, total=False):
     size: int
     height: int
     width: int
-    thumbnails: Dict[str, Dict[str, Union[str, int]]]
+    thumbnails: dict[str, dict[str, str | int]]
 
 
 class CreateAttachmentById(TypedDict):
@@ -105,7 +106,7 @@ class CreateAttachmentByUrl(TypedDict, total=False):
     filename: str
 
 
-CreateAttachmentDict: TypeAlias = Union[CreateAttachmentById, CreateAttachmentByUrl]
+CreateAttachmentDict: TypeAlias = CreateAttachmentById | CreateAttachmentByUrl
 
 
 class BarcodeDict(TypedDict, total=False):
@@ -135,7 +136,7 @@ class ButtonDict(TypedDict):
     """
 
     label: str
-    url: Optional[str]
+    url: str | None
 
 
 class CollaboratorDict(TypedDict, total=False):
@@ -217,9 +218,7 @@ class AddGroupCollaboratorDict(TypedDict):
     permissionLevel: str
 
 
-AddCollaboratorDict: TypeAlias = Union[
-    AddUserCollaboratorDict, AddGroupCollaboratorDict
-]
+AddCollaboratorDict: TypeAlias = AddUserCollaboratorDict | AddGroupCollaboratorDict
 
 
 #: Represents the types of values that we might receive from the API.
@@ -229,29 +228,29 @@ FieldValue: TypeAlias = Any
 
 
 #: A mapping of field names to values that we might receive from the API.
-Fields: TypeAlias = Dict[FieldName, FieldValue]
+Fields: TypeAlias = dict[FieldName, FieldValue]
 
 
 #: Represents the types of values that can be written to the Airtable API.
-WritableFieldValue: TypeAlias = Union[
-    None,
-    str,
-    int,
-    float,
-    bool,
-    CollaboratorDict,
-    CollaboratorEmailDict,
-    BarcodeDict,
-    List[str],
-    List[AttachmentDict],
-    List[CreateAttachmentDict],
-    List[CollaboratorDict],
-    List[CollaboratorEmailDict],
-]
+WritableFieldValue: TypeAlias = (
+    None
+    | str
+    | int
+    | float
+    | bool
+    | CollaboratorDict
+    | CollaboratorEmailDict
+    | BarcodeDict
+    | list[str]
+    | list[AttachmentDict]
+    | list[CreateAttachmentDict]
+    | list[CollaboratorDict]
+    | list[CollaboratorEmailDict]
+)
 
 
 #: A mapping of field names to values which can be sent to the API.
-WritableFields: TypeAlias = Dict[FieldName, WritableFieldValue]
+WritableFields: TypeAlias = dict[FieldName, WritableFieldValue]
 
 
 class RecordDict(TypedDict, total=False):
@@ -327,7 +326,7 @@ class UpdateRecordDict(TypedDict):
     fields: WritableFields
 
 
-AnyRecordDict: TypeAlias = Union[RecordDict, CreateRecordDict, UpdateRecordDict]
+AnyRecordDict: TypeAlias = RecordDict | CreateRecordDict | UpdateRecordDict
 
 
 class RecordDeletedDict(TypedDict):
@@ -359,9 +358,9 @@ class UpsertResultDict(TypedDict):
         }
     """
 
-    createdRecords: List[RecordId]
-    updatedRecords: List[RecordId]
-    records: List[RecordDict]
+    createdRecords: list[RecordId]
+    updatedRecords: list[RecordId]
+    records: list[RecordDict]
 
 
 class UserAndScopesDict(TypedDict, total=False):
@@ -374,7 +373,7 @@ class UserAndScopesDict(TypedDict, total=False):
     """
 
     id: Required[str]
-    scopes: List[str]
+    scopes: list[str]
 
 
 class UploadAttachmentResultDict(TypedDict):
@@ -401,11 +400,11 @@ class UploadAttachmentResultDict(TypedDict):
 
     id: RecordId
     createdTime: str
-    fields: Dict[str, List[AttachmentDict]]
+    fields: dict[str, list[AttachmentDict]]
 
 
 @lru_cache
-def _create_model_from_typeddict(cls: Type[T]) -> pydantic.TypeAdapter[Any]:
+def _create_model_from_typeddict(cls: type[T]) -> pydantic.TypeAdapter[Any]:
     """
     Create a pydantic model from a TypedDict to use as a validator.
     Memoizes the result so we don't have to call this more than once per class.
@@ -413,7 +412,7 @@ def _create_model_from_typeddict(cls: Type[T]) -> pydantic.TypeAdapter[Any]:
     return pydantic.TypeAdapter(cls)
 
 
-def assert_typed_dict(cls: Type[T], obj: Any) -> T:
+def assert_typed_dict(cls: type[T], obj: Any) -> T:
     """
     Raises a TypeError if the given object is not a dict, or raises
     pydantic.ValidationError if the given object does not conform
@@ -451,8 +450,8 @@ def assert_typed_dict(cls: Type[T], obj: Any) -> T:
     if not isinstance(obj, dict):
         raise TypeError(f"expected dict, got {type(obj)}")
 
-    # special case for handling a Union
-    if getattr(cls, "__origin__", None) is Union:
+    # special case for handling a Union (either `typing.Union[...]` or `X | Y`)
+    if getattr(cls, "__origin__", None) is Union or isinstance(cls, types.UnionType):
         typeddict_classes = list(getattr(cls, "__args__", []))
         while typeddict_cls := typeddict_classes.pop():
             try:
@@ -468,7 +467,7 @@ def assert_typed_dict(cls: Type[T], obj: Any) -> T:
     return cast(T, obj)
 
 
-def assert_typed_dicts(cls: Type[T], objects: Any) -> List[T]:
+def assert_typed_dicts(cls: type[T], objects: Any) -> list[T]:
     """
     Like :func:`~pyairtable.api.types.assert_typed_dict` but for a list of dicts.
 

--- a/pyairtable/api/workspace.py
+++ b/pyairtable/api/workspace.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any
 
 from pyairtable.models.schema import WorkspaceCollaborators
 from pyairtable.utils import Url, UrlBuilder, cache_unless_forced, enterprise_only
@@ -23,7 +24,7 @@ class Workspace:
     Most workspace functionality is limited to users on Enterprise billing plans.
     """
 
-    _collaborators: Optional[WorkspaceCollaborators] = None
+    _collaborators: WorkspaceCollaborators | None = None
 
     class _urls(UrlBuilder):
         #: URL for retrieving the workspace's metadata and collaborators.
@@ -44,7 +45,7 @@ class Workspace:
     def create_base(
         self,
         name: str,
-        tables: Sequence[Dict[str, Any]],
+        tables: Sequence[dict[str, Any]],
     ) -> "Base":
         """
         Create a base in the given workspace.
@@ -76,7 +77,7 @@ class Workspace:
         return WorkspaceCollaborators.from_api(payload, self.api, context=self)
 
     @enterprise_only
-    def bases(self) -> List["Base"]:
+    def bases(self) -> list["Base"]:
         """
         Retrieve all bases within the workspace.
         """
@@ -106,9 +107,9 @@ class Workspace:
     @enterprise_only
     def move_base(
         self,
-        base: Union[str, "Base"],
-        target: Union[str, "Workspace"],
-        index: Optional[int] = None,
+        base: "str | Base",
+        target: "str | Workspace",
+        index: int | None = None,
     ) -> None:
         """
         Move the given base to a new workspace.
@@ -122,7 +123,7 @@ class Workspace:
         """
         base_id = base if isinstance(base, str) else base.id
         target_id = target if isinstance(target, str) else target.id
-        payload: Dict[str, Any] = {"baseId": base_id, "targetWorkspaceId": target_id}
+        payload: dict[str, Any] = {"baseId": base_id, "targetWorkspaceId": target_id}
         if index is not None:
             payload["targetIndex"] = index
         self.api.post(self.urls.move_base, json=payload)

--- a/pyairtable/cli.py
+++ b/pyairtable/cli.py
@@ -7,12 +7,12 @@ import json
 import os
 import re
 import sys
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, Iterator, Optional, Sequence, Tuple, Union
+from typing import Any, ParamSpec, TypeVar
 
 from click import Context, HelpFormatter
-from typing_extensions import ParamSpec, TypeVar
 
 from pyairtable.api.api import Api
 from pyairtable.api.base import Base
@@ -47,7 +47,7 @@ class CliContext:
     base_id: str = ""
     table_id_or_name: str = ""
     enterprise_id: str = ""
-    click_context: Optional["click.Context"] = None
+    click_context: "click.Context | None" = None
 
     @functools.cached_property
     def api(self) -> Api:
@@ -91,7 +91,7 @@ class ShortcutGroup(click.Group):
     A command group that will accept partial command names and complete them.
     """
 
-    def get_command(self, ctx: click.Context, cmd_name: str) -> Optional[click.Command]:
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
         if exact := super().get_command(ctx, cmd_name):
             return exact
         # If exactly one subcommand starts with the given name, use that.
@@ -210,9 +210,9 @@ def base_table(ctx: CliContext, id_or_name: str) -> None:
 # fmt: on
 def base_table_records(
     ctx: CliContext,
-    formula: Optional[str],
-    view: Optional[str],
-    max_records: Optional[int],
+    formula: str | None,
+    view: str | None,
+    max_records: int | None,
     fields: Sequence[str],
     sort: Sequence[str],
 ) -> None:
@@ -392,9 +392,9 @@ def _dump(obj: Any) -> None:
 
 
 def _gather_commands(
-    command: Union[click.Command, click.Group] = cli,
+    command: click.Command | click.Group = cli,
     prefix: str = "",
-) -> Iterator[Tuple[str, Union[click.Command, click.Group]]]:
+) -> Iterator[tuple[str, click.Command | click.Group]]:
     """
     Enumerate through all commands and groups, yielding a 2-tuple of
     a human-readable command line and the associated function.

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -11,7 +11,7 @@ import warnings
 from collections.abc import Iterable
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, ClassVar, TypeAlias
+from typing import Any, ClassVar, TypeAlias, overload
 
 from typing_extensions import Self as SelfType
 
@@ -256,6 +256,12 @@ class Compound(Formula):
         return cls(operator, items)
 
 
+@overload
+def AND(*components: Formula, **fields: Any) -> Compound: ...
+@overload
+def AND(components: Iterable[Formula], /, **fields: Any) -> Compound: ...
+
+
 def AND(*components: Formula | Iterable[Formula], **fields: Any) -> Compound:
     """
     Join one or more logical conditions into an AND compound condition.
@@ -265,6 +271,12 @@ def AND(*components: Formula | Iterable[Formula], **fields: Any) -> Compound:
     AND(EQ('foo', 1), EQ(Field('bar'), 2), EQ(Field('baz'), 3))
     """
     return Compound.build("AND", *components, **fields)
+
+
+@overload
+def OR(*components: Formula, **fields: Any) -> Compound: ...
+@overload
+def OR(components: Iterable[Formula], /, **fields: Any) -> Compound: ...
 
 
 def OR(*components: Formula | Iterable[Formula], **fields: Any) -> Compound:

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -8,12 +8,12 @@ See :doc:`formulas` for more information.
 import datetime
 import re
 import warnings
+from collections.abc import Iterable
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, ClassVar, Iterable, List, Optional, Set, Union
+from typing import Any, ClassVar, TypeAlias
 
 from typing_extensions import Self as SelfType
-from typing_extensions import TypeAlias
 
 from pyairtable.api.types import Fields
 from pyairtable.exceptions import CircularFormulaError
@@ -202,7 +202,7 @@ class Compound(Formula):
     """
 
     operator: str
-    components: List[Formula]
+    components: list[Formula]
 
     def __init__(
         self,
@@ -229,13 +229,13 @@ class Compound(Formula):
     def __repr__(self) -> str:
         return f"{self.operator}({repr(self.components)[1:-1]})"
 
-    def flatten(self, /, memo: Optional[Set[int]] = None) -> "Compound":
+    def flatten(self, /, memo: set[int] | None = None) -> "Compound":
         """
         Reduces the depth of nested AND, OR, and NOT statements.
         """
         memo = memo if memo else set()
         memo.add(id(self))
-        flattened: List[Formula] = []
+        flattened: list[Formula] = []
         for item in self.components:
             if id(item) in memo:
                 raise CircularFormulaError(item)
@@ -256,7 +256,7 @@ class Compound(Formula):
         return cls(operator, items)
 
 
-def AND(*components: Union[Formula, Iterable[Formula]], **fields: Any) -> Compound:
+def AND(*components: Formula | Iterable[Formula], **fields: Any) -> Compound:
     """
     Join one or more logical conditions into an AND compound condition.
     Keyword arguments will be treated as field names.
@@ -267,7 +267,7 @@ def AND(*components: Union[Formula, Iterable[Formula]], **fields: Any) -> Compou
     return Compound.build("AND", *components, **fields)
 
 
-def OR(*components: Union[Formula, Iterable[Formula]], **fields: Any) -> Compound:
+def OR(*components: Formula | Iterable[Formula], **fields: Any) -> Compound:
     """
     Join one or more logical conditions into an OR compound condition.
     Keyword arguments will be treated as field names.
@@ -278,7 +278,7 @@ def OR(*components: Union[Formula, Iterable[Formula]], **fields: Any) -> Compoun
     return Compound.build("OR", *components, **fields)
 
 
-def NOT(component: Optional[Formula] = None, /, **fields: Any) -> Compound:
+def NOT(component: Formula | None = None, /, **fields: Any) -> Compound:
     """
     Wrap one logical condition in a negation compound.
     Keyword arguments will be treated as field names.
@@ -310,7 +310,7 @@ def NOT(component: Optional[Formula] = None, /, **fields: Any) -> Compound:
     Traceback (most recent call last):
     ValueError: NOT() requires exactly one condition; got 0
     """
-    items: List[Formula] = [EQ(Field(k), v) for (k, v) in fields.items()]
+    items: list[Formula] = [EQ(Field(k), v) for (k, v) in fields.items()]
     if component:
         items.append(component)
     if (count := len(items)) != 1:
@@ -352,7 +352,7 @@ def match(field_values: Fields, *, match_any: bool = False) -> Formula:
             If ``True``, matches if *any* of the provided values match.
             Otherwise, all values must match.
     """
-    expressions: List[Formula] = []
+    expressions: list[Formula] = []
 
     for key, val in field_values.items():
         if isinstance(val, tuple) and len(val) == 2:
@@ -511,17 +511,17 @@ def field_name(name: str) -> str:
     return "{%s}" % name.replace("}", r"\}")
 
 
-FunctionArg: TypeAlias = Union[
-    str,
-    int,
-    float,
-    bool,
-    Decimal,
-    Fraction,
-    Formula,
-    datetime.date,
-    datetime.datetime,
-]
+FunctionArg: TypeAlias = (
+    str
+    | int
+    | float
+    | bool
+    | Decimal
+    | Fraction
+    | Formula
+    | datetime.date
+    | datetime.datetime
+)
 
 
 class FunctionCall(Formula):
@@ -596,7 +596,7 @@ for definition in definitions:
     splat = optional.pop().rstrip(".") if optional and optional[-1].endswith("...") else None
 
     if optional:
-        signature += [f"{arg}: Optional[FunctionArg] = None" for arg in optional]
+        signature += [f"{arg}: FunctionArg | None = None" for arg in optional]
         params += ["*(v for v in [" + ", ".join(optional) + "] if v is not None)"]
 
     if required or optional:
@@ -643,7 +643,7 @@ def BLANK() -> FunctionCall:
     return FunctionCall('BLANK')
 
 
-def CEILING(value: FunctionArg, significance: Optional[FunctionArg] = None, /) -> FunctionCall:
+def CEILING(value: FunctionArg, significance: FunctionArg | None = None, /) -> FunctionCall:
     """
     Returns the nearest integer multiple of significance that is greater than or equal to the value. If no significance is provided, a significance of 1 is assumed.
     """
@@ -706,14 +706,14 @@ def DATETIME_DIFF(date1: FunctionArg, date2: FunctionArg, units: FunctionArg, /)
     return FunctionCall('DATETIME_DIFF', date1, date2, units)
 
 
-def DATETIME_FORMAT(date: FunctionArg, output_format: Optional[FunctionArg] = None, /) -> FunctionCall:
+def DATETIME_FORMAT(date: FunctionArg, output_format: FunctionArg | None = None, /) -> FunctionCall:
     """
     Formats a datetime into a specified string. See an `explanation of how to use this function with date fields <https://support.airtable.com/hc/en-us/articles/215646218>`__ or a list of `supported format specifiers <https://support.airtable.com/hc/en-us/articles/216141218>`__.
     """
     return FunctionCall('DATETIME_FORMAT', date, *(v for v in [output_format] if v is not None))
 
 
-def DATETIME_PARSE(date: FunctionArg, input_format: Optional[FunctionArg] = None, locale: Optional[FunctionArg] = None, /) -> FunctionCall:
+def DATETIME_PARSE(date: FunctionArg, input_format: FunctionArg | None = None, locale: FunctionArg | None = None, /) -> FunctionCall:
     """
     Interprets a text string as a structured date, with optional input format and locale parameters. The output format will always be formatted 'M/D/YYYY h:mm a'.
     """
@@ -762,14 +762,14 @@ def FALSE() -> FunctionCall:
     return FunctionCall('FALSE')
 
 
-def FIND(string_to_find: FunctionArg, where_to_search: FunctionArg, start_from_position: Optional[FunctionArg] = None, /) -> FunctionCall:
+def FIND(string_to_find: FunctionArg, where_to_search: FunctionArg, start_from_position: FunctionArg | None = None, /) -> FunctionCall:
     """
     Finds an occurrence of stringToFind in whereToSearch string starting from an optional startFromPosition.(startFromPosition is 0 by default.) If no occurrence of stringToFind is found, the result will be 0.
     """
     return FunctionCall('FIND', string_to_find, where_to_search, *(v for v in [start_from_position] if v is not None))
 
 
-def FLOOR(value: FunctionArg, significance: Optional[FunctionArg] = None, /) -> FunctionCall:
+def FLOOR(value: FunctionArg, significance: FunctionArg | None = None, /) -> FunctionCall:
     """
     Returns the nearest integer multiple of significance that is less than or equal to the value. If no significance is provided, a significance of 1 is assumed.
     """
@@ -853,7 +853,7 @@ def LEN(string: FunctionArg, /) -> FunctionCall:
     return FunctionCall('LEN', string)
 
 
-def LOG(number: FunctionArg, base: Optional[FunctionArg] = None, /) -> FunctionCall:
+def LOG(number: FunctionArg, base: FunctionArg | None = None, /) -> FunctionCall:
     """
     Computes the logarithm of the value in provided base. The base defaults to 10 if not specified.
     """
@@ -1000,7 +1000,7 @@ def ROUNDUP(value: FunctionArg, precision: FunctionArg, /) -> FunctionCall:
     return FunctionCall('ROUNDUP', value, precision)
 
 
-def SEARCH(string_to_find: FunctionArg, where_to_search: FunctionArg, start_from_position: Optional[FunctionArg] = None, /) -> FunctionCall:
+def SEARCH(string_to_find: FunctionArg, where_to_search: FunctionArg, start_from_position: FunctionArg | None = None, /) -> FunctionCall:
     """
     Searches for an occurrence of stringToFind in whereToSearch string starting from an optional startFromPosition. (startFromPosition is 0 by default.) If no occurrence of stringToFind is found, the result will be empty.
     """
@@ -1035,7 +1035,7 @@ def SQRT(value: FunctionArg, /) -> FunctionCall:
     return FunctionCall('SQRT', value)
 
 
-def SUBSTITUTE(string: FunctionArg, old_text: FunctionArg, new_text: FunctionArg, index: Optional[FunctionArg] = None, /) -> FunctionCall:
+def SUBSTITUTE(string: FunctionArg, old_text: FunctionArg, new_text: FunctionArg, index: FunctionArg | None = None, /) -> FunctionCall:
     """
     Replaces occurrences of old_text in string with new_text.
     """
@@ -1112,28 +1112,28 @@ def VALUE(text: FunctionArg, /) -> FunctionCall:
     return FunctionCall('VALUE', text)
 
 
-def WEEKDAY(date: FunctionArg, start_day_of_week: Optional[FunctionArg] = None, /) -> FunctionCall:
+def WEEKDAY(date: FunctionArg, start_day_of_week: FunctionArg | None = None, /) -> FunctionCall:
     """
     Returns the day of the week as an integer between 0 (Sunday) and 6 (Saturday). You may optionally provide a second argument (either ``"Sunday"`` or ``"Monday"``) to start weeks on that day. If omitted, weeks start on Sunday by default.
     """
     return FunctionCall('WEEKDAY', date, *(v for v in [start_day_of_week] if v is not None))
 
 
-def WEEKNUM(date: FunctionArg, start_day_of_week: Optional[FunctionArg] = None, /) -> FunctionCall:
+def WEEKNUM(date: FunctionArg, start_day_of_week: FunctionArg | None = None, /) -> FunctionCall:
     """
     Returns the week number in a year. You may optionally provide a second argument (either ``"Sunday"`` or ``"Monday"``) to start weeks on that day. If omitted, weeks start on Sunday by default.
     """
     return FunctionCall('WEEKNUM', date, *(v for v in [start_day_of_week] if v is not None))
 
 
-def WORKDAY(start_date: FunctionArg, num_days: FunctionArg, holidays: Optional[FunctionArg] = None, /) -> FunctionCall:
+def WORKDAY(start_date: FunctionArg, num_days: FunctionArg, holidays: FunctionArg | None = None, /) -> FunctionCall:
     """
     Returns a date that is numDays working days after startDate. Working days exclude weekends and an optional list of holidays, formatted as a comma-separated string of ISO-formatted dates.
     """
     return FunctionCall('WORKDAY', start_date, num_days, *(v for v in [holidays] if v is not None))
 
 
-def WORKDAY_DIFF(start_date: FunctionArg, end_date: FunctionArg, holidays: Optional[FunctionArg] = None, /) -> FunctionCall:
+def WORKDAY_DIFF(start_date: FunctionArg, end_date: FunctionArg, holidays: FunctionArg | None = None, /) -> FunctionCall:
     """
     Counts the number of working days between startDate and endDate. Working days exclude weekends and an optional list of holidays, formatted as a comma-separated string of ISO-formatted dates.
     """
@@ -1154,5 +1154,5 @@ def YEAR(date: FunctionArg, /) -> FunctionCall:
     return FunctionCall('YEAR', date)
 
 
-# [[[end]]] (sum: 6J+3KYcsIL)
+# [[[end]]] (sum: nIiXbSJkZi)
 # fmt: on

--- a/pyairtable/formulas.py
+++ b/pyairtable/formulas.py
@@ -11,13 +11,16 @@ import warnings
 from collections.abc import Iterable
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, ClassVar, TypeAlias, overload
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, overload
 
 from typing_extensions import Self as SelfType
 
 from pyairtable.api.types import Fields
 from pyairtable.exceptions import CircularFormulaError
 from pyairtable.utils import date_to_iso_str, datetime_to_iso_str
+
+if TYPE_CHECKING:
+    from pyairtable import orm
 
 
 class Formula:
@@ -523,17 +526,35 @@ def field_name(name: str) -> str:
     return "{%s}" % name.replace("}", r"\}")
 
 
-FunctionArg: TypeAlias = (
-    str
-    | int
-    | float
-    | bool
-    | Decimal
-    | Fraction
-    | Formula
-    | datetime.date
-    | datetime.datetime
-)
+if TYPE_CHECKING:
+    FunctionArg: TypeAlias = (
+        str
+        | int
+        | float
+        | bool
+        | Decimal
+        | Fraction
+        | Formula
+        | datetime.date
+        | datetime.datetime
+        | orm.fields.AnyField
+    )
+else:
+    # The runtime value must remain a real union type, because generated
+    # signatures below evaluate ``FunctionArg | None`` at import time.
+    # orm.fields.AnyField is omitted here to avoid a circular import;
+    # it is only needed for static analysis.
+    FunctionArg = (
+        str
+        | int
+        | float
+        | bool
+        | Decimal
+        | Fraction
+        | Formula
+        | datetime.date
+        | datetime.datetime
+    )
 
 
 class FunctionCall(Formula):

--- a/pyairtable/models/_base.py
+++ b/pyairtable/models/_base.py
@@ -1,17 +1,7 @@
+from collections.abc import Iterable, Mapping
 from datetime import datetime
 from functools import partial
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Dict,
-    Iterable,
-    Mapping,
-    Optional,
-    Set,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import inflection
 import pydantic
@@ -38,7 +28,7 @@ class AirtableModel(pydantic.BaseModel):
         populate_by_name=True,
     )
 
-    _raw: Dict[str, Any] = pydantic.PrivateAttr()
+    _raw: dict[str, Any] = pydantic.PrivateAttr()
 
     def __init__(self, **data: Any) -> None:
         raw = data.copy()
@@ -59,10 +49,10 @@ class AirtableModel(pydantic.BaseModel):
     @classmethod
     def from_api(
         cls,
-        obj: Dict[str, Any],
+        obj: dict[str, Any],
         api: "Api",
         *,
-        context: Optional[Any] = None,
+        context: Any | None = None,
     ) -> SelfType:
         """
         Construct an instance which is able to update itself using an
@@ -89,7 +79,7 @@ def cascade_api(
     obj: Any,
     api: "Api",
     *,
-    context: Optional[Any] = None,
+    context: Any | None = None,
 ) -> None:
     """
     Ensure all nested objects have access to the given Api instance,
@@ -106,7 +96,7 @@ def cascade_api(
         context = {_context_name(context): context}
 
     # Ensure we don't get stuck in infinite loops
-    visited: Set[int] = context.setdefault("__visited__", set())
+    visited: set[int] = context.setdefault("__visited__", set())
     if id(obj) in visited:
         return
     visited.add(id(obj))
@@ -154,7 +144,7 @@ class RestfulModel(AirtableModel):
         cls.__url_pattern = kwargs.pop("url", cls.__url_pattern)
         super().__init_subclass__()
 
-    def _set_api(self, api: "Api", context: Dict[str, Any]) -> None:
+    def _set_api(self, api: "Api", context: dict[str, Any]) -> None:
         """
         Set a link to the API and build the REST URL used for this resource.
         """
@@ -171,7 +161,7 @@ class RestfulModel(AirtableModel):
         if self._url and not self._url.startswith("http"):
             self._url = api.build_url(self._url)
 
-    def _reload(self, obj: Optional[Dict[str, Any]] = None) -> None:
+    def _reload(self, obj: dict[str, Any] | None = None) -> None:
         """
         Reload the model's contents from the given object, or by making a GET request to the API.
         """
@@ -218,8 +208,8 @@ class CanUpdateModel(RestfulModel):
         * ``save_null_values=``: boolean indicating whether ``save()`` should write nulls (default: true)
     """
 
-    __writable: ClassVar[Optional[Iterable[str]]] = None
-    __readonly: ClassVar[Optional[Iterable[str]]] = None
+    __writable: ClassVar[Iterable[str] | None] = None
+    __readonly: ClassVar[Iterable[str] | None] = None
     __save_none: ClassVar[bool] = True
     __save_http_method: ClassVar[str] = "PATCH"
     __reload_after_save: ClassVar[bool] = True
@@ -287,7 +277,7 @@ class CanUpdateModel(RestfulModel):
 
 
 def _append_docstring_refs(
-    cls: Type[CanUpdateModel],
+    cls: type[CanUpdateModel],
     explanation: str,
     field_names: Iterable[str],
 ) -> None:
@@ -305,8 +295,8 @@ def _append_docstring_refs(
 
 
 def rebuild_models(
-    obj: Union[Type[AirtableModel], Mapping[str, Any]],
-    memo: Optional[Set[int]] = None,
+    obj: type[AirtableModel] | Mapping[str, Any],
+    memo: set[int] | None = None,
 ) -> None:
     """
     Convenience method to ensure we update forward references for all nested models.

--- a/pyairtable/models/audit.py
+++ b/pyairtable/models/audit.py
@@ -1,8 +1,7 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, TypeAlias
 
 import pydantic
-from typing_extensions import TypeAlias
 
 from pyairtable.models._base import AirtableModel, rebuild_models
 
@@ -15,12 +14,12 @@ class AuditLogResponse(AirtableModel):
     for more information on how to interpret this data structure.
     """
 
-    events: List["AuditLogEvent"]
-    pagination: Optional["AuditLogResponse.Pagination"] = None
+    events: list["AuditLogEvent"]
+    pagination: "AuditLogResponse.Pagination | None" = None
 
     class Pagination(AirtableModel):
-        next: Optional[str] = None
-        previous: Optional[str] = None
+        next: str | None = None
+        previous: str | None = None
 
 
 class AuditLogEvent(AirtableModel):
@@ -47,35 +46,35 @@ class AuditLogEvent(AirtableModel):
     origin: "AuditLogEvent.Origin"
 
     class Context(AirtableModel):
-        base_id: Optional[str] = None
+        base_id: str | None = None
         action_id: str
         enterprise_account_id: str
-        descendant_enterprise_account_id: Optional[str] = None
-        interface_id: Optional[str] = None
-        workspace_id: Optional[str] = None
+        descendant_enterprise_account_id: str | None = None
+        interface_id: str | None = None
+        workspace_id: str | None = None
 
     class Origin(AirtableModel):
         ip_address: str
         user_agent: str
-        oauth_access_token_id: Optional[str] = None
-        personal_access_token_id: Optional[str] = None
-        session_id: Optional[str] = None
+        oauth_access_token_id: str | None = None
+        personal_access_token_id: str | None = None
+        session_id: str | None = None
 
 
 class AuditLogActor(AirtableModel):
     type: str
-    user: Optional["AuditLogActor.UserInfo"] = None
-    view_id: Optional[str] = None
-    automation_id: Optional[str] = None
+    user: "AuditLogActor.UserInfo | None" = None
+    view_id: str | None = None
+    automation_id: str | None = None
 
     class UserInfo(AirtableModel):
         id: str
         email: str
-        name: Optional[str] = None
+        name: str | None = None
 
 
 # Placeholder until we can parse https://airtable.com/developers/web/api/audit-log-event-types
-AuditLogPayload: TypeAlias = Dict[str, Any]
+AuditLogPayload: TypeAlias = dict[str, Any]
 
 
 rebuild_models(vars())

--- a/pyairtable/models/collaborator.py
+++ b/pyairtable/models/collaborator.py
@@ -1,6 +1,4 @@
-from typing import Optional
-
-from typing_extensions import TypeAlias
+from typing import TypeAlias
 
 from pyairtable.models._base import AirtableModel
 
@@ -20,7 +18,7 @@ class Collaborator(AirtableModel):
     id: UserId
 
     #: The email address of the user.
-    email: Optional[str] = None
+    email: str | None = None
 
     #: The display name of the user.
-    name: Optional[str] = None
+    name: str | None = None

--- a/pyairtable/models/comment.py
+++ b/pyairtable/models/comment.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Dict, List, Optional
 
 import pydantic
 
@@ -59,22 +58,22 @@ class Comment(
     created_time: datetime
 
     #: The ISO 8601 timestamp of when the comment was last edited.
-    last_updated_time: Optional[datetime] = None
+    last_updated_time: datetime | None = None
 
     #: The account which created the comment.
     author: Collaborator
 
     #: Users or groups that were mentioned in the text.
-    mentioned: Dict[str, "Mentioned"] = pydantic.Field(default_factory=dict)
+    mentioned: dict[str, "Mentioned"] = pydantic.Field(default_factory=dict)
 
     #: The comment ID of the parent comment, if this comment is a threaded reply.
-    parent_comment_id: Optional[str] = None
+    parent_comment_id: str | None = None
 
     #: List of reactions to this comment.
-    reactions: List["Reaction"] = pydantic.Field(default_factory=list)
+    reactions: list["Reaction"] = pydantic.Field(default_factory=list)
 
     #: List of attachments on this comment.
-    attachments: List["Attachment"] = pydantic.Field(default_factory=list)
+    attachments: list["Attachment"] = pydantic.Field(default_factory=list)
 
 
 class Mentioned(AirtableModel):
@@ -99,7 +98,7 @@ class Mentioned(AirtableModel):
     id: str
     type: str
     display_name: str
-    email: Optional[str] = None
+    email: str | None = None
 
 
 class Reaction(AirtableModel):
@@ -112,8 +111,8 @@ class Reaction(AirtableModel):
 
     class ReactingUser(AirtableModel):
         user_id: str
-        email: Optional[str] = None
-        name: Optional[str] = None
+        email: str | None = None
+        name: str | None = None
 
     emoji_info: EmojiInfo = pydantic.Field(alias="emoji")
     reacting_user: ReactingUser
@@ -140,21 +139,21 @@ class Attachment(AirtableModel):
     class Thumbnails(AirtableModel):
         class Thumbnail(AirtableModel):
             url: str
-            height: Optional[int] = None
-            width: Optional[int] = None
+            height: int | None = None
+            width: int | None = None
 
-        full: Optional[Thumbnail] = None
-        large: Optional[Thumbnail] = None
-        small: Optional[Thumbnail] = None
+        full: Thumbnail | None = None
+        large: Thumbnail | None = None
+        small: Thumbnail | None = None
 
     id: str
     url: str
     filename: str
-    type: Optional[str] = None
-    size: Optional[int] = None
-    height: Optional[int] = None
-    width: Optional[int] = None
-    thumbnails: Optional[Thumbnails] = None
+    type: str | None = None
+    size: int | None = None
+    height: int | None = None
+    width: int | None = None
+    thumbnails: Thumbnails | None = None
 
 
 rebuild_models(vars())

--- a/pyairtable/models/schema.py
+++ b/pyairtable/models/schema.py
@@ -1,22 +1,11 @@
 import importlib
+from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
 from functools import partial
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Literal,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeVar, cast
 
 import pydantic
-from typing_extensions import TypeAlias
 
 from pyairtable.api.types import AddCollaboratorDict
 from pyairtable.models._base import (
@@ -80,7 +69,7 @@ class FieldType(str, Enum):
         return f"FieldType({self.value!r})"
 
 
-FieldSpecifier: TypeAlias = Union[str, "orm.fields.AnyField"]
+FieldSpecifier: TypeAlias = "str | orm.fields.AnyField"
 
 _T = TypeVar("_T", bound=Any)
 _FL = partial(pydantic.Field, default_factory=list)
@@ -99,11 +88,11 @@ def _F(classname: str, **kwargs: Any) -> Any:
     return pydantic.Field(**kwargs)
 
 
-def _find(collection: List[_T], id_or_name: str) -> _T:
+def _find(collection: list[_T], id_or_name: str) -> _T:
     """
     For use on a collection model to find objects by either id or name.
     """
-    items_by_name: Dict[str, _T] = {}
+    items_by_name: dict[str, _T] = {}
 
     for item in collection:
         if getattr(item, "deleted", None):
@@ -211,7 +200,7 @@ class Bases(AirtableModel):
     See https://airtable.com/developers/web/api/list-bases
     """
 
-    bases: List["Bases.Info"] = _FL()
+    bases: list["Bases.Info"] = _FL()
 
     def base(self, base_id: str) -> "Bases.Info":
         """
@@ -237,12 +226,12 @@ class BaseCollaborators(_Collaborators, url="meta/bases/{base.id}"):
     created_time: datetime
     permission_level: str
     workspace_id: str
-    interfaces: Dict[str, "BaseCollaborators.InterfaceCollaborators"] = _FD()
+    interfaces: dict[str, "BaseCollaborators.InterfaceCollaborators"] = _FD()
     group_collaborators: "BaseCollaborators.GroupCollaborators" = _F("BaseCollaborators.GroupCollaborators")  # fmt: skip
     individual_collaborators: "BaseCollaborators.IndividualCollaborators" = _F("BaseCollaborators.IndividualCollaborators")  # fmt: skip
     invite_links: "BaseCollaborators.InviteLinks" = _F("BaseCollaborators.InviteLinks")  # fmt: skip
-    sensitivity_label: Optional["BaseCollaborators.SensitivityLabel"] = None
-    package_installations: List["BaseCollaborators.PackageInstallation"] = _FL()
+    sensitivity_label: "BaseCollaborators.SensitivityLabel | None" = None
+    package_installations: list["BaseCollaborators.PackageInstallation"] = _FL()
 
     class InterfaceCollaborators(
         _Collaborators,
@@ -251,22 +240,22 @@ class BaseCollaborators(_Collaborators, url="meta/bases/{base.id}"):
         id: str
         name: str
         created_time: datetime
-        first_publish_time: Optional[datetime] = None
-        group_collaborators: List["GroupCollaborator"] = _FL()
-        individual_collaborators: List["IndividualCollaborator"] = _FL()
-        invite_links: List["InterfaceInviteLink"] = _FL()
+        first_publish_time: datetime | None = None
+        group_collaborators: list["GroupCollaborator"] = _FL()
+        individual_collaborators: list["IndividualCollaborator"] = _FL()
+        invite_links: list["InterfaceInviteLink"] = _FL()
 
     class GroupCollaborators(AirtableModel):
-        via_base: List["GroupCollaborator"] = _FL(alias="baseCollaborators")
-        via_workspace: List["GroupCollaborator"] = _FL(alias="workspaceCollaborators")
+        via_base: list["GroupCollaborator"] = _FL(alias="baseCollaborators")
+        via_workspace: list["GroupCollaborator"] = _FL(alias="workspaceCollaborators")
 
     class IndividualCollaborators(AirtableModel):
-        via_base: List["IndividualCollaborator"] = _FL(alias="baseCollaborators")
-        via_workspace: List["IndividualCollaborator"] = _FL(alias="workspaceCollaborators")  # fmt: skip
+        via_base: list["IndividualCollaborator"] = _FL(alias="baseCollaborators")
+        via_workspace: list["IndividualCollaborator"] = _FL(alias="workspaceCollaborators")  # fmt: skip
 
     class InviteLinks(RestfulModel, url="{base_collaborators._url}/invites"):
-        via_base: List["InviteLink"] = _FL(alias="baseInviteLinks")
-        via_workspace: List["WorkspaceInviteLink"] = _FL(alias="workspaceInviteLinks")  # fmt: skip
+        via_base: list["InviteLink"] = _FL(alias="baseInviteLinks")
+        via_workspace: list["WorkspaceInviteLink"] = _FL(alias="workspaceInviteLinks")  # fmt: skip
 
     class SensitivityLabel(AirtableModel):
         id: str
@@ -276,7 +265,7 @@ class BaseCollaborators(_Collaborators, url="meta/bases/{base.id}"):
     class PackageInstallation(AirtableModel):
         id: str
         package_id: str
-        package_release_id: Optional[str] = None
+        package_release_id: str | None = None
         installation_type: str
 
 
@@ -287,7 +276,7 @@ class BaseShares(AirtableModel):
     See https://airtable.com/developers/web/api/list-shares
     """
 
-    shares: List["BaseShares.Info"]
+    shares: list["BaseShares.Info"]
 
     class Info(
         CanUpdateModel,
@@ -301,13 +290,13 @@ class BaseShares(AirtableModel):
         created_time: datetime
         share_id: str
         type: str
-        can_be_synced: Optional[bool] = None
+        can_be_synced: bool | None = None
         is_password_protected: bool
-        block_installation_id: Optional[str] = None
-        restricted_to_email_domains: List[str] = _FL()
+        block_installation_id: str | None = None
+        restricted_to_email_domains: list[str] = _FL()
         restricted_to_enterprise_members: bool
-        view_id: Optional[str] = None
-        effective_email_domain_allow_list: List[str] = _FL()
+        view_id: str | None = None
+        effective_email_domain_allow_list: list[str] = _FL()
 
         def enable(self) -> None:
             """
@@ -345,7 +334,7 @@ class BaseSchema(AirtableModel):
         )
     """
 
-    tables: List["TableSchema"]
+    tables: list["TableSchema"]
 
     def table(self, id_or_name: str) -> "TableSchema":
         """
@@ -394,10 +383,10 @@ class TableSchema(
     id: str
     name: str
     primary_field_id: str
-    description: Optional[str] = None
-    fields: List["FieldSchema"]
-    views: List["ViewSchema"]
-    date_dependency: Optional["DateDependency"] = pydantic.Field(
+    description: str | None = None
+    fields: list["FieldSchema"]
+    views: list["ViewSchema"]
+    date_dependency: "DateDependency | None" = pydantic.Field(
         alias="dateDependencySettings", default=None
     )
 
@@ -423,9 +412,9 @@ class TableSchema(
         end_date_field: FieldSpecifier,
         duration_field: FieldSpecifier,
         rescheduling_mode: str,
-        predecessor_field: Optional[FieldSpecifier] = None,
+        predecessor_field: "FieldSpecifier | None" = None,
         skip_weekends_and_holidays: bool = False,
-        holidays: Optional[List[str]] = None,
+        holidays: list[str] | None = None,
     ) -> None:
         """
         Create or replace the `date dependency settings <https://airtable.com/developers/web/api/model/date-dependency-settings>`__
@@ -492,11 +481,11 @@ class TableSchema(
         duration_field_id: str
         start_date_field_id: str
         end_date_field_id: str
-        predecessor_field_id: Optional[str] = None
+        predecessor_field_id: str | None = None
         rescheduling_mode: str
         should_skip_weekends_and_holidays: bool
-        holidays: List[str] = _FL()
-        is_forward_only: Optional[bool] = None
+        holidays: list[str] = _FL()
+        is_forward_only: bool | None = None
 
 
 class ViewSchema(CanDeleteModel, url="meta/bases/{base.id}/views/{self.id}"):
@@ -517,8 +506,8 @@ class ViewSchema(CanDeleteModel, url="meta/bases/{base.id}/views/{self.id}"):
     id: str
     type: str
     name: str
-    personal_for_user_id: Optional[str] = None
-    visible_field_ids: Optional[List[str]] = None
+    personal_for_user_id: str | None = None
+    visible_field_ids: list[str] | None = None
 
 
 class GroupCollaborator(AirtableModel):
@@ -555,10 +544,10 @@ class InviteLink(CanDeleteModel, url="{invite_links._url}/{self.id}"):
     id: str
     type: str
     created_time: datetime
-    invited_email: Optional[str] = None
+    invited_email: str | None = None
     referred_by_user_id: str
     permission_level: str
-    restricted_to_email_domains: List[str] = _FL()
+    restricted_to_email_domains: list[str] = _FL()
 
 
 class BaseInviteLink(
@@ -602,23 +591,23 @@ class EnterpriseInfo(AirtableModel):
 
     id: str
     created_time: datetime
-    group_ids: List[str]
-    user_ids: List[str]
-    workspace_ids: List[str]
-    email_domains: List["EnterpriseInfo.EmailDomain"]
+    group_ids: list[str]
+    user_ids: list[str]
+    workspace_ids: list[str]
+    email_domains: list["EnterpriseInfo.EmailDomain"]
     root_enterprise_id: str = pydantic.Field(alias="rootEnterpriseAccountId")
-    descendant_enterprise_ids: List[str] = _FL(alias="descendantEnterpriseAccountIds")
-    aggregated: Optional["EnterpriseInfo.AggregatedIds"] = None
-    descendants: Dict[str, "EnterpriseInfo.AggregatedIds"] = _FD()
+    descendant_enterprise_ids: list[str] = _FL(alias="descendantEnterpriseAccountIds")
+    aggregated: "EnterpriseInfo.AggregatedIds | None" = None
+    descendants: dict[str, "EnterpriseInfo.AggregatedIds"] = _FD()
 
     class EmailDomain(AirtableModel):
         email_domain: str
         is_sso_required: bool
 
     class AggregatedIds(AirtableModel):
-        group_ids: List[str] = _FL()
-        user_ids: List[str] = _FL()
-        workspace_ids: List[str] = _FL()
+        group_ids: list[str] = _FL()
+        user_ids: list[str] = _FL()
+        workspace_ids: list[str] = _FL()
 
 
 class Package(AirtableModel):
@@ -632,15 +621,15 @@ class Package(AirtableModel):
     type: str
     created_by_user_id: str
     created_time: datetime
-    description: Optional[str] = None
-    enterprise_account_id: Optional[str] = None
+    description: str | None = None
+    enterprise_account_id: str | None = None
     install_count: int
     last_updated_by_user_id: str
     last_updated_time: datetime
-    latest_release_id: Optional[str] = None
+    latest_release_id: str | None = None
     name: str
     source_application_id: str
-    tagline: Optional[str] = None
+    tagline: str | None = None
 
 
 class WorkspaceCollaborators(_Collaborators, url="meta/workspaces/{self.id}"):
@@ -653,7 +642,7 @@ class WorkspaceCollaborators(_Collaborators, url="meta/workspaces/{self.id}"):
     id: str
     name: str
     created_time: datetime
-    base_ids: List[str]
+    base_ids: list[str]
     restrictions: "WorkspaceCollaborators.Restrictions" = pydantic.Field(alias="workspaceRestrictions")  # fmt: skip
     group_collaborators: "WorkspaceCollaborators.GroupCollaborators" = _F("WorkspaceCollaborators.GroupCollaborators")  # fmt: skip
     individual_collaborators: "WorkspaceCollaborators.IndividualCollaborators" = _F("WorkspaceCollaborators.IndividualCollaborators")  # fmt: skip
@@ -669,18 +658,18 @@ class WorkspaceCollaborators(_Collaborators, url="meta/workspaces/{self.id}"):
         share_creation: str = pydantic.Field(alias="shareCreationRestriction")
 
     class GroupCollaborators(AirtableModel):
-        via_base: List["BaseGroupCollaborator"] = _FL(alias="baseCollaborators")
-        via_workspace: List["GroupCollaborator"] = _FL(alias="workspaceCollaborators")
+        via_base: list["BaseGroupCollaborator"] = _FL(alias="baseCollaborators")
+        via_workspace: list["GroupCollaborator"] = _FL(alias="workspaceCollaborators")
 
     class IndividualCollaborators(AirtableModel):
-        via_base: List["BaseIndividualCollaborator"] = _FL(alias="baseCollaborators")
-        via_workspace: List["IndividualCollaborator"] = _FL(
+        via_base: list["BaseIndividualCollaborator"] = _FL(alias="baseCollaborators")
+        via_workspace: list["IndividualCollaborator"] = _FL(
             alias="workspaceCollaborators"
         )
 
     class InviteLinks(RestfulModel, url="{workspace_collaborators._url}/invites"):
-        via_base: List["BaseInviteLink"] = _FL(alias="baseInviteLinks")
-        via_workspace: List["InviteLink"] = _FL(alias="workspaceInviteLinks")
+        via_base: list["BaseInviteLink"] = _FL(alias="baseInviteLinks")
+        via_workspace: list["InviteLink"] = _FL(alias="workspaceInviteLinks")
 
 
 class NestedId(AirtableModel):
@@ -698,9 +687,9 @@ class Collaborations(AirtableModel):
     See https://airtable.com/developers/web/api/model/collaborations
     """
 
-    base_collaborations: List["Collaborations.BaseCollaboration"] = _FL()
-    interface_collaborations: List["Collaborations.InterfaceCollaboration"] = _FL()
-    workspace_collaborations: List["Collaborations.WorkspaceCollaboration"] = _FL()
+    base_collaborations: list["Collaborations.BaseCollaboration"] = _FL()
+    interface_collaborations: list["Collaborations.InterfaceCollaboration"] = _FL()
+    workspace_collaborations: list["Collaborations.WorkspaceCollaboration"] = _FL()
 
     def __bool__(self) -> bool:
         return bool(
@@ -710,21 +699,21 @@ class Collaborations(AirtableModel):
         )
 
     @property
-    def bases(self) -> Dict[str, "Collaborations.BaseCollaboration"]:
+    def bases(self) -> dict[str, "Collaborations.BaseCollaboration"]:
         """
         Mapping of base IDs to collaborations, to make lookups easier.
         """
         return {c.base_id: c for c in self.base_collaborations}
 
     @property
-    def interfaces(self) -> Dict[str, "Collaborations.InterfaceCollaboration"]:
+    def interfaces(self) -> dict[str, "Collaborations.InterfaceCollaboration"]:
         """
         Mapping of interface IDs to collaborations, to make lookups easier.
         """
         return {c.interface_id: c for c in self.interface_collaborations}
 
     @property
-    def workspaces(self) -> Dict[str, "Collaborations.WorkspaceCollaboration"]:
+    def workspaces(self) -> dict[str, "Collaborations.WorkspaceCollaboration"]:
         """
         Mapping of workspace IDs to collaborations, to make lookups easier.
         """
@@ -765,36 +754,36 @@ class UserInfo(
     is_service_account: bool
     is_sso_required: bool
     is_two_factor_auth_enabled: bool
-    last_activity_time: Optional[datetime] = None
-    created_time: Optional[datetime] = None
-    license_type: Optional[str] = None
-    enterprise_user_type: Optional[str] = None
-    invited_to_airtable_by_user_id: Optional[str] = None
+    last_activity_time: datetime | None = None
+    created_time: datetime | None = None
+    license_type: str | None = None
+    enterprise_user_type: str | None = None
+    invited_to_airtable_by_user_id: str | None = None
     is_managed: bool = False
     is_admin: bool = False
     is_super_admin: bool = False
-    groups: List[NestedId] = _FL()
+    groups: list[NestedId] = _FL()
     collaborations: "Collaborations" = _F("Collaborations")
-    descendants: Dict[str, "UserInfo.DescendantIds"] = _FD()
-    aggregated: Optional["UserInfo.AggregatedIds"] = None
+    descendants: dict[str, "UserInfo.DescendantIds"] = _FD()
+    aggregated: "UserInfo.AggregatedIds | None" = None
 
     def logout(self) -> None:
         self._api.post(self._url + "/logout")
 
     class DescendantIds(AirtableModel):
-        license_type: Optional[str] = None
-        last_activity_time: Optional[datetime] = None
-        collaborations: Optional["Collaborations"] = None
+        license_type: str | None = None
+        last_activity_time: datetime | None = None
+        collaborations: "Collaborations | None" = None
         is_admin: bool = False
         is_managed: bool = False
-        groups: List[NestedId] = _FL()
+        groups: list[NestedId] = _FL()
 
     class AggregatedIds(AirtableModel):
-        license_type: Optional[str] = None
-        last_activity_time: Optional[datetime] = None
-        collaborations: Optional["Collaborations"] = None
+        license_type: str | None = None
+        last_activity_time: datetime | None = None
+        collaborations: "Collaborations | None" = None
         is_admin: bool = False
-        groups: List[NestedId] = _FL()
+        groups: list[NestedId] = _FL()
 
 
 class UserGroup(AirtableModel):
@@ -809,9 +798,9 @@ class UserGroup(AirtableModel):
     enterprise_account_id: str
     created_time: datetime
     updated_time: datetime
-    members: List["UserGroup.Member"]
+    members: list["UserGroup.Member"]
     collaborations: "Collaborations" = _F("Collaborations")
-    mapped_user_license_type: Optional[str] = None
+    mapped_user_license_type: str | None = None
 
     class Member(AirtableModel):
         user_id: str
@@ -840,8 +829,8 @@ class AITextFieldConfig(AirtableModel):
 
 
 class AITextFieldOptions(AirtableModel):
-    prompt: List[Union[str, "AITextFieldOptions.PromptField"]] = _FL()
-    referenced_field_ids: List[str] = _FL()
+    prompt: list["str | AITextFieldOptions.PromptField"] = _FL()
+    referenced_field_ids: list[str] = _FL()
 
     class PromptField(AirtableModel):
         field: NestedFieldId
@@ -896,7 +885,7 @@ class CountFieldConfig(AirtableModel):
 
 class CountFieldOptions(AirtableModel):
     is_valid: bool
-    record_link_field_id: Optional[str] = None
+    record_link_field_id: str | None = None
 
 
 class CreatedByFieldConfig(AirtableModel):
@@ -1007,8 +996,8 @@ class FormulaFieldConfig(AirtableModel):
 class FormulaFieldOptions(AirtableModel):
     formula: str
     is_valid: bool
-    referenced_field_ids: Optional[List[str]] = None
-    result: Optional["FieldConfig"] = None
+    referenced_field_ids: list[str] | None = None
+    result: "FieldConfig | None" = None
 
 
 class LastModifiedByFieldConfig(AirtableModel):
@@ -1030,8 +1019,8 @@ class LastModifiedTimeFieldConfig(AirtableModel):
 
 class LastModifiedTimeFieldOptions(AirtableModel):
     is_valid: bool
-    referenced_field_ids: Optional[List[str]] = None
-    result: Optional[Union["DateFieldConfig", "DateTimeFieldConfig"]] = None
+    referenced_field_ids: list[str] | None = None
+    result: "DateFieldConfig | DateTimeFieldConfig | None" = None
 
 
 class ManualSortFieldConfig(AirtableModel):
@@ -1086,9 +1075,9 @@ class MultipleLookupValuesFieldConfig(AirtableModel):
 
 class MultipleLookupValuesFieldOptions(AirtableModel):
     is_valid: bool
-    field_id_in_linked_table: Optional[str] = None
-    record_link_field_id: Optional[str] = None
-    result: Optional["FieldConfig"] = None
+    field_id_in_linked_table: str | None = None
+    record_link_field_id: str | None = None
+    result: "FieldConfig | None" = None
 
 
 class MultipleRecordLinksFieldConfig(AirtableModel):
@@ -1104,8 +1093,8 @@ class MultipleRecordLinksFieldOptions(AirtableModel):
     is_reversed: bool
     linked_table_id: str
     prefers_single_record_link: bool
-    inverse_link_field_id: Optional[str] = None
-    view_id_for_record_selection: Optional[str] = None
+    inverse_link_field_id: str | None = None
+    view_id_for_record_selection: str | None = None
 
 
 class MultipleSelectsFieldConfig(AirtableModel):
@@ -1180,11 +1169,11 @@ class RollupFieldConfig(AirtableModel):
 
 
 class RollupFieldOptions(AirtableModel):
-    field_id_in_linked_table: Optional[str] = None
+    field_id_in_linked_table: str | None = None
     is_valid: bool
-    record_link_field_id: Optional[str] = None
-    referenced_field_ids: Optional[List[str]] = None
-    result: Optional["FieldConfig"] = None
+    record_link_field_id: str | None = None
+    referenced_field_ids: list[str] | None = None
+    result: "FieldConfig | None" = None
 
 
 class SingleCollaboratorFieldConfig(AirtableModel):
@@ -1213,12 +1202,12 @@ class SingleSelectFieldConfig(AirtableModel):
 
 
 class SingleSelectFieldOptions(AirtableModel):
-    choices: List["SingleSelectFieldOptions.Choice"]
+    choices: list["SingleSelectFieldOptions.Choice"]
 
     class Choice(AirtableModel):
         id: str
         name: str
-        color: Optional[str] = None
+        color: str | None = None
 
 
 class UrlFieldConfig(AirtableModel):
@@ -1236,7 +1225,7 @@ class UnknownFieldConfig(AirtableModel):
     """
 
     type: str
-    options: Optional[Dict[str, Any]] = None
+    options: dict[str, Any] | None = None
 
 
 class _FieldSchemaBase(
@@ -1247,7 +1236,7 @@ class _FieldSchemaBase(
 ):
     id: str
     name: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 # This section is auto-generated so that FieldSchema and FieldConfig are kept aligned.
@@ -1265,10 +1254,10 @@ with open(cog.inFile) as fp:
 
 cog.out("\n\n")
 
-cog.outl("FieldConfig: TypeAlias = Union[")
-for fld, _ in field_types:
-    cog.outl(f"    {fld}Config,")
-cog.outl("]")
+cog.outl("FieldConfig: TypeAlias = (")
+for i, (fld, _) in enumerate(field_types):
+    cog.outl(f"    {'' if i == 0 else '| '}{fld}Config")
+cog.outl(")")
 cog.out("\n\n")
 
 for fld, doc in field_types:
@@ -1280,51 +1269,53 @@ for fld, doc in field_types:
         cog.outl("pass")
     cog.out("\n\n")
 
-cog.outl("FieldSchema: TypeAlias = Union[")
-for fld, _ in field_types:
-    cog.outl(f"    {fld}Schema,")
-cog.outl("]")
+cog.outl("FieldSchema: TypeAlias = (")
+for idx, (fld, doc) in enumerate(field_types):
+    cog.out("    ")
+    cog.out('' if idx == 0 else '| ')
+    cog.outl(f"{fld}Schema")
+cog.outl(")")
 
 [[[out]]]"""
 
 
-FieldConfig: TypeAlias = Union[
-    AITextFieldConfig,
-    AutoNumberFieldConfig,
-    BarcodeFieldConfig,
-    ButtonFieldConfig,
-    CheckboxFieldConfig,
-    CountFieldConfig,
-    CreatedByFieldConfig,
-    CreatedTimeFieldConfig,
-    CurrencyFieldConfig,
-    DateFieldConfig,
-    DateTimeFieldConfig,
-    DurationFieldConfig,
-    EmailFieldConfig,
-    ExternalSyncSourceFieldConfig,
-    FormulaFieldConfig,
-    LastModifiedByFieldConfig,
-    LastModifiedTimeFieldConfig,
-    ManualSortFieldConfig,
-    MultilineTextFieldConfig,
-    MultipleAttachmentsFieldConfig,
-    MultipleCollaboratorsFieldConfig,
-    MultipleLookupValuesFieldConfig,
-    MultipleRecordLinksFieldConfig,
-    MultipleSelectsFieldConfig,
-    NumberFieldConfig,
-    PercentFieldConfig,
-    PhoneNumberFieldConfig,
-    RatingFieldConfig,
-    RichTextFieldConfig,
-    RollupFieldConfig,
-    SingleCollaboratorFieldConfig,
-    SingleLineTextFieldConfig,
-    SingleSelectFieldConfig,
-    UrlFieldConfig,
-    UnknownFieldConfig,
-]
+FieldConfig: TypeAlias = (
+    AITextFieldConfig
+    | AutoNumberFieldConfig
+    | BarcodeFieldConfig
+    | ButtonFieldConfig
+    | CheckboxFieldConfig
+    | CountFieldConfig
+    | CreatedByFieldConfig
+    | CreatedTimeFieldConfig
+    | CurrencyFieldConfig
+    | DateFieldConfig
+    | DateTimeFieldConfig
+    | DurationFieldConfig
+    | EmailFieldConfig
+    | ExternalSyncSourceFieldConfig
+    | FormulaFieldConfig
+    | LastModifiedByFieldConfig
+    | LastModifiedTimeFieldConfig
+    | ManualSortFieldConfig
+    | MultilineTextFieldConfig
+    | MultipleAttachmentsFieldConfig
+    | MultipleCollaboratorsFieldConfig
+    | MultipleLookupValuesFieldConfig
+    | MultipleRecordLinksFieldConfig
+    | MultipleSelectsFieldConfig
+    | NumberFieldConfig
+    | PercentFieldConfig
+    | PhoneNumberFieldConfig
+    | RatingFieldConfig
+    | RichTextFieldConfig
+    | RollupFieldConfig
+    | SingleCollaboratorFieldConfig
+    | SingleLineTextFieldConfig
+    | SingleSelectFieldConfig
+    | UrlFieldConfig
+    | UnknownFieldConfig
+)
 
 
 class AITextFieldSchema(_FieldSchemaBase, AITextFieldConfig):
@@ -1538,44 +1529,44 @@ class UnknownFieldSchema(_FieldSchemaBase, UnknownFieldConfig):
     """
 
 
-FieldSchema: TypeAlias = Union[
-    AITextFieldSchema,
-    AutoNumberFieldSchema,
-    BarcodeFieldSchema,
-    ButtonFieldSchema,
-    CheckboxFieldSchema,
-    CountFieldSchema,
-    CreatedByFieldSchema,
-    CreatedTimeFieldSchema,
-    CurrencyFieldSchema,
-    DateFieldSchema,
-    DateTimeFieldSchema,
-    DurationFieldSchema,
-    EmailFieldSchema,
-    ExternalSyncSourceFieldSchema,
-    FormulaFieldSchema,
-    LastModifiedByFieldSchema,
-    LastModifiedTimeFieldSchema,
-    ManualSortFieldSchema,
-    MultilineTextFieldSchema,
-    MultipleAttachmentsFieldSchema,
-    MultipleCollaboratorsFieldSchema,
-    MultipleLookupValuesFieldSchema,
-    MultipleRecordLinksFieldSchema,
-    MultipleSelectsFieldSchema,
-    NumberFieldSchema,
-    PercentFieldSchema,
-    PhoneNumberFieldSchema,
-    RatingFieldSchema,
-    RichTextFieldSchema,
-    RollupFieldSchema,
-    SingleCollaboratorFieldSchema,
-    SingleLineTextFieldSchema,
-    SingleSelectFieldSchema,
-    UrlFieldSchema,
-    UnknownFieldSchema,
-]
-# [[[end]]] (sum: yhWbyMdrHR)
+FieldSchema: TypeAlias = (
+    AITextFieldSchema
+    | AutoNumberFieldSchema
+    | BarcodeFieldSchema
+    | ButtonFieldSchema
+    | CheckboxFieldSchema
+    | CountFieldSchema
+    | CreatedByFieldSchema
+    | CreatedTimeFieldSchema
+    | CurrencyFieldSchema
+    | DateFieldSchema
+    | DateTimeFieldSchema
+    | DurationFieldSchema
+    | EmailFieldSchema
+    | ExternalSyncSourceFieldSchema
+    | FormulaFieldSchema
+    | LastModifiedByFieldSchema
+    | LastModifiedTimeFieldSchema
+    | ManualSortFieldSchema
+    | MultilineTextFieldSchema
+    | MultipleAttachmentsFieldSchema
+    | MultipleCollaboratorsFieldSchema
+    | MultipleLookupValuesFieldSchema
+    | MultipleRecordLinksFieldSchema
+    | MultipleSelectsFieldSchema
+    | NumberFieldSchema
+    | PercentFieldSchema
+    | PhoneNumberFieldSchema
+    | RatingFieldSchema
+    | RichTextFieldSchema
+    | RollupFieldSchema
+    | SingleCollaboratorFieldSchema
+    | SingleLineTextFieldSchema
+    | SingleSelectFieldSchema
+    | UrlFieldSchema
+    | UnknownFieldSchema
+)
+# [[[end]]] (sum: gPKie2ugBW)
 # fmt: on
 
 
@@ -1585,7 +1576,7 @@ class _HasFieldSchema(AirtableModel):
     field_schema: FieldSchema
 
 
-def parse_field_schema(obj: Dict[str, Any]) -> FieldSchema:
+def parse_field_schema(obj: dict[str, Any]) -> FieldSchema:
     """
     Given a ``dict`` representing a field schema,
     parse it into the appropriate FieldSchema subclass.

--- a/pyairtable/models/webhook.py
+++ b/pyairtable/models/webhook.py
@@ -1,8 +1,9 @@
 import base64
+from collections.abc import Callable, Iterator
 from datetime import datetime
 from functools import partial
 from hmac import HMAC
-from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Union
+from typing import Any, Literal
 
 import pydantic
 from typing_extensions import Self as SelfType
@@ -55,10 +56,10 @@ class Webhook(CanDeleteModel, url="bases/{base.id}/webhooks/{self.id}"):
     are_notifications_enabled: bool
     cursor_for_next_payload: int
     is_hook_enabled: bool
-    last_successful_notification_time: Optional[datetime] = None
-    notification_url: Optional[str] = None
-    last_notification_result: Optional["WebhookNotificationResult"] = None
-    expiration_time: Optional[datetime] = None
+    last_successful_notification_time: datetime | None = None
+    notification_url: str | None = None
+    last_notification_result: "WebhookNotificationResult | None" = None
+    expiration_time: datetime | None = None
     specification: "WebhookSpecification"
 
     def enable_notifications(self) -> None:
@@ -88,7 +89,7 @@ class Webhook(CanDeleteModel, url="bases/{base.id}/webhooks/{self.id}"):
         self.expiration_time = response.get("expirationTime")
 
     def payloads(
-        self, cursor: int = 1, *, limit: Optional[int] = None
+        self, cursor: int = 1, *, limit: int | None = None
     ) -> Iterator["WebhookPayload"]:
         """
         Iterate through all payloads on or after the given cursor.
@@ -185,7 +186,7 @@ class WebhookNotification(AirtableModel):
         cls,
         body: str,
         header: str,
-        secret: Union[bytes, str],
+        secret: bytes | str,
     ) -> SelfType:
         """
         Validate a request body and X-Airtable-Content-MAC header
@@ -218,8 +219,8 @@ class WebhookNotificationResult(AirtableModel):
     completion_timestamp: datetime
     duration_ms: float
     retry_number: int
-    will_be_retried: Optional[bool] = None
-    error: Optional["WebhookError"] = None
+    will_be_retried: bool | None = None
+    error: "WebhookError | None" = None
 
 
 class WebhookError(AirtableModel):
@@ -231,20 +232,20 @@ class WebhookSpecification(AirtableModel):
 
     class Options(AirtableModel):
         filters: "WebhookSpecification.Filters"
-        includes: Optional["WebhookSpecification.Includes"] = None
+        includes: "WebhookSpecification.Includes | None" = None
 
     class Filters(AirtableModel):
-        data_types: List[str]
-        record_change_scope: Optional[str] = None
-        change_types: List[str] = FL()
-        from_sources: List[str] = FL()
-        source_options: Optional["WebhookSpecification.SourceOptions"] = None
-        watch_data_in_field_ids: List[str] = FL()
-        watch_schemas_of_field_ids: List[str] = FL()
+        data_types: list[str]
+        record_change_scope: str | None = None
+        change_types: list[str] = FL()
+        from_sources: list[str] = FL()
+        source_options: "WebhookSpecification.SourceOptions | None" = None
+        watch_data_in_field_ids: list[str] = FL()
+        watch_schemas_of_field_ids: list[str] = FL()
 
     class SourceOptions(AirtableModel):
-        form_submission: Optional["FormSubmission"] = None
-        form_page_submission: Optional["FormPageSubmission"] = None
+        form_submission: "FormSubmission | None" = None
+        form_page_submission: "FormPageSubmission | None" = None
 
         class FormSubmission(AirtableModel):
             view_id: str
@@ -253,13 +254,13 @@ class WebhookSpecification(AirtableModel):
             page_id: str
 
     class Includes(AirtableModel):
-        include_cell_values_in_field_ids: Union[None, List[str], Literal["all"]] = None
+        include_cell_values_in_field_ids: list[str] | Literal["all"] | None = None
         include_previous_cell_values: bool = False
         include_previous_field_definitions: bool = False
 
 
 class CreateWebhook(AirtableModel):
-    notification_url: Optional[str] = None
+    notification_url: str | None = None
     specification: WebhookSpecification
 
 
@@ -278,7 +279,7 @@ class CreateWebhookResponse(AirtableModel):
     mac_secret_base64: str
 
     #: The timestamp when the webhook will expire and be deleted.
-    expiration_time: Optional[datetime] = None
+    expiration_time: datetime | None = None
 
 
 class WebhookPayload(AirtableModel):
@@ -290,12 +291,12 @@ class WebhookPayload(AirtableModel):
     timestamp: datetime
     base_transaction_number: int
     payload_format: str
-    action_metadata: Optional["WebhookPayload.ActionMetadata"] = None
-    changed_tables_by_id: Dict[str, "WebhookPayload.TableChanged"] = FD()
-    created_tables_by_id: Dict[str, "WebhookPayload.TableCreated"] = FD()
-    destroyed_table_ids: List[str] = FL()
-    error: Optional[bool] = None
-    error_code: Optional[str] = pydantic.Field(alias="code", default=None)
+    action_metadata: "WebhookPayload.ActionMetadata | None" = None
+    changed_tables_by_id: dict[str, "WebhookPayload.TableChanged"] = FD()
+    created_tables_by_id: dict[str, "WebhookPayload.TableCreated"] = FD()
+    destroyed_table_ids: list[str] = FL()
+    error: bool | None = None
+    error_code: str | None = pydantic.Field(alias="code", default=None)
 
     #: The payload transaction number, as described in
     #: `List webhook payloads - Response format <https://airtable.com/developers/web/api/list-webhook-payloads#response>`__.
@@ -303,65 +304,65 @@ class WebhookPayload(AirtableModel):
     #: along with any more payloads recorded after it.
     #:
     #: This field is specific to pyAirtable, and is not part of Airtable's webhook payload specification.
-    cursor: Optional[int] = None
+    cursor: int | None = None
 
     class ActionMetadata(AirtableModel):
         source: str
-        source_metadata: Dict[Any, Any] = FD()
+        source_metadata: dict[Any, Any] = FD()
 
     class TableInfo(AirtableModel):
         name: str = ""
-        description: Optional[str] = None
+        description: str | None = None
 
     class FieldInfo(AirtableModel):
-        name: Optional[str] = None
-        type: Optional[str] = None
+        name: str | None = None
+        type: str | None = None
 
     class FieldChanged(AirtableModel):
         current: "WebhookPayload.FieldInfo"
-        previous: Optional["WebhookPayload.FieldInfo"] = None
+        previous: "WebhookPayload.FieldInfo | None" = None
 
     class TableChanged(AirtableModel):
-        changed_views_by_id: Dict[str, "WebhookPayload.ViewChanged"] = FD()
-        changed_fields_by_id: Dict[str, "WebhookPayload.FieldChanged"] = FD()
-        changed_records_by_id: Dict[RecordId, "WebhookPayload.RecordChanged"] = FD()
-        created_fields_by_id: Dict[str, "WebhookPayload.FieldInfo"] = FD()
-        created_records_by_id: Dict[RecordId, "WebhookPayload.RecordCreated"] = FD()
-        changed_metadata: Optional["WebhookPayload.TableChanged.ChangedMetadata"] = None
-        destroyed_field_ids: List[str] = FL()
-        destroyed_record_ids: List[RecordId] = FL()
+        changed_views_by_id: dict[str, "WebhookPayload.ViewChanged"] = FD()
+        changed_fields_by_id: dict[str, "WebhookPayload.FieldChanged"] = FD()
+        changed_records_by_id: dict[RecordId, "WebhookPayload.RecordChanged"] = FD()
+        created_fields_by_id: dict[str, "WebhookPayload.FieldInfo"] = FD()
+        created_records_by_id: dict[RecordId, "WebhookPayload.RecordCreated"] = FD()
+        changed_metadata: "WebhookPayload.TableChanged.ChangedMetadata | None" = None
+        destroyed_field_ids: list[str] = FL()
+        destroyed_record_ids: list[RecordId] = FL()
 
         class ChangedMetadata(AirtableModel):
             current: "WebhookPayload.TableInfo"
             previous: "WebhookPayload.TableInfo"
 
     class ViewChanged(AirtableModel):
-        changed_records_by_id: Dict[RecordId, "WebhookPayload.RecordChanged"] = FD()
-        created_records_by_id: Dict[RecordId, "WebhookPayload.RecordCreated"] = FD()
-        destroyed_record_ids: List[RecordId] = FL()
+        changed_records_by_id: dict[RecordId, "WebhookPayload.RecordChanged"] = FD()
+        created_records_by_id: dict[RecordId, "WebhookPayload.RecordCreated"] = FD()
+        destroyed_record_ids: list[RecordId] = FL()
 
     class TableCreated(AirtableModel):
-        metadata: Optional["WebhookPayload.TableInfo"] = None
-        fields_by_id: Dict[str, "WebhookPayload.FieldInfo"] = FD()
-        records_by_id: Dict[RecordId, "WebhookPayload.RecordCreated"] = FD()
+        metadata: "WebhookPayload.TableInfo | None" = None
+        fields_by_id: dict[str, "WebhookPayload.FieldInfo"] = FD()
+        records_by_id: dict[RecordId, "WebhookPayload.RecordCreated"] = FD()
 
     class RecordChanged(AirtableModel):
         current: "WebhookPayload.CellValuesByFieldId"
-        previous: Optional["WebhookPayload.CellValuesByFieldId"] = None
-        unchanged: Optional["WebhookPayload.CellValuesByFieldId"] = None
+        previous: "WebhookPayload.CellValuesByFieldId | None" = None
+        unchanged: "WebhookPayload.CellValuesByFieldId | None" = None
 
     class CellValuesByFieldId(AirtableModel):
-        cell_values_by_field_id: Dict[str, Any]
+        cell_values_by_field_id: dict[str, Any]
 
     class RecordCreated(AirtableModel):
         created_time: datetime
-        cell_values_by_field_id: Dict[str, Any]
+        cell_values_by_field_id: dict[str, Any]
 
 
 class WebhookPayloads(AirtableModel):
     cursor: int
     might_have_more: bool
-    payloads: List[WebhookPayload]
+    payloads: list[WebhookPayload]
 
 
 rebuild_models(vars())

--- a/pyairtable/orm/fields.py
+++ b/pyairtable/orm/fields.py
@@ -28,29 +28,22 @@ which allows us to define methods and type annotations for getting and setting a
 import abc
 import importlib
 import re
+from collections.abc import Callable
 from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     ClassVar,
-    Dict,
     Generic,
-    List,
     Literal,
-    Optional,
-    Set,
-    Tuple,
-    Type,
+    TypeAlias,
     TypeVar,
-    Union,
     cast,
     overload,
 )
 
 from typing_extensions import Self as SelfType
-from typing_extensions import TypeAlias
 
 from pyairtable import formulas, utils
 from pyairtable.api.types import (
@@ -76,7 +69,7 @@ if TYPE_CHECKING:
     from pyairtable.orm import Model
 
 
-_ClassInfo: TypeAlias = Union[type, Tuple["_ClassInfo", ...]]
+_ClassInfo: TypeAlias = type | tuple["_ClassInfo", ...]
 T = TypeVar("T")
 T_Linked = TypeVar("T_Linked", bound="Model")  # used by LinkField
 T_API = TypeVar("T_API")  # type used to exchange values w/ Airtable API
@@ -111,16 +104,16 @@ class Field(Generic[T_API, T_ORM, T_Missing], metaclass=abc.ABCMeta):
     readonly: bool = False
 
     # Contains a reference to the Model class (if possible)
-    _model: Optional[Type["Model"]] = None
+    _model: type["Model"] | None = None
 
     # The name of the attribute on the Model class (if possible)
-    _attribute_name: Optional[str] = None
+    _attribute_name: str | None = None
 
     def __init__(
         self,
         field_name: str,
         validate_type: bool = True,
-        readonly: Optional[bool] = None,
+        readonly: bool | None = None,
     ) -> None:
         """
         Args:
@@ -166,17 +159,15 @@ class Field(Generic[T_API, T_ORM, T_Missing], metaclass=abc.ABCMeta):
 
     # Model.field will call __get__(instance=None, owner=Model)
     @overload
-    def __get__(self, instance: None, owner: Type[Any]) -> SelfType: ...
+    def __get__(self, instance: None, owner: type[Any]) -> SelfType: ...
 
     # obj.field will call __get__(instance=obj, owner=Model)
     @overload
-    def __get__(
-        self, instance: "Model", owner: Type[Any]
-    ) -> Union[T_ORM, T_Missing]: ...
+    def __get__(self, instance: "Model", owner: type[Any]) -> T_ORM | T_Missing: ...
 
     def __get__(
-        self, instance: Optional["Model"], owner: Type[Any]
-    ) -> Union[SelfType, T_ORM, T_Missing]:
+        self, instance: "Model | None", owner: type[Any]
+    ) -> SelfType | T_ORM | T_Missing:
         # allow calling Model.field to get the field object instead of a value
         if not instance:
             return self
@@ -188,7 +179,7 @@ class Field(Generic[T_API, T_ORM, T_Missing], metaclass=abc.ABCMeta):
             return cast(T_Missing, self.missing_value)
         return cast(T_ORM, value)
 
-    def __set__(self, instance: "Model", value: Optional[T_ORM]) -> None:
+    def __set__(self, instance: "Model", value: T_ORM | None) -> None:
         self._raise_if_readonly()
         if self.validate_type and value is not None:
             self.valid_or_raise(value)
@@ -231,7 +222,7 @@ class Field(Generic[T_API, T_ORM, T_Missing], metaclass=abc.ABCMeta):
         args += [f"{key}={val!r}" for (key, val) in self._repr_fields()]
         return self.__class__.__name__ + "(" + ", ".join(args) + ")"
 
-    def _repr_fields(self) -> List[Tuple[str, Any]]:
+    def _repr_fields(self) -> list[tuple[str, Any]]:
         return [
             ("readonly", self.readonly),
             ("validate_type", self.validate_type),
@@ -285,20 +276,18 @@ class _Requires_API_ORM(Generic[T_API, T_ORM], Field[T_API, T_ORM, T_ORM]):
     """
 
     @overload
-    def __get__(self, instance: None, owner: Type[Any]) -> SelfType: ...
+    def __get__(self, instance: None, owner: type[Any]) -> SelfType: ...
 
     @overload
-    def __get__(self, instance: "Model", owner: Type[Any]) -> T_ORM: ...
+    def __get__(self, instance: "Model", owner: type[Any]) -> T_ORM: ...
 
-    def __get__(
-        self, instance: Optional["Model"], owner: Type[Any]
-    ) -> Union[SelfType, T_ORM]:
+    def __get__(self, instance: "Model | None", owner: type[Any]) -> SelfType | T_ORM:
         value = super().__get__(instance, owner)
         if value is None or value == "":
             raise MissingValueError(f"{self._description} received an empty value")
         return value
 
-    def __set__(self, instance: "Model", value: Optional[T_ORM]) -> None:
+    def __set__(self, instance: "Model", value: T_ORM | None) -> None:
         if value in (None, ""):
             raise MissingValueError(f"{self._description} does not accept empty values")
         super().__set__(instance, value)
@@ -340,14 +329,14 @@ AnyField: TypeAlias = Field[Any, Any, Any]
 # ======================================================
 
 
-T_Field = TypeVar("T_Field", bound=Type[Field[Any, Any, Any]])
+T_Field = TypeVar("T_Field", bound=type[Field[Any, Any, Any]])
 
 
 def _use_inherited_docstring(cls: T_Field) -> T_Field:
     """
     Reuses the class's first parent class's docstring if it's undocumented.
     """
-    from_cls: Type[Any] = cls
+    from_cls: type[Any] = cls
     while len(from_cls.__mro__) > 1 and not from_cls.__doc__:
         from_cls = from_cls.__mro__[1]
         if from_cls is Field:
@@ -481,7 +470,7 @@ class SingleLineTextField(_StringField, _FieldSchema[S.SingleLineTextFieldSchema
 @_field_api_docstring("Single line text", "simpletext", "Long text", "multilinetext")
 class TextField(
     _StringField,
-    _FieldSchema[Union[S.SingleLineTextFieldSchema, S.MultilineTextFieldSchema]],
+    _FieldSchema[S.SingleLineTextFieldSchema | S.MultilineTextFieldSchema],
 ):
     pass
 
@@ -510,7 +499,7 @@ class _NumericFieldBase(_BasicField[T]):
         super().valid_or_raise(value)
 
 
-class _NumberField(_NumericFieldBase[Union[int, float]]):
+class _NumberField(_NumericFieldBase[int | float]):
     """
     Number field with unspecified precision. Accepts either ``int`` or ``float``.
     """
@@ -658,7 +647,7 @@ class DurationField(
         """
         return value.total_seconds()
 
-    def to_internal_value(self, value: Union[int, float]) -> timedelta:
+    def to_internal_value(self, value: int | float) -> timedelta:
         """
         Convert a number of seconds into a ``timedelta``.
         """
@@ -672,7 +661,7 @@ class DurationField(
 
 class _ListFieldBase(
     Generic[T_API, T_ORM, T_ORM_List],
-    Field[List[T_API], List[T_ORM], T_ORM_List],
+    Field[list[T_API], list[T_ORM], T_ORM_List],
 ):
     """
     Generic type for a field that stores a list of values.
@@ -685,8 +674,8 @@ class _ListFieldBase(
     """
 
     valid_types = list
-    list_class: Type[T_ORM_List]
-    contains_type: Optional[Type[T_ORM]]
+    list_class: type[T_ORM_List]
+    contains_type: type[T_ORM] | None
 
     # List fields will always return a list, never ``None``, so we
     # have to overload the type annotations for __get__
@@ -707,24 +696,24 @@ class _ListFieldBase(
         return super().__init_subclass__(**kwargs)
 
     @overload
-    def __get__(self, instance: None, owner: Type[Any]) -> SelfType: ...
+    def __get__(self, instance: None, owner: type[Any]) -> SelfType: ...
 
     @overload
-    def __get__(self, instance: "Model", owner: Type[Any]) -> T_ORM_List: ...
+    def __get__(self, instance: "Model", owner: type[Any]) -> T_ORM_List: ...
 
     def __get__(
-        self, instance: Optional["Model"], owner: Type[Any]
-    ) -> Union[SelfType, T_ORM_List]:
+        self, instance: "Model | None", owner: type[Any]
+    ) -> SelfType | T_ORM_List:
         if not instance:
             return self
         return self._get_list_value(instance)
 
-    def __set__(self, instance: "Model", value: Optional[List[T_ORM]]) -> None:
+    def __set__(self, instance: "Model", value: list[T_ORM] | None) -> None:
         if isinstance(value, list) and not isinstance(value, self.list_class):
             assert isinstance(self.list_class, type)
             assert issubclass(self.list_class, ChangeTrackingList)
             value = self.list_class(value, field=self, model=instance)
-        super().__set__(instance, cast(Optional[List[T_ORM]], value))
+        super().__set__(instance, cast(list[T_ORM] | None, value))
 
     def _get_list_value(self, instance: "Model") -> T_ORM_List:
         value = instance._fields.get(self.field_name)
@@ -786,15 +775,15 @@ class LinkField(
     provided the field is created with ``readonly=True``.
     """
 
-    _linked_model: Union[str, Literal[_LinkFieldOptions.LinkSelf], Type[T_Linked]]
-    _max_retrieve: Optional[int] = None
+    _linked_model: str | Literal[_LinkFieldOptions.LinkSelf] | type[T_Linked]
+    _max_retrieve: int | None = None
 
     def __init__(
         self,
         field_name: str,
-        model: Union[str, Literal[_LinkFieldOptions.LinkSelf], Type[T_Linked]],
+        model: str | Literal[_LinkFieldOptions.LinkSelf] | type[T_Linked],
         validate_type: bool = True,
-        readonly: Optional[bool] = None,
+        readonly: bool | None = None,
         lazy: bool = False,
     ):
         """
@@ -833,7 +822,7 @@ class LinkField(
         self._lazy = lazy
 
     @property
-    def linked_model(self) -> Type[T_Linked]:
+    def linked_model(self) -> type[T_Linked]:
         """
         Resolve a :class:`~pyairtable.orm.Model` class based on
         the ``model=`` constructor parameter to this field instance.
@@ -846,16 +835,16 @@ class LinkField(
                 modpath = self._model.__module__
             mod = importlib.import_module(modpath)
             cls = getattr(mod, clsname)
-            self._linked_model = cast(Type[T_Linked], cls)
+            self._linked_model = cast(type[T_Linked], cls)
 
         elif self._linked_model is _LinkFieldOptions.LinkSelf:
             if self._model is None:
                 raise RuntimeError(f"{self._description} not created on a Model")
-            self._linked_model = cast(Type[T_Linked], self._model)
+            self._linked_model = cast(type[T_Linked], self._model)
 
         return self._linked_model
 
-    def _repr_fields(self) -> List[Tuple[str, Any]]:
+    def _repr_fields(self) -> list[tuple[str, Any]]:
         return [
             ("model", self._linked_model),
             ("validate_type", self.validate_type),
@@ -867,8 +856,8 @@ class LinkField(
         self,
         instance: "Model",
         *,
-        lazy: Optional[bool] = None,
-        memoize: Optional[bool] = None,
+        lazy: bool | None = None,
+        memoize: bool | None = None,
     ) -> None:
         """
         Populates the field's value for the given instance. This allows you to
@@ -913,7 +902,7 @@ class LinkField(
             new_records = {
                 record.id: record
                 for record in self.linked_model.from_ids(
-                    cast(List[RecordId], new_record_ids),
+                    cast(list[RecordId], new_record_ids),
                     memoize=memoize,
                     fetch=(not lazy),
                 )
@@ -943,7 +932,7 @@ class LinkField(
         self.populate(instance)
         return super()._get_list_value(instance)
 
-    def to_record_value(self, value: List[Union[str, T_Linked]]) -> List[str]:
+    def to_record_value(self, value: list[str | T_Linked]) -> list[str]:
         """
         Build the list of record IDs which should be persisted to the API.
         """
@@ -951,7 +940,7 @@ class LinkField(
         # but we never actually accessed the value (see _get_list_value).
         # When persisting this model back to the API, we can just write those IDs.
         if all(isinstance(v, str) for v in value):
-            return cast(List[str], value)
+            return cast(list[str], value)
 
         # Validate any items in our list which are not record IDs
         records = [v for v in value if not isinstance(v, str)]
@@ -973,7 +962,7 @@ class LinkField(
 
 class SingleLinkField(
     Generic[T_Linked],
-    Field[List[str], T_Linked, None],
+    Field[list[str], T_Linked, None],
     _FieldSchema[S.MultipleRecordLinksFieldSchema],
 ):
     """
@@ -1035,9 +1024,9 @@ class SingleLinkField(
     def __init__(
         self,
         field_name: str,
-        model: Union[str, Literal[_LinkFieldOptions.LinkSelf], Type[T_Linked]],
+        model: str | Literal[_LinkFieldOptions.LinkSelf] | type[T_Linked],
         validate_type: bool = True,
-        readonly: Optional[bool] = None,
+        readonly: bool | None = None,
         lazy: bool = False,
         raise_if_many: bool = False,
     ):
@@ -1053,7 +1042,7 @@ class SingleLinkField(
         )
         self._link_field._max_retrieve = 1
 
-    def _repr_fields(self) -> List[Tuple[str, Any]]:
+    def _repr_fields(self) -> list[tuple[str, Any]]:
         return [
             ("model", self._link_field._linked_model),
             ("validate_type", self.validate_type),
@@ -1063,14 +1052,14 @@ class SingleLinkField(
         ]
 
     @overload
-    def __get__(self, instance: None, owner: Type[Any]) -> SelfType: ...
+    def __get__(self, instance: None, owner: type[Any]) -> SelfType: ...
 
     @overload
-    def __get__(self, instance: "Model", owner: Type[Any]) -> Optional[T_Linked]: ...
+    def __get__(self, instance: "Model", owner: type[Any]) -> T_Linked | None: ...
 
     def __get__(
-        self, instance: Optional["Model"], owner: Type[Any]
-    ) -> Union[SelfType, Optional[T_Linked]]:
+        self, instance: "Model | None", owner: type[Any]
+    ) -> SelfType | T_Linked | None:
         if not instance:
             return self
         if self._raise_if_many and len(instance._fields.get(self.field_name) or []) > 1:
@@ -1083,7 +1072,7 @@ class SingleLinkField(
         except IndexError:
             return None
 
-    def __set__(self, instance: "Model", value: Optional[T_Linked]) -> None:
+    def __set__(self, instance: "Model", value: T_Linked | None) -> None:
         values = None if value is None else [value]
         self._link_field.__set__(instance, values)
 
@@ -1091,7 +1080,7 @@ class SingleLinkField(
         super().__set_name__(owner, name)
         self._link_field.__set_name__(owner, name)
 
-    def to_record_value(self, value: List[Union[str, T_Linked]]) -> List[str]:
+    def to_record_value(self, value: list[str | T_Linked]) -> list[str]:
         return self._link_field.to_record_value(value)
 
     @utils.docstring_from(LinkField.populate)
@@ -1099,14 +1088,14 @@ class SingleLinkField(
         self,
         instance: "Model",
         *,
-        lazy: Optional[bool] = None,
-        memoize: Optional[bool] = None,
+        lazy: bool | None = None,
+        memoize: bool | None = None,
     ) -> None:
         self._link_field.populate(instance, lazy=lazy, memoize=memoize)
 
     @property
     @utils.docstring_from(LinkField.linked_model)
-    def linked_model(self) -> Type[T_Linked]:
+    def linked_model(self) -> type[T_Linked]:
         return self._link_field.linked_model
 
 
@@ -1131,7 +1120,7 @@ class AITextField(_DictField[AITextDict], _FieldSchema[S.AITextFieldSchema]):
 @_field_api_docstring("Attachments", "multipleattachment")
 class AttachmentsField(
     _ListFieldBase[
-        AttachmentDict, Union[AttachmentDict, CreateAttachmentDict], AttachmentsList
+        AttachmentDict, AttachmentDict | CreateAttachmentDict, AttachmentsList
     ],
     _FieldSchema[S.MultipleAttachmentsFieldSchema],
     list_class=AttachmentsList,
@@ -1166,7 +1155,7 @@ class ButtonField(
 
 @_field_api_docstring("Collaborator")
 class CollaboratorField(
-    _DictField[Union[CollaboratorDict, CollaboratorEmailDict]],
+    _DictField[CollaboratorDict | CollaboratorEmailDict],
     _FieldSchema[S.SingleCollaboratorFieldSchema],
 ):
     """
@@ -1243,7 +1232,7 @@ class LookupField(_ListField[T], _FieldSchema[S.MultipleLookupValuesFieldSchema]
 
 @_field_api_docstring("Multiple collaborators", "multicollaborator")
 class MultipleCollaboratorsField(
-    _ListField[Union[CollaboratorDict, CollaboratorEmailDict]],
+    _ListField[CollaboratorDict | CollaboratorEmailDict],
     _FieldSchema[S.MultipleCollaboratorsFieldSchema],
     contains_type=dict,
 ):
@@ -1290,7 +1279,7 @@ class RequiredBarcodeField(BarcodeField, _Requires[BarcodeDict]):
 @_required_value_docstring
 class RequiredCollaboratorField(
     CollaboratorField,
-    _Requires[Union[CollaboratorDict, CollaboratorEmailDict]],
+    _Requires[CollaboratorDict | CollaboratorEmailDict],
 ):
     pass
 
@@ -1301,7 +1290,7 @@ class RequiredCountField(CountField, _Requires[int]):
 
 
 @_required_value_docstring
-class RequiredCurrencyField(CurrencyField, _Requires[Union[int, float]]):
+class RequiredCurrencyField(CurrencyField, _Requires[int | float]):
     pass
 
 
@@ -1336,12 +1325,12 @@ class RequiredIntegerField(IntegerField, _Requires[int]):
 
 
 @_required_value_docstring
-class RequiredNumberField(NumberField, _Requires[Union[int, float]]):
+class RequiredNumberField(NumberField, _Requires[int | float]):
     pass
 
 
 @_required_value_docstring
-class RequiredPercentField(PercentField, _Requires[Union[int, float]]):
+class RequiredPercentField(PercentField, _Requires[int | float]):
     pass
 
 
@@ -1388,7 +1377,7 @@ class RequiredUrlField(UrlField, _Requires[str]):
 #: Set of all Field subclasses exposed by the library.
 #:
 #: :meta hide-value:
-ALL_FIELDS: Set[Type[AnyField]] = {
+ALL_FIELDS: set[type[AnyField]] = {
     field_class
     for name, field_class in vars().items()
     if isinstance(field_class, type)
@@ -1401,7 +1390,7 @@ ALL_FIELDS: Set[Type[AnyField]] = {
 #: Set of all read-only Field subclasses exposed by the library.
 #:
 #: :meta hide-value:
-READONLY_FIELDS: Set[Type[AnyField]] = {cls for cls in ALL_FIELDS if cls.readonly}
+READONLY_FIELDS: set[type[AnyField]] = {cls for cls in ALL_FIELDS if cls.readonly}
 
 
 #: Mapping of Airtable field type names to their ORM classes.
@@ -1417,7 +1406,7 @@ READONLY_FIELDS: Set[Type[AnyField]] = {cls for cls in ALL_FIELDS if cls.readonl
 #: which inherit from ``str`` and can be used in string comparisons.
 #:
 #: :meta hide-value:
-FIELD_TYPES_TO_CLASSES: Dict[str, Type[AnyField]] = {
+FIELD_TYPES_TO_CLASSES: dict[str, type[AnyField]] = {
     FieldType.AI_TEXT: AITextField,
     FieldType.AUTO_NUMBER: AutoNumberField,
     FieldType.BARCODE: BarcodeField,
@@ -1459,7 +1448,7 @@ FIELD_TYPES_TO_CLASSES: Dict[str, Type[AnyField]] = {
 #: Mapping of field classes to the set of supported Airtable field types.
 #:
 #: :meta hide-value:
-FIELD_CLASSES_TO_TYPES: Dict[Type[AnyField], Set[str]] = {
+FIELD_CLASSES_TO_TYPES: dict[type[AnyField], set[str]] = {
     cls: {key for (key, val) in FIELD_TYPES_TO_CLASSES.items() if val == cls}
     for cls in ALL_FIELDS
 }

--- a/pyairtable/orm/generate.py
+++ b/pyairtable/orm/generate.py
@@ -10,9 +10,10 @@ The simplest way to use this functionality is with the command line utility:
 """
 
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, Dict, List, Optional, Sequence, Type
+from typing import Any
 
 import inflection
 
@@ -27,7 +28,6 @@ _ANNOTATION_IMPORTS = {
     "datetime": "from datetime import datetime",
     "timedelta": "from datetime import timedelta",
     "Any": "from typing import Any",
-    r"Union\[.+\]": "from typing import Union",
 }
 
 
@@ -40,8 +40,8 @@ class ModelFileBuilder:
     def __init__(
         self,
         base: Base,
-        table_ids: Optional[Sequence[str]] = None,
-        table_names: Optional[Sequence[str]] = None,
+        table_ids: Sequence[str] | None = None,
+        table_names: Sequence[str] | None = None,
     ):
         """
         Args:
@@ -57,7 +57,7 @@ class ModelFileBuilder:
         self.model_builders = [ModelBuilder(self, table) for table in tables]
 
     @cached_property
-    def model_lookup(self) -> Dict[str, "ModelBuilder"]:
+    def model_lookup(self) -> dict[str, "ModelBuilder"]:
         return {
             key: builder
             for builder in self.model_builders
@@ -102,7 +102,7 @@ class ModelBuilder:
     meta_envvar: str = "AIRTABLE_API_KEY"
 
     @property
-    def field_builders(self) -> List["FieldBuilder"]:
+    def field_builders(self) -> list["FieldBuilder"]:
         return [
             FieldBuilder(field_schema, lookup=self.file_generator.model_lookup)
             for field_schema in self.table.schema().fields
@@ -129,14 +129,14 @@ class ModelBuilder:
 @dataclass
 class FieldBuilder:
     schema: S.FieldSchema
-    lookup: Dict[str, ModelBuilder]
+    lookup: dict[str, ModelBuilder]
 
     @property
     def var_name(self) -> str:
         return field_variable_name(self.schema.name)
 
     @property
-    def field_class(self) -> Type[fields.AnyField]:
+    def field_class(self) -> type[fields.AnyField]:
         field_type = self.schema.type
         if isinstance(self.schema, (S.FormulaFieldSchema, S.RollupFieldSchema)):
             if self.schema.options.result:
@@ -149,8 +149,8 @@ class FieldBuilder:
         return fields.FIELD_TYPES_TO_CLASSES[field_type]
 
     def __str__(self) -> str:
-        args: List[Any] = [self.schema.name]
-        kwargs: Dict[str, Any] = {}
+        args: list[Any] = [self.schema.name]
+        kwargs: dict[str, Any] = {}
         generic = ""
         cls = self.field_class
 
@@ -218,10 +218,10 @@ def lookup_field_type_annotation(schema: S.MultipleLookupValuesFieldSchema) -> s
     valid_types = _flatten(cls.valid_types)
     if len(valid_types) == 1:
         return valid_types[0].__name__
-    return "Union[%s]" % ", ".join(t.__name__ for t in _flatten(cls.valid_types))
+    return " | ".join(t.__name__ for t in _flatten(cls.valid_types))
 
 
-def _flatten(class_info: fields._ClassInfo) -> List[Type[Any]]:
+def _flatten(class_info: fields._ClassInfo) -> list[type[Any]]:
     """
     Given a _ClassInfo tuple (which can contain multiple levels of nested tuples)
     return a single list of all the actual types contained.

--- a/pyairtable/orm/lists.py
+++ b/pyairtable/orm/lists.py
@@ -1,17 +1,9 @@
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    SupportsIndex,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, SupportsIndex, TypeVar, overload
 
-from typing_extensions import Self, TypeVar
+from typing_extensions import Self
 
 from pyairtable.api.types import AttachmentDict, CreateAttachmentDict
 from pyairtable.exceptions import ReadonlyFieldError, UnsavedRecordError
@@ -25,7 +17,7 @@ if TYPE_CHECKING:
     from pyairtable.orm.model import Model
 
 
-class ChangeTrackingList(List[T]):
+class ChangeTrackingList(list[T]):
     """
     A list that keeps track of when its contents are modified. This allows us to know
     if any mutations happened to the lists returned from linked record fields.
@@ -66,14 +58,14 @@ class ChangeTrackingList(List[T]):
 
     def __setitem__(
         self,
-        index: Union[SupportsIndex, slice],
-        value: Union[T, Iterable[T]],
+        index: SupportsIndex | slice,
+        value: T | Iterable[T],
         /,
     ) -> None:
         self._on_change()
         return super().__setitem__(index, value)  # type: ignore
 
-    def __delitem__(self, key: Union[SupportsIndex, slice]) -> None:
+    def __delitem__(self, key: SupportsIndex | slice) -> None:
         self._on_change()
         return super().__delitem__(key)
 
@@ -102,12 +94,12 @@ class ChangeTrackingList(List[T]):
         return super().pop(index)
 
 
-class AttachmentsList(ChangeTrackingList[Union[AttachmentDict, CreateAttachmentDict]]):
+class AttachmentsList(ChangeTrackingList[AttachmentDict | CreateAttachmentDict]):
     def upload(
         self,
-        filename: Union[str, Path],
-        content: Optional[Union[str, bytes]] = None,
-        content_type: Optional[str] = None,
+        filename: str | Path,
+        content: str | bytes | None = None,
+        content_type: str | None = None,
     ) -> None:
         """
         Upload an attachment to the Airtable API and refresh the field's values.

--- a/pyairtable/orm/model.py
+++ b/pyairtable/orm/model.py
@@ -1,22 +1,10 @@
 import dataclasses
 import datetime
 import warnings
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from functools import cached_property
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Set,
-    Type,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from typing_extensions import Self as SelfType
 
@@ -121,20 +109,20 @@ class Model:
 
     #: The time when the Airtable record was created. If empty, the instance
     #: has never been saved to (or fetched from) the API.
-    created_time: Optional[datetime.datetime] = None
+    created_time: datetime.datetime | None = None
 
     #: The number of comments on this record. Only populated if the record was
     #: fetched with ``count_comments=True``.
-    comment_count: Optional[int] = None
+    comment_count: int | None = None
 
     #: A wrapper allowing type-annotated access to ORM configuration.
     meta: ClassVar["_Meta"]
 
     _deleted: bool = False
     _fetched: bool = False
-    _fields: Dict[FieldName, Any]
-    _changed: Dict[FieldName, bool]
-    _memoized: ClassVar[Dict[RecordId, SelfType]]
+    _fields: dict[FieldName, Any]
+    _changed: dict[FieldName, bool]
+    _memoized: ClassVar[dict[RecordId, SelfType]]
 
     def __init_subclass__(cls, **kwargs: Any):
         cls.meta = _Meta(cls)
@@ -159,7 +147,7 @@ class Model:
             )
 
     @classmethod
-    def _attribute_descriptor_map(cls) -> Dict[str, AnyField]:
+    def _attribute_descriptor_map(cls) -> dict[str, AnyField]:
         """
         Build a mapping of the model's attribute names to field descriptor instances.
 
@@ -176,7 +164,7 @@ class Model:
         return {k: v for k, v in cls.__dict__.items() if isinstance(v, Field)}
 
     @classmethod
-    def _field_name_descriptor_map(cls) -> Dict[FieldName, AnyField]:
+    def _field_name_descriptor_map(cls) -> dict[FieldName, AnyField]:
         """
         Build a mapping of the model's field names to field descriptor instances.
 
@@ -296,7 +284,7 @@ class Model:
         return bool(result["deleted"])
 
     @classmethod
-    def all(cls, *, memoize: Optional[bool] = None, **kwargs: Any) -> List[SelfType]:
+    def all(cls, *, memoize: bool | None = None, **kwargs: Any) -> list[SelfType]:
         """
         Retrieve all records for this model. For all supported
         keyword arguments, see :meth:`Table.all <pyairtable.Table.all>`.
@@ -311,9 +299,7 @@ class Model:
         ]
 
     @classmethod
-    def first(
-        cls, *, memoize: Optional[bool] = None, **kwargs: Any
-    ) -> Optional[SelfType]:
+    def first(cls, *, memoize: bool | None = None, **kwargs: Any) -> SelfType | None:
         """
         Retrieve the first record for this model. For all supported
         keyword arguments, see :meth:`Table.first <pyairtable.Table.first>`.
@@ -327,7 +313,7 @@ class Model:
         return None
 
     @classmethod
-    def _maybe_memoize(cls, instance: SelfType, memoize: Optional[bool]) -> None:
+    def _maybe_memoize(cls, instance: SelfType, memoize: bool | None) -> None:
         """
         If memoization is enabled, save the instance to the memoization cache.
         """
@@ -358,7 +344,7 @@ class Model:
 
     @classmethod
     def from_record(
-        cls, record: RecordDict, *, memoize: Optional[bool] = None
+        cls, record: RecordDict, *, memoize: bool | None = None
     ) -> SelfType:
         """
         Create an instance from a record dict.
@@ -396,7 +382,7 @@ class Model:
         record_id: RecordId,
         *,
         fetch: bool = True,
-        memoize: Optional[bool] = None,
+        memoize: bool | None = None,
     ) -> SelfType:
         """
         Create an instance from a record ID.
@@ -435,8 +421,8 @@ class Model:
         record_ids: Iterable[RecordId],
         *,
         fetch: bool = True,
-        memoize: Optional[bool] = None,
-    ) -> List[SelfType]:
+        memoize: bool | None = None,
+    ) -> list[SelfType]:
         """
         Create a list of instances from record IDs. If any record IDs returned
         are invalid this will raise a KeyError, but only *after* retrieving all
@@ -451,7 +437,7 @@ class Model:
             return [cls.from_id(record_id, fetch=False) for record_id in record_ids]
 
         record_ids = list(record_ids)
-        by_id: Dict[RecordId, SelfType] = {}
+        by_id: dict[RecordId, SelfType] = {}
 
         if cls._memoized:
             for record_id in record_ids:
@@ -474,7 +460,7 @@ class Model:
         return [by_id[record_id] for record_id in record_ids]
 
     @classmethod
-    def batch_save(cls, models: List[SelfType]) -> None:
+    def batch_save(cls, models: list[SelfType]) -> None:
         """
         Save a list of model instances to the Airtable API with as few
         network requests as possible. Can accept a mixture of new records
@@ -485,12 +471,12 @@ class Model:
 
         create_models = [model for model in models if not model.id]
         update_models = [model for model in models if model.id]
-        create_records: List[WritableFields] = [
+        create_records: list[WritableFields] = [
             record["fields"]
             for model in create_models
             if (record := model.to_record(only_writable=True))
         ]
-        update_records: List[UpdateRecordDict] = [
+        update_records: list[UpdateRecordDict] = [
             {"id": record["id"], "fields": record["fields"]}
             for model in update_models
             if (record := model.to_record(only_writable=True))
@@ -513,7 +499,7 @@ class Model:
                 model.created_time = datetime_from_iso_str(record["createdTime"])
 
     @classmethod
-    def batch_delete(cls, models: List[SelfType]) -> None:
+    def batch_delete(cls, models: list[SelfType]) -> None:
         """
         Delete a list of model instances from Airtable.
 
@@ -526,7 +512,7 @@ class Model:
             raise TypeError(set(type(model) for model in models))
         cls.meta.table.batch_delete([model.id for model in models])
 
-    def comments(self) -> List[Comment]:
+    def comments(self) -> list[Comment]:
         """
         Return a list of comments on this record.
         See :meth:`Table.comments <pyairtable.Table.comments>`.
@@ -548,7 +534,7 @@ class _Meta:
     configuration values (which may or may not be defined in the original class).
     """
 
-    model: Type[Model]
+    model: type[Model]
 
     @property
     def _config(self) -> Mapping[str, Any]:
@@ -569,7 +555,7 @@ class _Meta:
         default: Any = None,
         required: bool = False,
         call: bool = True,
-        check_types: Optional["_ClassInfo"] = None,
+        check_types: "_ClassInfo | None" = None,
     ) -> Any:
         """
         Given a name, retrieve the model configuration with that name.
@@ -598,7 +584,7 @@ class _Meta:
         return str(self.get("api_key", required=True))
 
     @property
-    def timeout(self) -> Optional[TimeoutTuple]:
+    def timeout(self) -> TimeoutTuple | None:
         return self.get(  # type: ignore[no-any-return]
             "timeout",
             default=None,
@@ -606,7 +592,7 @@ class _Meta:
         )
 
     @property
-    def retry_strategy(self) -> Optional[Union[bool, retrying.Retry]]:
+    def retry_strategy(self) -> bool | retrying.Retry | None:
         return self.get(  # type: ignore[no-any-return]
             "retry",
             default=True,
@@ -650,7 +636,7 @@ class _Meta:
         return bool(self.get("memoize", default=False))
 
     @property
-    def request_kwargs(self) -> Dict[str, Any]:
+    def request_kwargs(self) -> dict[str, Any]:
         return {
             "user_locale": None,
             "cell_format": "json",
@@ -696,7 +682,7 @@ class SaveResult:
     created: bool = False
     updated: bool = False
     forced: bool = False
-    field_names: Set[FieldName] = dataclasses.field(default_factory=set)
+    field_names: set[FieldName] = dataclasses.field(default_factory=set)
 
     def __bool__(self) -> bool:
         """

--- a/pyairtable/testing.py
+++ b/pyairtable/testing.py
@@ -11,25 +11,14 @@ import mimetypes
 import random
 import string
 from collections import defaultdict
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import ExitStack, contextmanager
 from functools import partialmethod
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    cast,
-    overload,
-)
+from typing import Any, TypeAlias, cast, overload
 from unittest import mock
 
 import urllib3
-from typing_extensions import Self, TypeAlias
+from typing_extensions import Self
 
 from pyairtable.api import retrying
 from pyairtable.api.api import Api, TimeoutTuple
@@ -79,8 +68,8 @@ def fake_meta(
     base_id: str = "",
     table_name: str = "",
     api_key: str = "patFakePersonalAccessToken",
-    timeout: Optional[TimeoutTuple] = None,
-    retry: Optional[Union[bool, retrying.Retry]] = None,
+    timeout: TimeoutTuple | None = None,
+    retry: bool | retrying.Retry | None = None,
     typecast: bool = True,
     use_field_ids: bool = False,
     memoize: bool = False,
@@ -102,8 +91,8 @@ def fake_meta(
 
 
 def fake_record(
-    fields: Optional[Fields] = None,
-    id: Optional[str] = None,
+    fields: Fields | None = None,
+    id: str | None = None,
     **other_fields: Any,
 ) -> RecordDict:
     """
@@ -190,7 +179,7 @@ def fake_attachment(url: str = "", filename: str = "") -> AttachmentDict:
     }
 
 
-BaseAndTableId: TypeAlias = Tuple[str, str]
+BaseAndTableId: TypeAlias = tuple[str, str]
 
 
 class MockAirtable:
@@ -272,10 +261,10 @@ class MockAirtable:
     ]
 
     # 2-layer mapping of (base, table) IDs --> record IDs --> record dicts.
-    records: Dict[BaseAndTableId, Dict[RecordId, RecordDict]]
+    records: dict[BaseAndTableId, dict[RecordId, RecordDict]]
 
-    _stack: Optional[ExitStack]
-    _mocks: Dict[str, Any]
+    _stack: ExitStack | None
+    _mocks: dict[str, Any]
 
     def __init__(self, passthrough: bool = False) -> None:
         """
@@ -355,18 +344,18 @@ class MockAirtable:
         base_id: str,
         table_id_or_name: str,
         /,
-        records: Iterable[Dict[str, Any]],
-    ) -> List[RecordDict]: ...
+        records: Iterable[dict[str, Any]],
+    ) -> list[RecordDict]: ...
 
     @overload
     def add_records(
         self,
         table: Table,
         /,
-        records: Iterable[Dict[str, Any]],
-    ) -> List[RecordDict]: ...
+        records: Iterable[dict[str, Any]],
+    ) -> list[RecordDict]: ...
 
-    def add_records(self, *args: Any, **kwargs: Any) -> List[RecordDict]:
+    def add_records(self, *args: Any, **kwargs: Any) -> list[RecordDict]:
         """
         Add a list of records to the mock Airtable instance. These will be returned
         from methods like :meth:`~pyairtable.Table.all` and :meth:`~pyairtable.Table.get`.
@@ -414,7 +403,7 @@ class MockAirtable:
         base_id: str,
         table_id_or_name: str,
         /,
-        records: Iterable[Dict[str, Any]],
+        records: Iterable[dict[str, Any]],
     ) -> None: ...
 
     @overload
@@ -422,7 +411,7 @@ class MockAirtable:
         self,
         table: Table,
         /,
-        records: Iterable[Dict[str, Any]],
+        records: Iterable[dict[str, Any]],
     ) -> None: ...
 
     def set_records(self, *args: Any, **kwargs: Any) -> None:
@@ -462,7 +451,7 @@ class MockAirtable:
         mocked = self._mocks["Api.request"]
         return mocked.temp_original(api, method, url, **kwargs)
 
-    def _table_iterate(self, table: Table, **options: Any) -> List[List[RecordDict]]:
+    def _table_iterate(self, table: Table, **options: Any) -> list[list[RecordDict]]:
         return [list(self.records[(table.base.id, table.name)].values())]
 
     def _table_get(self, table: Table, record_id: str, **options: Any) -> RecordDict:
@@ -501,7 +490,7 @@ class MockAirtable:
         table: Table,
         records: Iterable[CreateRecordDict],
         **kwargs: Any,
-    ) -> List[RecordDict]:
+    ) -> list[RecordDict]:
         return [self._table_create(table, record) for record in records]
 
     def _table_batch_update(
@@ -509,7 +498,7 @@ class MockAirtable:
         table: Table,
         records: Iterable[UpdateRecordDict],
         **kwargs: Any,
-    ) -> List[RecordDict]:
+    ) -> list[RecordDict]:
         return [
             self._table_update(table, record["id"], record["fields"])
             for record in records
@@ -519,7 +508,7 @@ class MockAirtable:
         self,
         table: Table,
         record_ids: Iterable[RecordId],
-    ) -> List[RecordDeletedDict]:
+    ) -> list[RecordDeletedDict]:
         return [self._table_delete(table, record_id) for record_id in record_ids]
 
     def _table_batch_upsert(
@@ -542,7 +531,7 @@ class MockAirtable:
         }
 
         for record in records:
-            existing_record: Optional[RecordDict]
+            existing_record: RecordDict | None
             if "id" in record:
                 record_id = str(record.get("id"))
                 existing_record = existing_by_id[record_id]
@@ -561,7 +550,7 @@ class MockAirtable:
         return result
 
 
-def coerce_fake_record(record: Union[AnyRecordDict, Fields]) -> RecordDict:
+def coerce_fake_record(record: AnyRecordDict | Fields) -> RecordDict:
     """
     Coerce a record dict or field mapping to the expected format for
     an Airtable record, creating a fake ID and createdTime if necessary.
@@ -580,9 +569,9 @@ def coerce_fake_record(record: Union[AnyRecordDict, Fields]) -> RecordDict:
 
 def _extract_args(
     args: Sequence[Any],
-    kwargs: Dict[str, Any],
-    extract: Optional[Sequence[str]] = None,
-) -> Tuple[Any, ...]:
+    kwargs: dict[str, Any],
+    extract: Sequence[str] | None = None,
+) -> tuple[Any, ...]:
     """
     Convenience function for functions/methods which accept either
     a Table or a (base_id, table_name) as their first posargs.

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -346,7 +346,7 @@ class Url(str):
     def __and__(self, params: dict[str, Any]) -> Self:
         return self.add_qs(params)
 
-    def add_path(self, *others: Iterable[Any]) -> Self:
+    def add_path(self, *others: Any) -> Self:
         """
         Build a copy of this URL with additional path segments.
 

--- a/pyairtable/utils.py
+++ b/pyairtable/utils.py
@@ -3,26 +3,13 @@ import re
 import textwrap
 import urllib.parse
 import warnings
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from datetime import date, datetime
 from functools import partial, wraps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, cast
 
 import requests
-from typing_extensions import ParamSpec, Protocol, Self
+from typing_extensions import Protocol, Self
 
 from pyairtable.api.types import AnyRecordDict, CreateAttachmentByUrl, FieldValue
 
@@ -60,7 +47,7 @@ def datetime_from_iso_str(value: str) -> datetime:
     return datetime.fromisoformat(value)
 
 
-def date_to_iso_str(value: Union[date, datetime]) -> str:
+def date_to_iso_str(value: date | datetime) -> str:
     """
     Convert a ``date`` or ``datetime`` into an Airtable-compatible ISO 8601 string
 
@@ -251,7 +238,7 @@ def cache_unless_forced(func: Callable[[C], R]) -> _FetchMethod[C, R]:
     return cast(_FetchMethod[C, R], _inner)
 
 
-def coerce_iso_str(value: Any) -> Optional[str]:
+def coerce_iso_str(value: Any) -> str | None:
     """
     Given an input that might be a date or datetime, or an ISO 8601 formatted str,
     convert the value into an ISO 8601 formatted str.
@@ -266,7 +253,7 @@ def coerce_iso_str(value: Any) -> Optional[str]:
     raise TypeError(f"cannot coerce {type(value)} into ISO 8601 str")
 
 
-def coerce_list_str(value: Optional[Union[str, Iterable[str]]]) -> List[str]:
+def coerce_list_str(value: str | Iterable[str] | None) -> list[str]:
     """
     Given an input that is either a str or an iterable of str, return a list.
     """
@@ -279,7 +266,7 @@ def coerce_list_str(value: Optional[Union[str, Iterable[str]]]) -> List[str]:
 
 def fieldgetter(
     *fields: str,
-    required: Union[bool, Iterable[str]] = False,
+    required: bool | Iterable[str] = False,
 ) -> Callable[[AnyRecordDict], Any]:
     """
     Create a function that extracts ID, created time, or field values from a record.
@@ -356,7 +343,7 @@ class Url(str):
     def __floordiv__(self, others: Iterable[Any]) -> Self:
         return self.add_path(*others)
 
-    def __and__(self, params: Dict[str, Any]) -> Self:
+    def __and__(self, params: dict[str, Any]) -> Self:
         return self.add_qs(params)
 
     def add_path(self, *others: Iterable[Any]) -> Self:
@@ -387,7 +374,7 @@ class Url(str):
 
     def add_qs(
         self,
-        params: Optional[Dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
         **other_params: Any,
     ) -> Self:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,10 @@ import importlib
 import json
 import re
 from collections import OrderedDict
+from collections.abc import Callable
 from pathlib import Path
 from posixpath import join as urljoin
-from typing import Any, Callable
+from typing import Any
 from urllib.parse import quote, urlencode
 
 import pytest

--- a/tests/test_api_api.py
+++ b/tests/test_api_api.py
@@ -53,6 +53,27 @@ def test_update_api_key(api):
     assert "123" in api.session.headers["Authorization"]
 
 
+def test_request_timeout_default(api, requests_mock):
+    """
+    Test that requests are made without a timeout when none is configured.
+    """
+    requests_mock.get("https://api.airtable.com/v0/meta/whoami", json={})
+    api.request("GET", api.urls.whoami)
+    assert requests_mock.last_request.timeout is None
+
+
+def test_request_timeout_configured(requests_mock):
+    """
+    Test that the timeout passed to Api() is forwarded to the underlying
+    request, so users configuring ``Api(timeout=(2, 5))`` actually get a
+    connect/read timeout enforced.
+    """
+    api = Api("apikey", timeout=(2, 5))
+    requests_mock.get("https://api.airtable.com/v0/meta/whoami", json={})
+    api.request("GET", api.urls.whoami)
+    assert requests_mock.last_request.timeout == (2, 5)
+
+
 def test_whoami(api, requests_mock):
     """
     Test the /whoami endpoint gets passed straight through.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from typing import List
 
 import pytest
 
@@ -126,7 +125,7 @@ def test_save__nested_reload(requests_mock, api):
     class Parent(CanUpdateModel, url="foo/{self.id}"):
         id: int
         name: str
-        children: List["Parent.Child"]  # noqa
+        children: list["Parent.Child"]  # noqa
 
         class Child(CanUpdateModel, url="foo/{parent.id}/child/{child.id}"):
             id: int

--- a/tests/test_models_schema.py
+++ b/tests/test_models_schema.py
@@ -1,5 +1,4 @@
 from operator import attrgetter
-from typing import List, Optional
 
 import mock
 import pytest
@@ -95,12 +94,12 @@ def test_deserialized_values(obj_path, expected_value, schema_obj):
 
 
 class Outer(AirtableModel):
-    inners: List["Outer.Inner"]
+    inners: list["Outer.Inner"]
 
     class Inner(AirtableModel):
         id: str
         name: str
-        deleted: Optional[bool] = None
+        deleted: bool | None = None
 
     def find(self, id_or_name):
         return schema._find(self.inners, id_or_name)

--- a/tests/test_orm_generate.py
+++ b/tests/test_orm_generate.py
@@ -44,7 +44,7 @@ def test_field_variable_name(value, expected):
         (None, "Any"),
         ({"type": "multipleRecordLinks"}, "str"),
         ({"type": "singleLineText"}, "str"),
-        ({"type": "number"}, "Union[int, float]"),
+        ({"type": "number"}, "int | float"),
         ({"type": "date"}, "date"),
         ({"type": "dateTime"}, "datetime"),
         ({"type": "rating"}, "int"),

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -288,6 +288,25 @@ if TYPE_CHECKING:
     assert_type(F.to_formula("Bob"), F.Formula)
     assert_type(F.CONCATENATE(1, 2, 3), F.FunctionCall)
 
+    # AND()/OR() accept either multiple Formula args, or a single iterable
+    # of Formula, plus optional keyword fields -- but not a mix of the two,
+    # since Compound.build() only flattens a lone iterable positional arg.
+    formula_list = [formula, formula]
+    assert_type(F.AND(formula, formula, formula), F.Compound)
+    assert_type(F.AND(formula_list), F.Compound)
+    assert_type(F.AND(x for x in formula_list), F.Compound)
+    assert_type(F.AND(foo=1, bar="baz"), F.Compound)
+    assert_type(F.AND(formula, formula, foo=1), F.Compound)
+    assert_type(F.AND(formula_list, foo=1), F.Compound)
+    assert_type(F.OR(formula, formula, formula), F.Compound)
+    assert_type(F.OR(formula_list), F.Compound)
+    assert_type(F.OR(x for x in formula_list), F.Compound)
+    assert_type(F.OR(foo=1, bar="baz"), F.Compound)
+    assert_type(F.OR(formula, formula, foo=1), F.Compound)
+    assert_type(F.OR(formula_list, foo=1), F.Compound)
+    F.AND(formula, formula_list)  # type: ignore[call-overload]
+    F.OR(formula, formula_list)  # type: ignore[call-overload]
+
     # Test type annotations for pyairtable.utils.Url
     v = pyairtable.utils.Url("https://example.com")
     assert v == "https://example.com"

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -288,6 +288,10 @@ if TYPE_CHECKING:
     assert_type(F.to_formula("Bob"), F.Formula)
     assert_type(F.CONCATENATE(1, 2, 3), F.FunctionCall)
 
+    # Formula functions must accept ORM field descriptors as arguments,
+    # since to_formula() converts them to field references at runtime.
+    assert_type(F.SUM(EveryField.integer, 1), F.FunctionCall)
+
     # AND()/OR() accept either multiple Formula args, or a single iterable
     # of Formula, plus optional keyword fields -- but not a mix of the two,
     # since Compound.build() only flattens a lone iterable positional arg.

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -3,7 +3,8 @@ Tests that pyairtable.api functions/methods return appropriately typed responses
 """
 
 import datetime
-from typing import TYPE_CHECKING, Iterator, List, Optional, Union
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 from typing_extensions import assert_type
 
@@ -39,16 +40,16 @@ if TYPE_CHECKING:
     table = pyairtable.Table(None, base, table_name)
     assert_type(table, pyairtable.Table)
     assert_type(table.get(record_id), T.RecordDict)
-    assert_type(table.iterate(), Iterator[List[T.RecordDict]])
-    assert_type(table.all(), List[T.RecordDict])
-    assert_type(table.first(), Optional[T.RecordDict])
+    assert_type(table.iterate(), Iterator[list[T.RecordDict]])
+    assert_type(table.all(), list[T.RecordDict])
+    assert_type(table.first(), T.RecordDict | None)
     assert_type(table.create({}), T.RecordDict)
     assert_type(table.update(record_id, {}), T.RecordDict)
     assert_type(table.delete(record_id), T.RecordDeletedDict)
-    assert_type(table.batch_create([]), List[T.RecordDict])
-    assert_type(table.batch_update([]), List[T.RecordDict])
+    assert_type(table.batch_create([]), list[T.RecordDict])
+    assert_type(table.batch_update([]), list[T.RecordDict])
     assert_type(table.batch_upsert([], []), T.UpsertResultDict)
-    assert_type(table.batch_delete([]), List[T.RecordDeletedDict])
+    assert_type(table.batch_delete([]), list[T.RecordDeletedDict])
 
     # Ensure we can set all kinds of field values
     table.update(record_id, {"Field Name": "name"})
@@ -79,7 +80,7 @@ if TYPE_CHECKING:
     assert_type(Actor().name, str)
     assert_type(
         Actor().logins,
-        L.ChangeTrackingList[Union[T.CollaboratorDict, T.CollaboratorEmailDict]],
+        L.ChangeTrackingList[T.CollaboratorDict | T.CollaboratorEmailDict],
     )
     Actor().logins.append({"id": "usr123"})
     Actor().logins.append({"email": "alice@example.com"})
@@ -95,10 +96,10 @@ if TYPE_CHECKING:
 
     movie = Movie()
     assert_type(movie.name, str)
-    assert_type(movie.rating, Optional[int])
+    assert_type(movie.rating, int | None)
     assert_type(movie.actors, L.ChangeTrackingList[Actor])
     assert_type(movie.prequels, L.ChangeTrackingList[Movie])
-    assert_type(movie.prequel, Optional[Movie])
+    assert_type(movie.prequel, Movie | None)
     assert_type(movie.actors[0], Actor)
     assert_type(movie.actors[0].name, str)
 
@@ -153,51 +154,51 @@ if TYPE_CHECKING:
     # Check the types of values returned from these fields
     # fmt: off
     record = EveryField()
-    assert_type(record.aitext, Optional[T.AITextDict])
+    assert_type(record.aitext, T.AITextDict | None)
     assert_type(record.attachments, L.AttachmentsList)
-    assert_type(record.attachments[0], Union[T.AttachmentDict, T.CreateAttachmentDict])
+    assert_type(record.attachments[0], T.AttachmentDict | T.CreateAttachmentDict)
     assert_type(record.attachments.upload("", b""), None)
     assert_type(record.autonumber, int)
-    assert_type(record.barcode, Optional[T.BarcodeDict])
+    assert_type(record.barcode, T.BarcodeDict | None)
     assert_type(record.button, T.ButtonDict)
     assert_type(record.checkbox, bool)
-    assert_type(record.collaborator, Optional[Union[T.CollaboratorDict, T.CollaboratorEmailDict]])
-    assert_type(record.count, Optional[int])
+    assert_type(record.collaborator, T.CollaboratorDict | T.CollaboratorEmailDict | None)
+    assert_type(record.count, int | None)
     assert_type(record.created_by, T.CollaboratorDict)
     assert_type(record.created, datetime.datetime)
-    assert_type(record.currency, Optional[Union[int, float]])
-    assert_type(record.date, Optional[datetime.date])
-    assert_type(record.datetime, Optional[datetime.datetime])
-    assert_type(record.duration, Optional[datetime.timedelta])
+    assert_type(record.currency, int | float | None)
+    assert_type(record.date, datetime.date | None)
+    assert_type(record.datetime, datetime.datetime | None)
+    assert_type(record.duration, datetime.timedelta | None)
     assert_type(record.email, str)
-    assert_type(record.float, Optional[float])
-    assert_type(record.integer, Optional[int])
-    assert_type(record.last_modified_by, Optional[T.CollaboratorDict])
-    assert_type(record.last_modified, Optional[datetime.datetime])
-    assert_type(record.multi_user, L.ChangeTrackingList[Union[T.CollaboratorDict, T.CollaboratorEmailDict]])
-    assert_type(record.multi_user[0], Union[T.CollaboratorDict, T.CollaboratorEmailDict])
+    assert_type(record.float, float | None)
+    assert_type(record.integer, int | None)
+    assert_type(record.last_modified_by, T.CollaboratorDict | None)
+    assert_type(record.last_modified, datetime.datetime | None)
+    assert_type(record.multi_user, L.ChangeTrackingList[T.CollaboratorDict | T.CollaboratorEmailDict])
+    assert_type(record.multi_user[0], T.CollaboratorDict | T.CollaboratorEmailDict)
     assert_type(record.multi_select, L.ChangeTrackingList[str])
     assert_type(record.multi_select[0], str)
-    assert_type(record.number, Optional[Union[int, float]])
-    assert_type(record.percent, Optional[Union[int, float]])
+    assert_type(record.number, int | float | None)
+    assert_type(record.percent, int | float | None)
     assert_type(record.phone, str)
-    assert_type(record.rating, Optional[int])
+    assert_type(record.rating, int | None)
     assert_type(record.rich_text, str)
-    assert_type(record.select, Optional[str])
+    assert_type(record.select, str | None)
     assert_type(record.url, str)
     assert_type(record.required_aitext, T.AITextDict)
     assert_type(record.required_barcode, T.BarcodeDict)
-    assert_type(record.required_collaborator, Union[T.CollaboratorDict, T.CollaboratorEmailDict])
+    assert_type(record.required_collaborator, T.CollaboratorDict | T.CollaboratorEmailDict)
     assert_type(record.required_count, int)
-    assert_type(record.required_currency, Union[int, float])
+    assert_type(record.required_currency, int | float)
     assert_type(record.required_date, datetime.date)
     assert_type(record.required_datetime, datetime.datetime)
     assert_type(record.required_duration, datetime.timedelta)
     assert_type(record.required_email, str)
     assert_type(record.required_float, float)
     assert_type(record.required_integer, int)
-    assert_type(record.required_number, Union[int, float])
-    assert_type(record.required_percent, Union[int, float])
+    assert_type(record.required_number, int | float)
+    assert_type(record.required_percent, int | float)
     assert_type(record.required_phone, str)
     assert_type(record.required_rating, int)
     assert_type(record.required_rich_text, str)
@@ -205,7 +206,7 @@ if TYPE_CHECKING:
     assert_type(record.required_url, str)
 
     # Check the types of each field schema
-    assert_type(Movie.name.field_schema(), Union[schema.SingleLineTextFieldSchema, schema.MultilineTextFieldSchema])
+    assert_type(Movie.name.field_schema(), schema.SingleLineTextFieldSchema | schema.MultilineTextFieldSchema)
     assert_type(Actor.name.field_schema(), schema.SingleLineTextFieldSchema)
     assert_type(Actor.bio.field_schema(), schema.MultilineTextFieldSchema)
     assert_type(EveryField.aitext.field_schema(), schema.AITextFieldSchema)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -287,3 +287,12 @@ if TYPE_CHECKING:
     assert_type(F.to_formula(True), F.Formula)
     assert_type(F.to_formula("Bob"), F.Formula)
     assert_type(F.CONCATENATE(1, 2, 3), F.FunctionCall)
+
+    # Test type annotations for pyairtable.utils.Url
+    v = pyairtable.utils.Url("https://example.com")
+    assert v == "https://example.com"
+    assert v / "foo/bar" / "baz" == "https://example.com/foo/bar/baz"
+    assert v // [1, 2, "a", "b"] == "https://example.com/1/2/a/b"
+    assert v & {"a": 1, "b": [2, 3, 4]} == "https://example.com?a=1&b=2&b=3&b=4"
+    assert v.add_path(1, 2, "a", "b") == "https://example.com/1/2/a/b"
+    assert v.add_qs({"a": 1}, b=[2, 3, 4]) == "https://example.com?a=1&b=2&b=3&b=4"


### PR DESCRIPTION
- Fixed a regression, introduced in 3.0.0, that ignored the `Api(timeout=)` argument
- AND/OR no longer accept (in type annotations) a mix of iterables and formulas, since that would produce an invalid formula at runtime
- Formula functions now accept ORM fields without type errors, e.g. `SUM(MyModel.amount, 1)`
- Fixed the type annotation of `Url.add_path`