### PR TITLE
Add support for new endpoints since 3.4.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -17,10 +17,10 @@ Changelog
   e.g. ``SUM(MyModel.amount, 1)``.
 * Fixed the type annotation of :meth:`Url.add_path <pyairtable.utils.Url.add_path>`.
 * Added support for listing and revoking enterprise users' personal access tokens
-  via :meth:`Enterprise.personal_access_tokens <pyairtable.Enterprise.personal_access_tokens>`
-  and :meth:`Enterprise.revoke_personal_access_tokens <pyairtable.Enterprise.revoke_personal_access_tokens>`.
+  via :meth:`Enterprise.access_tokens <pyairtable.Enterprise.access_tokens>`
+  and :meth:`Enterprise.revoke_access_tokens <pyairtable.Enterprise.revoke_access_tokens>`.
 * Added support for `updating the workspace AI allowlist <https://airtable.com/developers/web/api/update-workspace-ai-allowlist>`_
-  via :meth:`Enterprise.update_ai_allowlist <pyairtable.Enterprise.update_ai_allowlist>`.
+  via :meth:`Enterprise.allow_ai <pyairtable.Enterprise.allow_ai>`.
 
 3.4.2 (2026-07-25)
 ------------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,6 +16,11 @@ Changelog
 * Formula functions now accept ORM fields without type errors,
   e.g. ``SUM(MyModel.amount, 1)``.
 * Fixed the type annotation of :meth:`Url.add_path <pyairtable.utils.Url.add_path>`.
+* Added support for listing and revoking enterprise users' personal access tokens
+  via :meth:`Enterprise.personal_access_tokens <pyairtable.Enterprise.personal_access_tokens>`
+  and :meth:`Enterprise.revoke_personal_access_tokens <pyairtable.Enterprise.revoke_personal_access_tokens>`.
+* Added support for `updating the workspace AI allowlist <https://airtable.com/developers/web/api/update-workspace-ai-allowlist>`_
+  via :meth:`Enterprise.update_ai_allowlist <pyairtable.Enterprise.update_ai_allowlist>`.
 
 3.4.2 (2026-07-25)
 ------------------------

--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -171,6 +171,14 @@ via the following methods.
     >>> enterprise.revoke_admin("user@example.com")
     >>> enterprise.revoke_admin(enterprise.user("usrUserId"))
 
+`List personal access tokens <https://airtable.com/developers/web/api/list-enterprise-personal-access-tokens>`__
+
+    >>> enterprise.personal_access_tokens()
+
+`Revoke personal access tokens <https://airtable.com/developers/web/api/revoke-enterprise-personal-access-tokens>`__
+
+    >>> enterprise.revoke_personal_access_tokens(["patTokenId1", "patTokenId2"])
+
 
 Managing workspaces and organizations
 --------------------------------------
@@ -193,6 +201,10 @@ via the following methods.
 `Create descendant enterprise <https://airtable.com/developers/web/api/create-descendant-enterprise>`__
 
     >>> descendant = enterprise.create_descendant("Descendant Organization Name")
+
+`Update workspace AI allowlist <https://airtable.com/developers/web/api/update-workspace-ai-allowlist>`__
+
+    >>> enterprise.update_ai_allowlist({"wspId1": True, "wspId2": False})
 
 
 Managing bases and packages

--- a/docs/source/enterprise.rst
+++ b/docs/source/enterprise.rst
@@ -173,11 +173,11 @@ via the following methods.
 
 `List personal access tokens <https://airtable.com/developers/web/api/list-enterprise-personal-access-tokens>`__
 
-    >>> enterprise.personal_access_tokens()
+    >>> enterprise.access_tokens()
 
 `Revoke personal access tokens <https://airtable.com/developers/web/api/revoke-enterprise-personal-access-tokens>`__
 
-    >>> enterprise.revoke_personal_access_tokens(["patTokenId1", "patTokenId2"])
+    >>> enterprise.revoke_access_tokens(["patTokenId1", "patTokenId2"])
 
 
 Managing workspaces and organizations
@@ -204,7 +204,7 @@ via the following methods.
 
 `Update workspace AI allowlist <https://airtable.com/developers/web/api/update-workspace-ai-allowlist>`__
 
-    >>> enterprise.update_ai_allowlist({"wspId1": True, "wspId2": False})
+    >>> enterprise.allow_ai({"wspId1": True, "wspId2": False})
 
 
 Managing bases and packages

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -73,10 +73,10 @@ class Enterprise:
         packages = meta / "packages"
 
         #: URL for listing personal access tokens.
-        personal_access_tokens = meta / "personalAccessTokens"
+        access_tokens = meta / "personalAccessTokens"
 
         #: URL for revoking personal access tokens.
-        revoke_personal_access_tokens = personal_access_tokens / "revoke"
+        revoke_access_tokens = access_tokens / "revoke"
 
         #: URL for updating the workspace AI allowlist.
         workspace_ai_allowlist = meta / "workspaceAiAllowlist"
@@ -683,7 +683,7 @@ class Enterprise:
         response = self.api.post(self.urls.package_install(package_id), json=payload)
         return self.api.base(response["id"], validate=True, force=True)
 
-    def personal_access_tokens(
+    def access_tokens(
         self,
         *,
         resources: bool = False,
@@ -702,13 +702,13 @@ class Enterprise:
         params: dict[str, Any] = {}
         if resources:
             params["includeResources"] = True
-        response = self.api.get(self.urls.personal_access_tokens, params=params)
+        response = self.api.get(self.urls.access_tokens, params=params)
         return [
             PersonalAccessToken.from_api(token, self.api, context=self)
             for token in response.get("personalAccessTokens", [])
         ]
 
-    def revoke_personal_access_tokens(
+    def revoke_access_tokens(
         self,
         token_ids: str | Iterable[str],
     ) -> "RevokeTokensResponse":
@@ -725,14 +725,14 @@ class Enterprise:
         """
         token_ids = coerce_list_str(token_ids)
         response = self.api.post(
-            self.urls.revoke_personal_access_tokens,
+            self.urls.revoke_access_tokens,
             json={"tokenIds": token_ids},
         )
         return RevokeTokensResponse.from_api(response, self.api, context=self)
 
-    def update_ai_allowlist(
+    def allow_ai(
         self,
-        workspaces: dict[str, bool],
+        workspaces: "dict[str | Workspace, bool]",
         *,
         descendants: bool = False,
     ) -> "UpdateAiAllowlistResponse":
@@ -745,20 +745,24 @@ class Enterprise:
         See `Update workspace AI allowlist <https://airtable.com/developers/web/api/update-workspace-ai-allowlist>`__.
 
         Usage:
-            >>> enterprise.update_ai_allowlist(
+            >>> enterprise.allow_ai(
             ...     {"wspmhESAta6clCCwF": True, "wspHvvm4dAktsStZH": False}
             ... )
 
         Args:
-            workspaces: A ``dict`` mapping workspace IDs to whether each
-                workspace should be allowed to use AI features.
+            workspaces: A ``dict`` mapping workspace IDs or instances of
+                :class:`~pyairtable.Workspace` to whether each workspace
+                should be allowed to use AI features.
             descendants: If ``True``, changes will also be applied to
                 workspaces belonging to descendant org units.
         """
         payload: dict[str, Any] = {
             "workspaces": [
-                {"workspaceId": workspace_id, "isAllowed": is_allowed}
-                for (workspace_id, is_allowed) in workspaces.items()
+                {
+                    "workspaceId": ws if isinstance(ws, str) else ws.id,
+                    "isAllowed": is_allowed,
+                }
+                for (ws, is_allowed) in workspaces.items()
             ]
         }
         if descendants:

--- a/pyairtable/api/enterprise.py
+++ b/pyairtable/api/enterprise.py
@@ -72,6 +72,15 @@ class Enterprise:
         #: URL for listing enterprise packages.
         packages = meta / "packages"
 
+        #: URL for listing personal access tokens.
+        personal_access_tokens = meta / "personalAccessTokens"
+
+        #: URL for revoking personal access tokens.
+        revoke_personal_access_tokens = personal_access_tokens / "revoke"
+
+        #: URL for updating the workspace AI allowlist.
+        workspace_ai_allowlist = meta / "workspaceAiAllowlist"
+
         def package_install(self, package_id: str) -> Url:
             """
             URL for installing a package (creating a base from a package).
@@ -674,6 +683,89 @@ class Enterprise:
         response = self.api.post(self.urls.package_install(package_id), json=payload)
         return self.api.base(response["id"], validate=True, force=True)
 
+    def personal_access_tokens(
+        self,
+        *,
+        resources: bool = False,
+    ) -> list["PersonalAccessToken"]:
+        """
+        List personal access tokens for users administered by this
+        enterprise account. Only supported for root (organization-level)
+        enterprise accounts.
+
+        See `List personal access tokens <https://airtable.com/developers/web/api/list-enterprise-personal-access-tokens>`__.
+
+        Args:
+            resources: If ``True``, the API will include information
+                about the resources that each token can access.
+        """
+        params: dict[str, Any] = {}
+        if resources:
+            params["includeResources"] = True
+        response = self.api.get(self.urls.personal_access_tokens, params=params)
+        return [
+            PersonalAccessToken.from_api(token, self.api, context=self)
+            for token in response.get("personalAccessTokens", [])
+        ]
+
+    def revoke_personal_access_tokens(
+        self,
+        token_ids: str | Iterable[str],
+    ) -> "RevokeTokensResponse":
+        """
+        Revoke personal access tokens for users administered by this
+        enterprise account. Only supported for root (organization-level)
+        enterprise accounts. The response includes both revoked tokens and
+        errors, so that callers can handle partial success.
+
+        See `Revoke personal access tokens <https://airtable.com/developers/web/api/revoke-enterprise-personal-access-tokens>`__.
+
+        Args:
+            token_ids: One or more personal access token IDs (maximum of 100).
+        """
+        token_ids = coerce_list_str(token_ids)
+        response = self.api.post(
+            self.urls.revoke_personal_access_tokens,
+            json={"tokenIds": token_ids},
+        )
+        return RevokeTokensResponse.from_api(response, self.api, context=self)
+
+    def update_ai_allowlist(
+        self,
+        workspaces: dict[str, bool],
+        *,
+        descendants: bool = False,
+    ) -> "UpdateAiAllowlistResponse":
+        """
+        Add or remove workspaces from the enterprise AI allowlist
+        (maximum of 10 workspaces per request). Only applicable when the
+        enterprise AI workspace restriction policy is set to allow
+        specified workspaces.
+
+        See `Update workspace AI allowlist <https://airtable.com/developers/web/api/update-workspace-ai-allowlist>`__.
+
+        Usage:
+            >>> enterprise.update_ai_allowlist(
+            ...     {"wspmhESAta6clCCwF": True, "wspHvvm4dAktsStZH": False}
+            ... )
+
+        Args:
+            workspaces: A ``dict`` mapping workspace IDs to whether each
+                workspace should be allowed to use AI features.
+            descendants: If ``True``, changes will also be applied to
+                workspaces belonging to descendant org units.
+        """
+        payload: dict[str, Any] = {
+            "workspaces": [
+                {"workspaceId": workspace_id, "isAllowed": is_allowed}
+                for (workspace_id, is_allowed) in workspaces.items()
+            ]
+        }
+        if descendants:
+            payload["includeDescendantWorkspaces"] = True
+        response = self.api.post(self.urls.workspace_ai_allowlist, json=payload)
+        return UpdateAiAllowlistResponse.from_api(response, self.api, context=self)
+
 
 class UserRemoved(AirtableModel):
     """
@@ -785,6 +877,65 @@ class MoveWorkspacesResponse(AirtableModel):
 
     moved_workspaces: list[NestedId] = pydantic.Field(default_factory=list)
     errors: list[MoveError] = pydantic.Field(default_factory=list)
+
+
+class PersonalAccessToken(AirtableModel):
+    """
+    A personal access token, as returned by the
+    `List personal access tokens <https://airtable.com/developers/web/api/list-enterprise-personal-access-tokens>`__
+    endpoint.
+    """
+
+    id: str
+    name: str
+    state: str
+    scopes: list[str] = pydantic.Field(default_factory=list)
+    resource_access: "PersonalAccessToken.ResourceAccess"
+    created_time: datetime
+    user_id: str
+    created_by_user_id: str
+
+    class ResourceAccess(AirtableModel):
+        mode: str
+        enterprise_account_id: str | None = None
+        resource_model_ids: list[str] | None = None
+
+
+class RevokeTokensResponse(AirtableModel):
+    """
+    Returned by the `Revoke personal access tokens <https://airtable.com/developers/web/api/revoke-enterprise-personal-access-tokens>`__
+    endpoint.
+    """
+
+    revoked_tokens: list["RevokeTokensResponse.RevokedToken"] = pydantic.Field(
+        default_factory=list
+    )
+    errors: list["RevokeTokensResponse.Error"] = pydantic.Field(default_factory=list)
+
+    class RevokedToken(AirtableModel):
+        id: str
+        user_id: str
+
+    class Error(AirtableModel):
+        type: str
+        message: str
+        token_id: str
+
+
+class UpdateAiAllowlistResponse(AirtableModel):
+    """
+    Returned by the `Update workspace AI allowlist <https://airtable.com/developers/web/api/update-workspace-ai-allowlist>`__
+    endpoint.
+    """
+
+    errors: list["UpdateAiAllowlistResponse.Error"] = pydantic.Field(
+        default_factory=list
+    )
+
+    class Error(AirtableModel):
+        type: str
+        message: str
+        workspace_id: str
 
 
 rebuild_models(vars())

--- a/pyairtable/cli.py
+++ b/pyairtable/cli.py
@@ -380,6 +380,31 @@ def enterprise_groups(
     )
 
 
+@enterprise.group(invoke_without_command=True, cls=ShortcutGroup)
+@needs_context
+def pat(ctx: CliContext) -> None:
+    ctx.default_subcommand(pat_list)
+
+
+@pat.command("list")
+@needs_context
+def pat_list(ctx: CliContext) -> None:
+    """
+    List personal access tokens.
+    """
+    _dump(ctx.enterprise.access_tokens(resources=True))
+
+
+@pat.command("revoke")
+@needs_context
+@click.argument("access_token_id")
+def pat_revoke(ctx: CliContext, access_token_id: str) -> None:
+    """
+    Revoke a personal access token.
+    """
+    _dump(ctx.enterprise.revoke_access_tokens(access_token_id))
+
+
 class JSONEncoder(json.JSONEncoder):
     def default(self, o: Any) -> Any:
         if isinstance(o, AirtableModel):

--- a/scripts/find_model_changes.py
+++ b/scripts/find_model_changes.py
@@ -35,6 +35,13 @@ SCAN_MODELS = {
     "pyairtable.api.enterprise:MoveError": "move-workspaces.response/@errors/items",
     "pyairtable.api.enterprise:MoveGroupsResponse": "move-user-groups.response",
     "pyairtable.api.enterprise:MoveWorkspacesResponse": "move-workspaces.response",
+    "pyairtable.api.enterprise:PersonalAccessToken": "list-enterprise-personal-access-tokens.response/@personalAccessTokens/items",
+    "pyairtable.api.enterprise:PersonalAccessToken.ResourceAccess": "list-enterprise-personal-access-tokens.response/@personalAccessTokens/items/@resourceAccess",
+    "pyairtable.api.enterprise:RevokeTokensResponse": "revoke-enterprise-personal-access-tokens.response",
+    "pyairtable.api.enterprise:RevokeTokensResponse.RevokedToken": "revoke-enterprise-personal-access-tokens.response/@revokedTokens/items",
+    "pyairtable.api.enterprise:RevokeTokensResponse.Error": "revoke-enterprise-personal-access-tokens.response/@errors/items",
+    "pyairtable.api.enterprise:UpdateAiAllowlistResponse": "update-workspace-ai-allowlist.response",
+    "pyairtable.api.enterprise:UpdateAiAllowlistResponse.Error": "update-workspace-ai-allowlist.response/@errors/items",
     "pyairtable.models.audit:AuditLogResponse": "audit-log-events.response",
     "pyairtable.models.audit:AuditLogEvent": "audit-log-events.response/@events/items",
     "pyairtable.models.audit:AuditLogEvent.Context": "audit-log-events.response/@events/items/@context",
@@ -167,7 +174,8 @@ def identify_missing_fields(api_data: "ApiData") -> None:
             r"\1operations/\2/\3/schema\4",
             data_path,
         )
-        issues.extend(scan_schema(model_cls, api_data.get_nested(data_path)))
+        schema = api_data.collapse_schema(api_data.get_nested(data_path))
+        issues.extend(scan_schema(model_cls, schema))
 
     if not issues:
         print("No missing/extra fields found in scanned classes")

--- a/tests/sample_data/PersonalAccessToken.json
+++ b/tests/sample_data/PersonalAccessToken.json
@@ -1,0 +1,16 @@
+{
+  "id": "pat8fN3RkQx9ZLm2T",
+  "name": "Integration token",
+  "state": "active",
+  "scopes": [
+    "data.records:read",
+    "enterprise.account:read"
+  ],
+  "resourceAccess": {
+    "mode": "enterprise",
+    "enterpriseAccountId": "entUBq2RGdihxl3vU"
+  },
+  "createdTime": "2023-01-01T00:00:00.000Z",
+  "userId": "usrL2PNC5o3H4lBEi",
+  "createdByUserId": "usrL2PNC5o3H4lBEi"
+}

--- a/tests/test_api_enterprise.py
+++ b/tests/test_api_enterprise.py
@@ -103,7 +103,7 @@ def enterprise_mocks(enterprise, requests_mock, sample_json):
         f"{enterprise_url}/personalAccessTokens/revoke",
         json=m.revoke_pats_json,
     )
-    m.update_ai_allowlist = requests_mock.post(
+    m.allow_ai = requests_mock.post(
         f"{enterprise_url}/workspaceAiAllowlist",
         json={"errors": []},
     )
@@ -715,8 +715,8 @@ def test_create_base(api, base_id, workspace_id, requests_mock, sample_json):
     }
 
 
-def test_personal_access_tokens(enterprise, enterprise_mocks):
-    tokens = enterprise.personal_access_tokens()
+def test_access_tokens(enterprise, enterprise_mocks):
+    tokens = enterprise.access_tokens()
     assert enterprise_mocks.list_pats.call_count == 1
     assert "includeresources" not in enterprise_mocks.list_pats.last_request.qs
     assert len(tokens) == 1
@@ -732,8 +732,8 @@ def test_personal_access_tokens(enterprise, enterprise_mocks):
     assert pat.created_by_user_id == "usrL2PNC5o3H4lBEi"
 
 
-def test_personal_access_tokens__include_resources(enterprise, enterprise_mocks):
-    enterprise.personal_access_tokens(include_resources=True)
+def test_access_tokens__include_resources(enterprise, enterprise_mocks):
+    enterprise.access_tokens(resources=True)
     assert enterprise_mocks.list_pats.call_count == 1
     assert enterprise_mocks.list_pats.last_request.qs["includeResources"] == ["True"]
 
@@ -746,11 +746,9 @@ def test_personal_access_tokens__include_resources(enterprise, enterprise_mocks)
         {"mode": "specificModelIds", "resourceModelIds": ["appLkNDICXNqxSDhG"]},
     ],
 )
-def test_personal_access_tokens__resource_access(
-    enterprise, enterprise_mocks, resource_access
-):
+def test_access_tokens__resource_access(enterprise, enterprise_mocks, resource_access):
     enterprise_mocks.json_pat["resourceAccess"] = resource_access
-    (pat,) = enterprise.personal_access_tokens()
+    (pat,) = enterprise.access_tokens()
     assert pat.resource_access.mode == resource_access["mode"]
     assert pat.resource_access.resource_model_ids == resource_access.get(
         "resourceModelIds"
@@ -769,10 +767,8 @@ def test_personal_access_tokens__resource_access(
         (iter(["pat8fN3RkQx9ZLm2T"]), ["pat8fN3RkQx9ZLm2T"]),
     ],
 )
-def test_revoke_personal_access_tokens(
-    enterprise, enterprise_mocks, token_ids, expected
-):
-    result = enterprise.revoke_personal_access_tokens(token_ids)
+def test_revoke_access_tokens(enterprise, enterprise_mocks, token_ids, expected):
+    result = enterprise.revoke_access_tokens(token_ids)
     assert enterprise_mocks.revoke_pats.call_count == 1
     assert enterprise_mocks.revoke_pats.last_request.json() == {"tokenIds": expected}
     assert isinstance(result, RevokeTokensResponse)
@@ -782,12 +778,12 @@ def test_revoke_personal_access_tokens(
     assert result.errors[0].token_id == "patZp6Lw9Dq3VxTn5"
 
 
-def test_update_ai_allowlist(enterprise, enterprise_mocks):
-    result = enterprise.update_ai_allowlist(
-        {"wspmhESAta6clCCwF": True, "wspHvvm4dAktsStZH": False}
+def test_allow_ai(api, enterprise, enterprise_mocks):
+    result = enterprise.allow_ai(
+        {api.workspace("wspmhESAta6clCCwF"): True, "wspHvvm4dAktsStZH": False}
     )
-    assert enterprise_mocks.update_ai_allowlist.call_count == 1
-    assert enterprise_mocks.update_ai_allowlist.last_request.json() == {
+    assert enterprise_mocks.allow_ai.call_count == 1
+    assert enterprise_mocks.allow_ai.last_request.json() == {
         "workspaces": [
             {"workspaceId": "wspmhESAta6clCCwF", "isAllowed": True},
             {"workspaceId": "wspHvvm4dAktsStZH", "isAllowed": False},
@@ -797,15 +793,15 @@ def test_update_ai_allowlist(enterprise, enterprise_mocks):
     assert result.errors == []
 
 
-def test_update_ai_allowlist__descendants(enterprise, enterprise_mocks):
-    enterprise.update_ai_allowlist({"wspmhESAta6clCCwF": True}, descendants=True)
-    assert enterprise_mocks.update_ai_allowlist.last_request.json() == {
+def test_allow_ai__descendants(enterprise, enterprise_mocks):
+    enterprise.allow_ai({"wspmhESAta6clCCwF": True}, descendants=True)
+    assert enterprise_mocks.allow_ai.last_request.json() == {
         "workspaces": [{"workspaceId": "wspmhESAta6clCCwF", "isAllowed": True}],
         "includeDescendantWorkspaces": True,
     }
 
 
-def test_update_ai_allowlist__errors(enterprise, enterprise_mocks, requests_mock):
+def test_allow_ai__errors(enterprise, enterprise_mocks, requests_mock):
     requests_mock.post(
         enterprise.urls.workspace_ai_allowlist,
         json={
@@ -818,6 +814,6 @@ def test_update_ai_allowlist__errors(enterprise, enterprise_mocks, requests_mock
             ]
         },
     )
-    result = enterprise.update_ai_allowlist({"wspFakeWorkspaceId": True})
+    result = enterprise.allow_ai({"wspFakeWorkspaceId": True})
     assert result.errors[0].type == "WORKSPACE_NOT_FOUND"
     assert result.errors[0].workspace_id == "wspFakeWorkspaceId"

--- a/tests/test_api_enterprise.py
+++ b/tests/test_api_enterprise.py
@@ -8,6 +8,9 @@ from pyairtable.api.enterprise import (
     DeleteUsersResponse,
     Enterprise,
     ManageUsersResponse,
+    PersonalAccessToken,
+    RevokeTokensResponse,
+    UpdateAiAllowlistResponse,
 )
 from pyairtable.exceptions import InvalidParameterError, MissingRecordError
 from pyairtable.models.schema import EnterpriseInfo, Package, UserGroup, UserInfo
@@ -80,6 +83,29 @@ def enterprise_mocks(enterprise, requests_mock, sample_json):
     m.get_packages = requests_mock.get(
         f"{enterprise_url}/packages",
         json=m.json_packages,
+    )
+    m.json_pat = sample_json("PersonalAccessToken")
+    m.list_pats = requests_mock.get(
+        f"{enterprise_url}/personalAccessTokens",
+        json={"personalAccessTokens": [m.json_pat]},
+    )
+    m.revoke_pats_json = {
+        "errors": [
+            {
+                "message": "Token has already been revoked.",
+                "tokenId": "patZp6Lw9Dq3VxTn5",
+                "type": "ALREADY_REVOKED",
+            }
+        ],
+        "revokedTokens": [{"id": "pat8fN3RkQx9ZLm2T", "userId": "usrL2PNC5o3H4lBEi"}],
+    }
+    m.revoke_pats = requests_mock.post(
+        f"{enterprise_url}/personalAccessTokens/revoke",
+        json=m.revoke_pats_json,
+    )
+    m.update_ai_allowlist = requests_mock.post(
+        f"{enterprise_url}/workspaceAiAllowlist",
+        json={"errors": []},
     )
     return m
 
@@ -687,3 +713,111 @@ def test_create_base(api, base_id, workspace_id, requests_mock, sample_json):
         "workspaceId": workspace_id,
         "tables": [{"name": "Table1"}],
     }
+
+
+def test_personal_access_tokens(enterprise, enterprise_mocks):
+    tokens = enterprise.personal_access_tokens()
+    assert enterprise_mocks.list_pats.call_count == 1
+    assert "includeresources" not in enterprise_mocks.list_pats.last_request.qs
+    assert len(tokens) == 1
+    assert isinstance(pat := tokens[0], PersonalAccessToken)
+    assert pat.id == "pat8fN3RkQx9ZLm2T"
+    assert pat.name == "Integration token"
+    assert pat.state == "active"
+    assert pat.scopes == ["data.records:read", "enterprise.account:read"]
+    assert pat.resource_access.mode == "enterprise"
+    assert pat.resource_access.enterprise_account_id == "entUBq2RGdihxl3vU"
+    assert pat.created_time == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert pat.user_id == "usrL2PNC5o3H4lBEi"
+    assert pat.created_by_user_id == "usrL2PNC5o3H4lBEi"
+
+
+def test_personal_access_tokens__include_resources(enterprise, enterprise_mocks):
+    enterprise.personal_access_tokens(include_resources=True)
+    assert enterprise_mocks.list_pats.call_count == 1
+    assert enterprise_mocks.list_pats.last_request.qs["includeResources"] == ["True"]
+
+
+@pytest.mark.parametrize(
+    "resource_access",
+    [
+        {"mode": "all"},
+        {"mode": "enterprise"},
+        {"mode": "specificModelIds", "resourceModelIds": ["appLkNDICXNqxSDhG"]},
+    ],
+)
+def test_personal_access_tokens__resource_access(
+    enterprise, enterprise_mocks, resource_access
+):
+    enterprise_mocks.json_pat["resourceAccess"] = resource_access
+    (pat,) = enterprise.personal_access_tokens()
+    assert pat.resource_access.mode == resource_access["mode"]
+    assert pat.resource_access.resource_model_ids == resource_access.get(
+        "resourceModelIds"
+    )
+
+
+# token_ids accepts a single str or any iterable of str
+@pytest.mark.parametrize(
+    "token_ids,expected",
+    [
+        ("pat8fN3RkQx9ZLm2T", ["pat8fN3RkQx9ZLm2T"]),
+        (
+            ["pat8fN3RkQx9ZLm2T", "patZp6Lw9Dq3VxTn5"],
+            ["pat8fN3RkQx9ZLm2T", "patZp6Lw9Dq3VxTn5"],
+        ),
+        (iter(["pat8fN3RkQx9ZLm2T"]), ["pat8fN3RkQx9ZLm2T"]),
+    ],
+)
+def test_revoke_personal_access_tokens(
+    enterprise, enterprise_mocks, token_ids, expected
+):
+    result = enterprise.revoke_personal_access_tokens(token_ids)
+    assert enterprise_mocks.revoke_pats.call_count == 1
+    assert enterprise_mocks.revoke_pats.last_request.json() == {"tokenIds": expected}
+    assert isinstance(result, RevokeTokensResponse)
+    assert result.revoked_tokens[0].id == "pat8fN3RkQx9ZLm2T"
+    assert result.revoked_tokens[0].user_id == "usrL2PNC5o3H4lBEi"
+    assert result.errors[0].type == "ALREADY_REVOKED"
+    assert result.errors[0].token_id == "patZp6Lw9Dq3VxTn5"
+
+
+def test_update_ai_allowlist(enterprise, enterprise_mocks):
+    result = enterprise.update_ai_allowlist(
+        {"wspmhESAta6clCCwF": True, "wspHvvm4dAktsStZH": False}
+    )
+    assert enterprise_mocks.update_ai_allowlist.call_count == 1
+    assert enterprise_mocks.update_ai_allowlist.last_request.json() == {
+        "workspaces": [
+            {"workspaceId": "wspmhESAta6clCCwF", "isAllowed": True},
+            {"workspaceId": "wspHvvm4dAktsStZH", "isAllowed": False},
+        ]
+    }
+    assert isinstance(result, UpdateAiAllowlistResponse)
+    assert result.errors == []
+
+
+def test_update_ai_allowlist__descendants(enterprise, enterprise_mocks):
+    enterprise.update_ai_allowlist({"wspmhESAta6clCCwF": True}, descendants=True)
+    assert enterprise_mocks.update_ai_allowlist.last_request.json() == {
+        "workspaces": [{"workspaceId": "wspmhESAta6clCCwF", "isAllowed": True}],
+        "includeDescendantWorkspaces": True,
+    }
+
+
+def test_update_ai_allowlist__errors(enterprise, enterprise_mocks, requests_mock):
+    requests_mock.post(
+        enterprise.urls.workspace_ai_allowlist,
+        json={
+            "errors": [
+                {
+                    "type": "WORKSPACE_NOT_FOUND",
+                    "message": "Workspace not found",
+                    "workspaceId": "wspFakeWorkspaceId",
+                }
+            ]
+        },
+    )
+    result = enterprise.update_ai_allowlist({"wspFakeWorkspaceId": True})
+    assert result.errors[0].type == "WORKSPACE_NOT_FOUND"
+    assert result.errors[0].workspace_id == "wspFakeWorkspaceId"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,17 @@ def mock_metadata(
     requests_mock.get(enterprise.urls.user(user_id), json=user_info)
     for group_id in enterprise_info["groupIds"]:
         requests_mock.get(enterprise.urls.group(group_id), json=user_group)
+    requests_mock.get(
+        enterprise.urls.access_tokens,
+        json={"personalAccessTokens": [sample_json("PersonalAccessToken")]},
+    )
+    requests_mock.post(
+        enterprise.urls.revoke_access_tokens,
+        json={
+            "revokedTokens": [{"id": "pat8fN3RkQx9ZLm2T", "userId": user_id}],
+            "errors": [],
+        },
+    )
 
 
 @pytest.fixture
@@ -255,3 +266,17 @@ def test_enterprise_groups(run, enterprise, option):
 def test_enterprise_groups__invalid(run, enterprise):
     run("enterprise", enterprise.id, "groups", fails=True)
     run("enterprise", enterprise.id, "groups", "--all", "ugp1mKGb3KXUyQfOZ", fails=True)
+
+
+@pytest.mark.parametrize("extra_args", [[], ["list"]])
+def test_enterprise_pat_list(run, enterprise, extra_args):
+    result = run.json("enterprise", enterprise.id, "pat", *extra_args)
+    assert len(result) == 1
+    assert result[0]["id"] == "pat8fN3RkQx9ZLm2T"
+    assert result[0]["name"] == "Integration token"
+
+
+def test_enterprise_pat_revoke(run, enterprise, requests_mock):
+    result = run.json("enterprise", enterprise.id, "pat", "revoke", "pat8fN3RkQx9ZLm2T")
+    assert result["revokedTokens"][0]["id"] == "pat8fN3RkQx9ZLm2T"
+    assert requests_mock.last_request.json() == {"tokenIds": ["pat8fN3RkQx9ZLm2T"]}


### PR DESCRIPTION
Adds support for a few new endpoints added since the last release:

- [List enterprise personal access tokens](https://airtable.com/developers/web/api/list-enterprise-personal-access-tokens)
- [Revoke enterprise personal access tokens](https://airtable.com/developers/web/api/revoke-enterprise-personal-access-tokens)
- [Update workspace AI allowlist](https://airtable.com/developers/web/api/update-workspace-ai-allowlist)